### PR TITLE
Making iso packagers support wipr/protect for PCI compliance

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/Display.java
+++ b/jpos/src/main/java/org/jpos/iso/Display.java
@@ -1,0 +1,8 @@
+package org.jpos.iso;
+
+public class Display {
+
+    public static final int WIPE    = 2;
+    public static final int PROTECT = 1;
+    public static final int NOP     = 0;
+}

--- a/jpos/src/main/java/org/jpos/iso/IFA_AMOUNT2003.java
+++ b/jpos/src/main/java/org/jpos/iso/IFA_AMOUNT2003.java
@@ -19,7 +19,7 @@
 package org.jpos.iso;
 
 public class IFA_AMOUNT2003 extends IFA_NUMERIC {
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOAmount (fieldNumber);    
     }
 }

--- a/jpos/src/main/java/org/jpos/iso/IFA_LLABINARY.java
+++ b/jpos/src/main/java/org/jpos/iso/IFA_LLABINARY.java
@@ -85,7 +85,7 @@ public class IFA_LLABINARY extends ISOFieldPackager {
         
         
     }
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOBinaryField (fieldNumber);
     }
     public int getMaxPackedLength() {

--- a/jpos/src/main/java/org/jpos/iso/IFA_LLLABINARY.java
+++ b/jpos/src/main/java/org/jpos/iso/IFA_LLLABINARY.java
@@ -85,7 +85,7 @@ public class IFA_LLLABINARY extends ISOFieldPackager {
         
       //CJH END
     }
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOBinaryField (fieldNumber);
     }
     public int getMaxPackedLength() {

--- a/jpos/src/main/java/org/jpos/iso/IFB_AMOUNT2003.java
+++ b/jpos/src/main/java/org/jpos/iso/IFB_AMOUNT2003.java
@@ -19,7 +19,7 @@
 package org.jpos.iso;
 
 public class IFB_AMOUNT2003 extends IFB_NUMERIC {
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOAmount (fieldNumber);    
     }
 }

--- a/jpos/src/main/java/org/jpos/iso/IFB_LLHFBINARY.java
+++ b/jpos/src/main/java/org/jpos/iso/IFB_LLHFBINARY.java
@@ -79,7 +79,7 @@ public class IFB_LLHFBINARY extends ISOFieldPackager {
         c.setValue (readBytes (in, len));
         in.skip (getLength () - len);
     }
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOBinaryField (fieldNumber);
     }
     public int getMaxPackedLength() {

--- a/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
@@ -18,16 +18,16 @@
 
 package org.jpos.iso;
 
-import org.jpos.util.LogEvent;
-import org.jpos.util.LogSource;
-import org.jpos.util.Logger;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Map;
+
+import org.jpos.util.LogEvent;
+import org.jpos.util.LogSource;
+import org.jpos.util.Logger;
 
 /**
  * provides base functionality for the actual packagers
@@ -66,6 +66,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
      * @return      Message image
      * @exception ISOException
      */
+    @Override
     public byte[] pack (ISOComponent m) throws ISOException {
         LogEvent evt = null;
         if (logger != null)
@@ -186,6 +187,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
      * @return      consumed bytes
      * @exception ISOException
      */
+    @Override
     public int unpack (ISOComponent m, byte[] b) throws ISOException {
         LogEvent evt = new LogEvent (this, "unpack");
         int consumed = 0;
@@ -208,7 +210,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
             
             if (!(fld[0] == null) && !(fld[0] instanceof ISOBitMapPackager))
             {
-                ISOComponent mti = fld[0].createComponent(0);
+                ISOComponent mti = fld[0].createComponent(0, fld[0].getDisplay());
                 consumed  += fld[0].unpack(mti, b, consumed);
                 m.set (mti);
             }
@@ -234,7 +236,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                         if (fld[i] == null)
                             throw new ISOException ("field packager '" + i + "' is null");
 
-                        ISOComponent c = fld[i].createComponent(i);
+                        ISOComponent c = fld[i].createComponent(i,fld[i].getDisplay());
                         consumed += fld[i].unpack (c, b, consumed);
                         if (logger != null) {
                             evt.addMessage ("<unpack fld=\"" + i 
@@ -305,7 +307,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
             if (!(fld[0] instanceof ISOMsgFieldPackager) &&
                 !(fld[0] instanceof ISOBitMapPackager))
             {
-                ISOComponent mti = fld[0].createComponent(0);
+                ISOComponent mti = fld[0].createComponent(0,  fld[0].getDisplay());
                 fld[0].unpack(mti, in);
                 m.set (mti);
             }
@@ -329,7 +331,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                     if (fld[i] == null)
                         throw new ISOException ("field packager '" + i + "' is null");
 
-                    ISOComponent c = fld[i].createComponent(i);
+                    ISOComponent c = fld[i].createComponent(i,  fld[i].getDisplay());
                     fld[i].unpack (c, in);
                     if (logger != null) {
                         evt.addMessage ("<unpack fld=\"" + i 
@@ -352,7 +354,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                 bmap= (BitSet) ((ISOComponent) m.getChildren().get(65)).getValue();
                 for (int i=1; i<64; i++) {
                     if (bmap == null || bmap.get(i)) {
-                        ISOComponent c = fld[i+128].createComponent(i);
+                        ISOComponent c = fld[i+128].createComponent(i,  fld[i+128].getDisplay());
                         fld[i+128].unpack (c, in);
                         if (logger != null) {
                             evt.addMessage ("<unpack fld=\"" + i+128
@@ -384,6 +386,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
      * @param   fldNumber the Field Number
      * @return  Field Description
      */
+    @Override
     public String getFieldDescription(ISOComponent m, int fldNumber) {
         return fld[fldNumber].getDescription();
     }
@@ -403,6 +406,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     {
         fld[fldNumber] = fieldPackager;
     }
+    @Override
     public ISOMsg createISOMsg () {
         return new ISOMsg();
     }
@@ -418,13 +422,16 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     protected ISOFieldPackager getBitMapfieldPackager() {
         return fld[1];
     }
+    @Override
     public void setLogger (Logger logger, String realm) {
         this.logger = logger;
         this.realm  = realm;
     }
+    @Override
     public String getRealm () {
         return realm;
     }
+    @Override
     public Logger getLogger() {
         return logger;
     }
@@ -436,6 +443,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     {
     	headerLength = len;
     }
+    @Override
     public String getDescription () {
         return getClass().getName();
     }

--- a/jpos/src/main/java/org/jpos/iso/ISOBinaryFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBinaryFieldPackager.java
@@ -178,7 +178,7 @@ public class ISOBinaryFieldPackager extends ISOFieldPackager
      * @param fieldNumber - the field number
      * @return the newly created component
      */
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOBinaryField (fieldNumber);
     }
 

--- a/jpos/src/main/java/org/jpos/iso/ISOBitMapPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBitMapPackager.java
@@ -36,7 +36,7 @@ public abstract class ISOBitMapPackager extends ISOFieldPackager {
     public ISOBitMapPackager(int len, String description) {
         super(len, description);
     }
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOBitMap (fieldNumber);
     }
 }

--- a/jpos/src/main/java/org/jpos/iso/ISOField.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOField.java
@@ -18,9 +18,15 @@
 
 package org.jpos.iso;
 
-import org.jpos.iso.packager.XMLPackager;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 
-import java.io.*;
+import org.jpos.iso.packager.XMLPackager;
 
 /**
  * implements <b>Leaf</b> for standard fields
@@ -29,14 +35,15 @@ import java.io.*;
  * @version $Id$
  * @see ISOComponent
  */
-public class ISOField 
-    extends ISOComponent 
+public class ISOField
+    extends ISOComponent
     implements Cloneable, Externalizable
 {
 
     private static final long serialVersionUID = -4053616930139887829L;
     protected int fieldNumber;
     protected String value;
+    private int display;
 
     /**
      * No args constructor 
@@ -48,10 +55,14 @@ public class ISOField
 
     /**
      * @param n - the FieldNumber
+     * @param display - flag to indicate if field should be wiped/protected or default while dumping
      */
-    public ISOField (int n) {
+    public ISOField (int n, int display) {
         fieldNumber = n;
+        this.display = display;
     }
+
+
     /**
      * @param n - fieldNumber
      * @param v - fieldValue
@@ -60,10 +71,17 @@ public class ISOField
         fieldNumber = n;
         value = v;
     }
+
+    public ISOField (int n, String v, int display) {
+        fieldNumber = n;
+        value = v;
+        this.display = display;
+    }
     /**
      * not available on Leaf - always throw ISOException
      * @exception ISOException
      */
+    @Override
     public byte[] pack() throws ISOException {
         throw new ISOException ("Not available on Leaf");
     }
@@ -71,6 +89,7 @@ public class ISOField
      * not available on Leaf - always throw ISOException
      * @exception ISOException
      */
+    @Override
     public int unpack(byte[] b) throws ISOException {
         throw new ISOException ("Not available on Leaf");
     }
@@ -78,18 +97,21 @@ public class ISOField
      * not available on Leaf - always throw ISOException
      * @exception ISOException
      */
+    @Override
     public void unpack(InputStream in) throws ISOException {
         throw new ISOException ("Not available on Leaf");
     }
     /**
      * @return Object representing this field number
      */
+    @Override
     public Object getKey() {
         return fieldNumber;
     }
     /**
      * @return Object representing this field value
      */
+    @Override
     public Object getValue() {
         return value;
     }
@@ -97,6 +119,7 @@ public class ISOField
      * @param obj - Object representing this field value
      * @exception ISOException
      */
+    @Override
     public void setValue(Object obj) throws ISOException {
         if (obj instanceof String)
             value = (String) obj;
@@ -106,6 +129,7 @@ public class ISOField
     /**
      * @return byte[] representing this field
      */
+    @Override
     public byte[] getBytes() {
         try {
             return (value != null) ? value.getBytes(ISOUtil.ENCODING) : new byte[] {};
@@ -118,17 +142,52 @@ public class ISOField
      * @param p - print stream
      * @param indent - optional indent string
      */
-    public void dump (PrintStream p, String indent) {
+    @Override
+    public void dump(PrintStream p, String indent) {
+
+        String temp = null;
         if (value != null && value.indexOf('<') >= 0) {
-            p.print (indent +"<"+XMLPackager.ISOFIELD_TAG + " " +
-                XMLPackager.ID_ATTR +"=\"" +fieldNumber +"\"><![CDATA[");
-            p.print (value);
-            p.println ("]]></" + XMLPackager.ISOFIELD_TAG + ">");                        
-        } else {
-            p.println (indent +"<"+XMLPackager.ISOFIELD_TAG + " " +
-                XMLPackager.ID_ATTR +"=\"" +fieldNumber +"\" "+
-                XMLPackager.VALUE_ATTR
-                +"=\"" +ISOUtil.normalize (value) +"\"/>");
+
+            switch (display) {
+
+            case Display.PROTECT:
+                temp = ISOUtil.protect(value);
+                break;
+            case Display.WIPE:
+                temp = "***";
+                break;
+            case Display.NOP:
+                temp = value;
+                break;
+            default:
+                temp = value;
+                break;
+            }
+
+            p.print(indent + "<" + XMLPackager.ISOFIELD_TAG + " " + XMLPackager.ID_ATTR + "=\"" + fieldNumber
+                    + "\"><![CDATA[");
+            p.print(value);
+            p.println("]]></" + XMLPackager.ISOFIELD_TAG + ">");
+        }
+        else {
+
+            switch (display) {
+
+            case Display.PROTECT:
+                temp = ISOUtil.protect(value);
+                break;
+            case Display.WIPE:
+                temp = "***";
+                break;
+            case Display.NOP:
+                temp = value;
+                break;
+            default:
+                temp = value;
+                break;
+            }
+            p.println(indent + "<" + XMLPackager.ISOFIELD_TAG + " " + XMLPackager.ID_ATTR + "=\"" + fieldNumber + "\" "
+                    + XMLPackager.VALUE_ATTR + "=\"" + ISOUtil.normalize(temp) + "\"/>");
         }
     }
     /**
@@ -137,14 +196,17 @@ public class ISOField
      * any reference held by a Composite.
      * @param fieldNumber new field number
      */
+    @Override
     public void setFieldNumber (int fieldNumber) {
         this.fieldNumber = fieldNumber;
     }
+    @Override
     public void writeExternal (ObjectOutput out) throws IOException {
         out.writeShort (fieldNumber);
         out.writeUTF (value);
     }
-    public void readExternal  (ObjectInput in) 
+    @Override
+    public void readExternal  (ObjectInput in)
         throws IOException, ClassNotFoundException
     {
         fieldNumber = in.readShort ();

--- a/jpos/src/main/java/org/jpos/iso/ISOFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOFieldPackager.java
@@ -62,6 +62,7 @@ public abstract class ISOFieldPackager {
     private int len;
     private String description;
     protected boolean pad;
+    protected int display;
 
     /**
      * Default Constructor
@@ -97,10 +98,20 @@ public abstract class ISOFieldPackager {
         this.pad = pad;
     }
 
+    public void setDisplay(int display) {
+        this.display = display;
+    }
+
+
+    public int getDisplay() {
+        return display;
+    }
+
+
     public abstract int getMaxPackedLength();
 
-    public ISOComponent createComponent(int fieldNumber) {
-        return new ISOField (fieldNumber);
+    public ISOComponent createComponent(int fieldNumber, int display) {
+        return new ISOField (fieldNumber, display);
     }
     /**
      * @param c - a component

--- a/jpos/src/main/java/org/jpos/iso/ISOMsgFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOMsgFieldPackager.java
@@ -93,7 +93,7 @@ public class ISOMsgFieldPackager extends ISOFieldPackager {
             msgPackager.unpack((ISOMsg) c, (byte[]) f.getValue());
         }
     }
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         ISOMsg m = new ISOMsg(fieldNumber);
         m.setPackager(msgPackager);
         return m;

--- a/jpos/src/main/java/org/jpos/iso/packager/Base1SubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/Base1SubFieldPackager.java
@@ -18,14 +18,21 @@
 
 package org.jpos.iso.packager;
 
-import org.jpos.iso.*;
-import org.jpos.util.LogEvent;
-import org.jpos.util.Logger;
-
-import java.util.BitSet;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
+
+import org.jpos.iso.ISOBasePackager;
+import org.jpos.iso.ISOBitMap;
+import org.jpos.iso.ISOBitMapPackager;
+import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOFieldPackager;
+import org.jpos.iso.ISOPackager;
+import org.jpos.iso.ISOUtil;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
 
 /**
  * ISO 8583 v1987 BINARY Packager 
@@ -45,16 +52,19 @@ public class Base1SubFieldPackager extends ISOBasePackager
     // except that fld[1] has been replaced with fld[0]
     // and a secondard bitmap is not allowed
 
+    @Override
     protected boolean emitBitMap()
     {
         return (fld[0] instanceof ISOBitMapPackager);
     }
 
+    @Override
     protected int getFirstField()
     {
         return (fld[0] instanceof ISOBitMapPackager) ? 1 : 0;
     }
 
+    @Override
     protected ISOFieldPackager getBitMapfieldPackager() 
     {
         return fld[0];
@@ -65,6 +75,7 @@ public class Base1SubFieldPackager extends ISOBasePackager
      * its corresponding ISOComponent
      */
 
+    @Override
     public int unpack (ISOComponent m, byte[] b) throws ISOException 
     {
         LogEvent evt = new LogEvent (this, "unpack");
@@ -91,7 +102,7 @@ public class Base1SubFieldPackager extends ISOBasePackager
             {
                 if (bmap == null || bmap.get(i)) 
                 {
-                    ISOComponent c = fld[i].createComponent(i);
+                    ISOComponent c = fld[i].createComponent(i, fld[i].getDisplay());
                     consumed += fld[i].unpack (c, b, consumed);
                     m.set(c);
                 }
@@ -118,6 +129,7 @@ public class Base1SubFieldPackager extends ISOBasePackager
      * Pack the subfield into a byte array
      */ 
 
+    @Override
     public byte[] pack (ISOComponent m) throws ISOException 
     {
         LogEvent evt = new LogEvent (this, "pack");

--- a/jpos/src/main/java/org/jpos/iso/packager/CTCSubElementPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/CTCSubElementPackager.java
@@ -18,6 +18,8 @@
 
 package org.jpos.iso.packager;
 
+import java.util.Map;
+
 import org.jpos.iso.ISOComponent;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOMsg;
@@ -25,8 +27,6 @@ import org.jpos.iso.ISOUtil;
 import org.jpos.iso.validator.ISOVException;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
-
-import java.util.Map;
 
 /**
  * Test validatingPackager for subelements in field 48.
@@ -44,6 +44,7 @@ public class CTCSubElementPackager extends ISOBaseValidatingPackager {
         super();
     }
 
+    @Override
     public byte[] pack ( ISOComponent c ) throws ISOException {
         try     {
             Map tab = c.getChildren();
@@ -61,11 +62,12 @@ public class CTCSubElementPackager extends ISOBaseValidatingPackager {
         }
     }
 
+    @Override
     public int unpack ( ISOComponent m, byte[] b ) throws ISOException {
         LogEvent evt = new LogEvent ( this, "unpack" );
         int consumed = 0;
         for ( int i=0; consumed < b.length ; i++ ) {
-            ISOComponent c = fld[i].createComponent( i );
+            ISOComponent c = fld[i].createComponent( i, fld[i].getDisplay() );
             consumed += fld[i].unpack ( c, b, consumed );
             if ( logger != null )       {
                 evt.addMessage ("<unpack fld=\"" + i
@@ -89,10 +91,12 @@ public class CTCSubElementPackager extends ISOBaseValidatingPackager {
      * Always return false
      * <br><br>
      **/
+    @Override
     protected boolean emitBitMap() {
         return false;
     }
 
+    @Override
     public ISOComponent validate( ISOComponent c ) throws org.jpos.iso.ISOException {
         LogEvent evt = new LogEvent( this, "validate" );
         try {

--- a/jpos/src/main/java/org/jpos/iso/packager/CTCSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/CTCSubFieldPackager.java
@@ -18,14 +18,14 @@
 
 package org.jpos.iso.packager;
 
+import java.util.Map;
+
 import org.jpos.iso.ISOComponent;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOField;
 import org.jpos.iso.validator.ISOVException;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
-
-import java.util.Map;
 
 /**
  * Tester validating packager for subfields in field 48.
@@ -43,6 +43,7 @@ public class CTCSubFieldPackager extends ISOBaseValidatingPackager {
         super();
     }
 
+    @Override
     public byte[] pack ( ISOComponent c ) throws ISOException {
         try     {
             Map tab = c.getChildren();
@@ -60,11 +61,12 @@ public class CTCSubFieldPackager extends ISOBaseValidatingPackager {
         }
     }
 
+    @Override
     public int unpack ( ISOComponent m, byte[] b ) throws ISOException {
         LogEvent evt = new LogEvent ( this, "unpack" );
         int consumed = 0;
         for ( int i=0; consumed < b.length ; i++ ) {
-            ISOComponent c = fld[i].createComponent( i );
+            ISOComponent c = fld[i].createComponent( i,  fld[i].getDisplay());
             consumed += fld[i].unpack ( c, b, consumed );
             if ( logger != null )       {
                 evt.addMessage ("<unpack fld=\"" + i
@@ -85,10 +87,12 @@ public class CTCSubFieldPackager extends ISOBaseValidatingPackager {
      * Always return false.
      * <br><br>
      **/
+    @Override
     protected boolean emitBitMap() {
         return false;
     }
 
+    @Override
     public ISOComponent validate( ISOComponent c ) throws org.jpos.iso.ISOException {
         LogEvent evt = new LogEvent( this, "validate" );
         try {

--- a/jpos/src/main/java/org/jpos/iso/packager/EuroSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/EuroSubFieldPackager.java
@@ -18,14 +18,20 @@
 
 package org.jpos.iso.packager;
 
-import org.jpos.iso.*;
-import org.jpos.util.LogEvent;
-import org.jpos.util.Logger;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.jpos.iso.AsciiPrefixer;
+import org.jpos.iso.ISOBasePackager;
+import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOPackager;
+import org.jpos.iso.ISOUtil;
+import org.jpos.iso.Prefixer;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
 
 /**
  * EuroPay SubField packager
@@ -109,7 +115,7 @@ public class EuroSubFieldPackager extends ISOBasePackager
             if (fld[i] == null)
                 throw new ISOException ("Unsupported sub-field " + i + " unpacking field " + m.getKey());
 
-            c = fld[i].createComponent(i);
+            c = fld[i].createComponent(i,  fld[i].getDisplay());
             consumed += fld[i].unpack (c, b, consumed);
             if (logger != null) 
             {

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
@@ -18,6 +18,16 @@
 
 package org.jpos.iso.packager;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Stack;
+import java.util.TreeMap;
+
 import org.jpos.core.Configurable;
 import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
@@ -37,16 +47,6 @@ import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Stack;
-import java.util.TreeMap;
 
 
 /**
@@ -315,6 +315,7 @@ public class GenericPackager
          *                                  or Reader for the InputSource.
          * @see org.xml.sax.InputSource
          */
+        @Override
         public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException
         {
             if(systemId==null) return null;
@@ -387,6 +388,7 @@ public class GenericPackager
                 String name = atts.getValue("name");
                 String size = atts.getValue("length");
                 String pad  = atts.getValue("pad");
+                String display  = atts.getValue("display");
                 // Modified for using IF_TBASE
                 String token = atts.getValue("token");
 
@@ -417,6 +419,11 @@ public class GenericPackager
                     f.setDescription(name);
                     f.setLength(Integer.parseInt(size));
                     f.setPad(Boolean.parseBoolean(pad));
+                    if (display==null) {
+                        display="0";
+                    }
+                    f.setDisplay(Integer.parseInt(display));
+
                     // Modified for using IF_TBASE
                     if( f instanceof IF_TBASE){
                       ((IF_TBASE)f).setToken( token );
@@ -443,6 +450,10 @@ public class GenericPackager
                     f.setDescription(name);
                     f.setLength(Integer.parseInt(size));
                     f.setPad(Boolean.parseBoolean(pad));
+                    if (display==null) {
+                        display="0";
+                    }
+                    f.setDisplay(Integer.parseInt(display));
                     // Modified for using IF_TBASE
                     if( f instanceof IF_TBASE){
                       ((IF_TBASE)f).setToken( token );

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericSubFieldPackager.java
@@ -18,14 +18,18 @@
 
 package org.jpos.iso.packager;
 
-import org.jpos.iso.*;
-import org.jpos.util.LogEvent;
-import org.jpos.util.Logger;
-
-import java.util.BitSet;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
+
+import org.jpos.iso.ISOBitMap;
+import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOField;
+import org.jpos.iso.ISOUtil;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
 
 /**
  * GenericSubFieldPackager
@@ -76,7 +80,7 @@ public class GenericSubFieldPackager extends GenericPackager
                 if (bmap == null || bmap.get(i)) 
                 {
                     if (fld[i] != null) {
-                        ISOComponent c = fld[i].createComponent(i);
+                        ISOComponent c = fld[i].createComponent(i,  fld[i].getDisplay());
                         consumed += fld[i].unpack (c, b, consumed);
                         m.set(c);
                     }

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericTaggedFieldsPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericTaggedFieldsPackager.java
@@ -18,17 +18,24 @@
 
 package org.jpos.iso.packager;
 
-import org.jpos.iso.*;
-import org.jpos.util.LogEvent;
-import org.jpos.util.Logger;
-import org.xml.sax.Attributes;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import org.jpos.iso.ISOBitMapPackager;
+import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOFieldPackager;
+import org.jpos.iso.ISOMsg;
+import org.jpos.iso.ISOMsgFieldPackager;
+import org.jpos.iso.ISOUtil;
+import org.jpos.iso.TaggedFieldPackagerBase;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
+import org.xml.sax.Attributes;
 
 /**
  *
@@ -63,7 +70,7 @@ public class GenericTaggedFieldsPackager extends GenericPackager {
             int maxField = fld.length;
             for (int i = getFirstField(); i < maxField && consumed < b.length; i++) {
                 if (fld[i] != null) {
-                    ISOComponent c = fld[i].createComponent(i);
+                    ISOComponent c = fld[i].createComponent(i,  fld[i].getDisplay());
                     int unpacked = fld[i].unpack(c, b, consumed);
                     consumed = consumed + unpacked;
                     if (unpacked > 0) {
@@ -103,7 +110,7 @@ public class GenericTaggedFieldsPackager extends GenericPackager {
 
             if (!(fld[0] instanceof ISOMsgFieldPackager) &&
                     !(fld[0] instanceof ISOBitMapPackager)) {
-                ISOComponent mti = fld[0].createComponent(0);
+                ISOComponent mti = fld[0].createComponent(0,  fld[0].getDisplay());
                 fld[0].unpack(mti, in);
                 m.set(mti);
             }
@@ -113,7 +120,7 @@ public class GenericTaggedFieldsPackager extends GenericPackager {
                 if (fld[i] == null)
                     continue;
 
-                ISOComponent c = fld[i].createComponent(i);
+                ISOComponent c = fld[i].createComponent(i,fld[i].getDisplay());
                 fld[i].unpack(c, in);
                 if (logger != null) {
                     evt.addMessage("<unpack fld=\"" + i
@@ -190,6 +197,7 @@ public class GenericTaggedFieldsPackager extends GenericPackager {
         }
     }
 
+    @Override
     public void setFieldPackager(ISOFieldPackager[] fld) {
         super.setFieldPackager(fld);
         for (int i = 0; i < fld.length; i++) {

--- a/jpos/src/main/resources/org/jpos/iso/packager/generic-subtag-packager.dtd
+++ b/jpos/src/main/resources/org/jpos/iso/packager/generic-subtag-packager.dtd
@@ -15,6 +15,7 @@
 <!ATTLIST isofield class                NMTOKEN      #REQUIRED>
 <!ATTLIST isofield token                CDATA        #IMPLIED>
 <!ATTLIST isofield pad                  (true|false) #IMPLIED>
+<!ATTLIST isofield display  				 (0|1|2)      #IMPLIED>
 
 <!-- isofieldpackager -->
 <!ELEMENT isofieldpackager (isofield+,isofieldpackager*)*>

--- a/jpos/src/main/resources/org/jpos/iso/packager/genericpackager.dtd
+++ b/jpos/src/main/resources/org/jpos/iso/packager/genericpackager.dtd
@@ -15,6 +15,7 @@
 <!ATTLIST isofield class  NMTOKEN      #REQUIRED>
 <!ATTLIST isofield token  CDATA        #IMPLIED>
 <!ATTLIST isofield pad    (true|false) #IMPLIED>
+<!ATTLIST isofield display  (0|1|2)        #IMPLIED>
 
 <!-- isofieldpackager -->
 <!ELEMENT isofieldpackager (isofield+,isofieldpackager*)*>


### PR DESCRIPTION
Modified the jpos framework to support ISO message logging to enbale pci
compliant logging via configuration of the packager itself.
An additional optional attribute called "display"is added in the
packager dtd which can take values 0 = default, 1 = protect, 2=wipe

This removes the dependency of adding an additional ProtectedLogListener
(logs messages received and sent) and configuring a ProtectDebugLog (to
protect the iso messages in the context).
These are kind of duplicate configuration to support PCI compliant
logging that can lead to errors.
The older way did not give us control to log unique field (e.g. if field
61 for incoming request from Interface 1 needed to be protected but
field 61 for incoming request from Interface 2 did not need to be
protected. Thus we did not have control of the individual fine grained
control fields.

This change is at the packager level hence we can protect different
fields in different interfaces.
