### PR TITLE
Making iso packagers support wipe/protect for PCI compliance

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/Display.java
+++ b/jpos/src/main/java/org/jpos/iso/Display.java
@@ -1,0 +1,8 @@
+package org.jpos.iso;
+
+public class Display {
+
+    public static final int WIPE    = 2;
+    public static final int PROTECT = 1;
+    public static final int NOP     = 0;
+}

--- a/jpos/src/main/java/org/jpos/iso/IFA_AMOUNT2003.java
+++ b/jpos/src/main/java/org/jpos/iso/IFA_AMOUNT2003.java
@@ -19,7 +19,7 @@
 package org.jpos.iso;
 
 public class IFA_AMOUNT2003 extends IFA_NUMERIC {
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOAmount (fieldNumber);    
     }
 }

--- a/jpos/src/main/java/org/jpos/iso/IFA_LLABINARY.java
+++ b/jpos/src/main/java/org/jpos/iso/IFA_LLABINARY.java
@@ -85,7 +85,7 @@ public class IFA_LLABINARY extends ISOFieldPackager {
         
         
     }
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOBinaryField (fieldNumber);
     }
     public int getMaxPackedLength() {

--- a/jpos/src/main/java/org/jpos/iso/IFA_LLLABINARY.java
+++ b/jpos/src/main/java/org/jpos/iso/IFA_LLLABINARY.java
@@ -85,7 +85,7 @@ public class IFA_LLLABINARY extends ISOFieldPackager {
         
       //CJH END
     }
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOBinaryField (fieldNumber);
     }
     public int getMaxPackedLength() {

--- a/jpos/src/main/java/org/jpos/iso/IFB_AMOUNT2003.java
+++ b/jpos/src/main/java/org/jpos/iso/IFB_AMOUNT2003.java
@@ -19,7 +19,7 @@
 package org.jpos.iso;
 
 public class IFB_AMOUNT2003 extends IFB_NUMERIC {
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOAmount (fieldNumber);    
     }
 }

--- a/jpos/src/main/java/org/jpos/iso/IFB_LLHFBINARY.java
+++ b/jpos/src/main/java/org/jpos/iso/IFB_LLHFBINARY.java
@@ -79,7 +79,7 @@ public class IFB_LLHFBINARY extends ISOFieldPackager {
         c.setValue (readBytes (in, len));
         in.skip (getLength () - len);
     }
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOBinaryField (fieldNumber);
     }
     public int getMaxPackedLength() {

--- a/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
@@ -18,16 +18,16 @@
 
 package org.jpos.iso;
 
-import org.jpos.util.LogEvent;
-import org.jpos.util.LogSource;
-import org.jpos.util.Logger;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Map;
+
+import org.jpos.util.LogEvent;
+import org.jpos.util.LogSource;
+import org.jpos.util.Logger;
 
 /**
  * provides base functionality for the actual packagers
@@ -66,6 +66,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
      * @return      Message image
      * @exception ISOException
      */
+    @Override
     public byte[] pack (ISOComponent m) throws ISOException {
         LogEvent evt = null;
         if (logger != null)
@@ -186,6 +187,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
      * @return      consumed bytes
      * @exception ISOException
      */
+    @Override
     public int unpack (ISOComponent m, byte[] b) throws ISOException {
         LogEvent evt = new LogEvent (this, "unpack");
         int consumed = 0;
@@ -208,7 +210,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
             
             if (!(fld[0] == null) && !(fld[0] instanceof ISOBitMapPackager))
             {
-                ISOComponent mti = fld[0].createComponent(0);
+                ISOComponent mti = fld[0].createComponent(0, fld[0].getDisplay());
                 consumed  += fld[0].unpack(mti, b, consumed);
                 m.set (mti);
             }
@@ -234,7 +236,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                         if (fld[i] == null)
                             throw new ISOException ("field packager '" + i + "' is null");
 
-                        ISOComponent c = fld[i].createComponent(i);
+                        ISOComponent c = fld[i].createComponent(i,fld[i].getDisplay());
                         consumed += fld[i].unpack (c, b, consumed);
                         if (logger != null) {
                             evt.addMessage ("<unpack fld=\"" + i 
@@ -305,7 +307,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
             if (!(fld[0] instanceof ISOMsgFieldPackager) &&
                 !(fld[0] instanceof ISOBitMapPackager))
             {
-                ISOComponent mti = fld[0].createComponent(0);
+                ISOComponent mti = fld[0].createComponent(0,  fld[0].getDisplay());
                 fld[0].unpack(mti, in);
                 m.set (mti);
             }
@@ -329,7 +331,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                     if (fld[i] == null)
                         throw new ISOException ("field packager '" + i + "' is null");
 
-                    ISOComponent c = fld[i].createComponent(i);
+                    ISOComponent c = fld[i].createComponent(i,  fld[i].getDisplay());
                     fld[i].unpack (c, in);
                     if (logger != null) {
                         evt.addMessage ("<unpack fld=\"" + i 
@@ -352,7 +354,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                 bmap= (BitSet) ((ISOComponent) m.getChildren().get(65)).getValue();
                 for (int i=1; i<64; i++) {
                     if (bmap == null || bmap.get(i)) {
-                        ISOComponent c = fld[i+128].createComponent(i);
+                        ISOComponent c = fld[i+128].createComponent(i,  fld[i+128].getDisplay());
                         fld[i+128].unpack (c, in);
                         if (logger != null) {
                             evt.addMessage ("<unpack fld=\"" + i+128
@@ -384,6 +386,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
      * @param   fldNumber the Field Number
      * @return  Field Description
      */
+    @Override
     public String getFieldDescription(ISOComponent m, int fldNumber) {
         return fld[fldNumber].getDescription();
     }
@@ -403,6 +406,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     {
         fld[fldNumber] = fieldPackager;
     }
+    @Override
     public ISOMsg createISOMsg () {
         return new ISOMsg();
     }
@@ -418,13 +422,16 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     protected ISOFieldPackager getBitMapfieldPackager() {
         return fld[1];
     }
+    @Override
     public void setLogger (Logger logger, String realm) {
         this.logger = logger;
         this.realm  = realm;
     }
+    @Override
     public String getRealm () {
         return realm;
     }
+    @Override
     public Logger getLogger() {
         return logger;
     }
@@ -436,6 +443,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     {
     	headerLength = len;
     }
+    @Override
     public String getDescription () {
         return getClass().getName();
     }

--- a/jpos/src/main/java/org/jpos/iso/ISOBinaryFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBinaryFieldPackager.java
@@ -178,7 +178,7 @@ public class ISOBinaryFieldPackager extends ISOFieldPackager
      * @param fieldNumber - the field number
      * @return the newly created component
      */
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOBinaryField (fieldNumber);
     }
 

--- a/jpos/src/main/java/org/jpos/iso/ISOBitMapPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBitMapPackager.java
@@ -36,7 +36,7 @@ public abstract class ISOBitMapPackager extends ISOFieldPackager {
     public ISOBitMapPackager(int len, String description) {
         super(len, description);
     }
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         return new ISOBitMap (fieldNumber);
     }
 }

--- a/jpos/src/main/java/org/jpos/iso/ISOFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOFieldPackager.java
@@ -62,6 +62,7 @@ public abstract class ISOFieldPackager {
     private int len;
     private String description;
     protected boolean pad;
+    protected int display;
 
     /**
      * Default Constructor
@@ -97,10 +98,20 @@ public abstract class ISOFieldPackager {
         this.pad = pad;
     }
 
+    public void setDisplay(int display) {
+        this.display = display;
+    }
+
+
+    public int getDisplay() {
+        return display;
+    }
+
+
     public abstract int getMaxPackedLength();
 
-    public ISOComponent createComponent(int fieldNumber) {
-        return new ISOField (fieldNumber);
+    public ISOComponent createComponent(int fieldNumber, int display) {
+        return new ISOField (fieldNumber, display);
     }
     /**
      * @param c - a component

--- a/jpos/src/main/java/org/jpos/iso/ISOMsgFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOMsgFieldPackager.java
@@ -93,7 +93,7 @@ public class ISOMsgFieldPackager extends ISOFieldPackager {
             msgPackager.unpack((ISOMsg) c, (byte[]) f.getValue());
         }
     }
-    public ISOComponent createComponent(int fieldNumber) {
+    public ISOComponent createComponent(int fieldNumber, int display) {
         ISOMsg m = new ISOMsg(fieldNumber);
         m.setPackager(msgPackager);
         return m;

--- a/jpos/src/main/java/org/jpos/iso/packager/Base1SubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/Base1SubFieldPackager.java
@@ -18,14 +18,21 @@
 
 package org.jpos.iso.packager;
 
-import org.jpos.iso.*;
-import org.jpos.util.LogEvent;
-import org.jpos.util.Logger;
-
-import java.util.BitSet;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
+
+import org.jpos.iso.ISOBasePackager;
+import org.jpos.iso.ISOBitMap;
+import org.jpos.iso.ISOBitMapPackager;
+import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOFieldPackager;
+import org.jpos.iso.ISOPackager;
+import org.jpos.iso.ISOUtil;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
 
 /**
  * ISO 8583 v1987 BINARY Packager 
@@ -45,16 +52,19 @@ public class Base1SubFieldPackager extends ISOBasePackager
     // except that fld[1] has been replaced with fld[0]
     // and a secondard bitmap is not allowed
 
+    @Override
     protected boolean emitBitMap()
     {
         return (fld[0] instanceof ISOBitMapPackager);
     }
 
+    @Override
     protected int getFirstField()
     {
         return (fld[0] instanceof ISOBitMapPackager) ? 1 : 0;
     }
 
+    @Override
     protected ISOFieldPackager getBitMapfieldPackager() 
     {
         return fld[0];
@@ -65,6 +75,7 @@ public class Base1SubFieldPackager extends ISOBasePackager
      * its corresponding ISOComponent
      */
 
+    @Override
     public int unpack (ISOComponent m, byte[] b) throws ISOException 
     {
         LogEvent evt = new LogEvent (this, "unpack");
@@ -91,7 +102,7 @@ public class Base1SubFieldPackager extends ISOBasePackager
             {
                 if (bmap == null || bmap.get(i)) 
                 {
-                    ISOComponent c = fld[i].createComponent(i);
+                    ISOComponent c = fld[i].createComponent(i, fld[i].getDisplay());
                     consumed += fld[i].unpack (c, b, consumed);
                     m.set(c);
                 }
@@ -118,6 +129,7 @@ public class Base1SubFieldPackager extends ISOBasePackager
      * Pack the subfield into a byte array
      */ 
 
+    @Override
     public byte[] pack (ISOComponent m) throws ISOException 
     {
         LogEvent evt = new LogEvent (this, "pack");

--- a/jpos/src/main/java/org/jpos/iso/packager/CTCSubElementPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/CTCSubElementPackager.java
@@ -18,6 +18,8 @@
 
 package org.jpos.iso.packager;
 
+import java.util.Map;
+
 import org.jpos.iso.ISOComponent;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOMsg;
@@ -25,8 +27,6 @@ import org.jpos.iso.ISOUtil;
 import org.jpos.iso.validator.ISOVException;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
-
-import java.util.Map;
 
 /**
  * Test validatingPackager for subelements in field 48.
@@ -44,6 +44,7 @@ public class CTCSubElementPackager extends ISOBaseValidatingPackager {
         super();
     }
 
+    @Override
     public byte[] pack ( ISOComponent c ) throws ISOException {
         try     {
             Map tab = c.getChildren();
@@ -61,11 +62,12 @@ public class CTCSubElementPackager extends ISOBaseValidatingPackager {
         }
     }
 
+    @Override
     public int unpack ( ISOComponent m, byte[] b ) throws ISOException {
         LogEvent evt = new LogEvent ( this, "unpack" );
         int consumed = 0;
         for ( int i=0; consumed < b.length ; i++ ) {
-            ISOComponent c = fld[i].createComponent( i );
+            ISOComponent c = fld[i].createComponent( i, fld[i].getDisplay() );
             consumed += fld[i].unpack ( c, b, consumed );
             if ( logger != null )       {
                 evt.addMessage ("<unpack fld=\"" + i
@@ -89,10 +91,12 @@ public class CTCSubElementPackager extends ISOBaseValidatingPackager {
      * Always return false
      * <br><br>
      **/
+    @Override
     protected boolean emitBitMap() {
         return false;
     }
 
+    @Override
     public ISOComponent validate( ISOComponent c ) throws org.jpos.iso.ISOException {
         LogEvent evt = new LogEvent( this, "validate" );
         try {

--- a/jpos/src/main/java/org/jpos/iso/packager/CTCSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/CTCSubFieldPackager.java
@@ -18,14 +18,14 @@
 
 package org.jpos.iso.packager;
 
+import java.util.Map;
+
 import org.jpos.iso.ISOComponent;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOField;
 import org.jpos.iso.validator.ISOVException;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
-
-import java.util.Map;
 
 /**
  * Tester validating packager for subfields in field 48.
@@ -43,6 +43,7 @@ public class CTCSubFieldPackager extends ISOBaseValidatingPackager {
         super();
     }
 
+    @Override
     public byte[] pack ( ISOComponent c ) throws ISOException {
         try     {
             Map tab = c.getChildren();
@@ -60,11 +61,12 @@ public class CTCSubFieldPackager extends ISOBaseValidatingPackager {
         }
     }
 
+    @Override
     public int unpack ( ISOComponent m, byte[] b ) throws ISOException {
         LogEvent evt = new LogEvent ( this, "unpack" );
         int consumed = 0;
         for ( int i=0; consumed < b.length ; i++ ) {
-            ISOComponent c = fld[i].createComponent( i );
+            ISOComponent c = fld[i].createComponent( i,  fld[i].getDisplay());
             consumed += fld[i].unpack ( c, b, consumed );
             if ( logger != null )       {
                 evt.addMessage ("<unpack fld=\"" + i
@@ -85,10 +87,12 @@ public class CTCSubFieldPackager extends ISOBaseValidatingPackager {
      * Always return false.
      * <br><br>
      **/
+    @Override
     protected boolean emitBitMap() {
         return false;
     }
 
+    @Override
     public ISOComponent validate( ISOComponent c ) throws org.jpos.iso.ISOException {
         LogEvent evt = new LogEvent( this, "validate" );
         try {

--- a/jpos/src/main/java/org/jpos/iso/packager/EuroSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/EuroSubFieldPackager.java
@@ -18,14 +18,20 @@
 
 package org.jpos.iso.packager;
 
-import org.jpos.iso.*;
-import org.jpos.util.LogEvent;
-import org.jpos.util.Logger;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.jpos.iso.AsciiPrefixer;
+import org.jpos.iso.ISOBasePackager;
+import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOPackager;
+import org.jpos.iso.ISOUtil;
+import org.jpos.iso.Prefixer;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
 
 /**
  * EuroPay SubField packager
@@ -109,7 +115,7 @@ public class EuroSubFieldPackager extends ISOBasePackager
             if (fld[i] == null)
                 throw new ISOException ("Unsupported sub-field " + i + " unpacking field " + m.getKey());
 
-            c = fld[i].createComponent(i);
+            c = fld[i].createComponent(i,fld[i].getDisplay());
             consumed += fld[i].unpack (c, b, consumed);
             if (logger != null) 
             {

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
@@ -18,6 +18,16 @@
 
 package org.jpos.iso.packager;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Stack;
+import java.util.TreeMap;
+
 import org.jpos.core.Configurable;
 import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
@@ -37,16 +47,6 @@ import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Stack;
-import java.util.TreeMap;
 
 
 /**
@@ -315,6 +315,7 @@ public class GenericPackager
          *                                  or Reader for the InputSource.
          * @see org.xml.sax.InputSource
          */
+        @Override
         public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException
         {
             if(systemId==null) return null;
@@ -387,6 +388,7 @@ public class GenericPackager
                 String name = atts.getValue("name");
                 String size = atts.getValue("length");
                 String pad  = atts.getValue("pad");
+                String display  = atts.getValue("display");
                 // Modified for using IF_TBASE
                 String token = atts.getValue("token");
 
@@ -417,6 +419,11 @@ public class GenericPackager
                     f.setDescription(name);
                     f.setLength(Integer.parseInt(size));
                     f.setPad(Boolean.parseBoolean(pad));
+                    if (display==null) {
+                        display="0";
+                    }
+                    f.setDisplay(Integer.parseInt(display));
+
                     // Modified for using IF_TBASE
                     if( f instanceof IF_TBASE){
                       ((IF_TBASE)f).setToken( token );
@@ -443,6 +450,10 @@ public class GenericPackager
                     f.setDescription(name);
                     f.setLength(Integer.parseInt(size));
                     f.setPad(Boolean.parseBoolean(pad));
+                    if (display==null) {
+                        display="0";
+                    }
+                    f.setDisplay(Integer.parseInt(display));
                     // Modified for using IF_TBASE
                     if( f instanceof IF_TBASE){
                       ((IF_TBASE)f).setToken( token );

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericSubFieldPackager.java
@@ -18,14 +18,18 @@
 
 package org.jpos.iso.packager;
 
-import org.jpos.iso.*;
-import org.jpos.util.LogEvent;
-import org.jpos.util.Logger;
-
-import java.util.BitSet;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
+
+import org.jpos.iso.ISOBitMap;
+import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOField;
+import org.jpos.iso.ISOUtil;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
 
 /**
  * GenericSubFieldPackager
@@ -76,7 +80,7 @@ public class GenericSubFieldPackager extends GenericPackager
                 if (bmap == null || bmap.get(i)) 
                 {
                     if (fld[i] != null) {
-                        ISOComponent c = fld[i].createComponent(i);
+                        ISOComponent c = fld[i].createComponent(i,fld[i].getDisplay());
                         consumed += fld[i].unpack (c, b, consumed);
                         m.set(c);
                     }

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericTaggedFieldsPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericTaggedFieldsPackager.java
@@ -18,17 +18,24 @@
 
 package org.jpos.iso.packager;
 
-import org.jpos.iso.*;
-import org.jpos.util.LogEvent;
-import org.jpos.util.Logger;
-import org.xml.sax.Attributes;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import org.jpos.iso.ISOBitMapPackager;
+import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOFieldPackager;
+import org.jpos.iso.ISOMsg;
+import org.jpos.iso.ISOMsgFieldPackager;
+import org.jpos.iso.ISOUtil;
+import org.jpos.iso.TaggedFieldPackagerBase;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
+import org.xml.sax.Attributes;
 
 /**
  *
@@ -63,7 +70,7 @@ public class GenericTaggedFieldsPackager extends GenericPackager {
             int maxField = fld.length;
             for (int i = getFirstField(); i < maxField && consumed < b.length; i++) {
                 if (fld[i] != null) {
-                    ISOComponent c = fld[i].createComponent(i);
+                    ISOComponent c = fld[i].createComponent(i,fld[i].getDisplay());
                     int unpacked = fld[i].unpack(c, b, consumed);
                     consumed = consumed + unpacked;
                     if (unpacked > 0) {
@@ -103,7 +110,7 @@ public class GenericTaggedFieldsPackager extends GenericPackager {
 
             if (!(fld[0] instanceof ISOMsgFieldPackager) &&
                     !(fld[0] instanceof ISOBitMapPackager)) {
-                ISOComponent mti = fld[0].createComponent(0);
+                ISOComponent mti = fld[0].createComponent(0,fld[0].getDisplay());
                 fld[0].unpack(mti, in);
                 m.set(mti);
             }
@@ -113,7 +120,7 @@ public class GenericTaggedFieldsPackager extends GenericPackager {
                 if (fld[i] == null)
                     continue;
 
-                ISOComponent c = fld[i].createComponent(i);
+                ISOComponent c = fld[i].createComponent(i,fld[i].getDisplay());
                 fld[i].unpack(c, in);
                 if (logger != null) {
                     evt.addMessage("<unpack fld=\"" + i
@@ -190,6 +197,7 @@ public class GenericTaggedFieldsPackager extends GenericPackager {
         }
     }
 
+    @Override
     public void setFieldPackager(ISOFieldPackager[] fld) {
         super.setFieldPackager(fld);
         for (int i = 0; i < fld.length; i++) {

--- a/jpos/src/main/resources/org/jpos/iso/packager/genericpackager.dtd
+++ b/jpos/src/main/resources/org/jpos/iso/packager/genericpackager.dtd
@@ -15,6 +15,7 @@
 <!ATTLIST isofield class  NMTOKEN      #REQUIRED>
 <!ATTLIST isofield token  CDATA        #IMPLIED>
 <!ATTLIST isofield pad    (true|false) #IMPLIED>
+<!ATTLIST isofield display  (0|1|2)        #IMPLIED>
 
 <!-- isofieldpackager -->
 <!ELEMENT isofieldpackager (isofield+,isofieldpackager*)*>

--- a/legal/cla-chhil.txt
+++ b/legal/cla-chhil.txt
@@ -1,0 +1,129 @@
+jPOS Project          
+Contributor License Agreement V1.0
+based on http://www.apache.org/licenses/
+
+Thank you for your interest in the jPOS project by Alejandro P. Revilla
+(Uruguayan company #212 752 380 016) doing business as jPOS Organization
+(jPOS.org). In order to clarify the intellectual property license granted with
+Contributions from any person or entity, jPOS.org must have a Contributor
+License Agreement ("CLA") that has been signed by each Contributor, indicating
+agreement to the license terms below. This license is for your protection as a
+Contributor as well as the protection of jPOS.org and its users; it does not
+change your rights to use your own Contributions for any other purpose.  
+
+If you have not already done so, please complete this agreement and
+commit it to the jPOS repository at
+https://svn.sourceforge.net/svnroot/jpos at legal/cla-USERNAME.txt using
+your authenticated SourceForge login. If you do not have commit
+privilege to the repository, please email the file to license@jpos.org.
+If possible, digitally sign the committed file, otherwise also send a
+signed Agreement to jPOS.org.
+
+Please read this document carefully before signing and keep a copy for
+your records.
+
+  Full name: Murtuza Chhil
+  E-Mail:    chillum@gmail.com
+  Mailing Address: J904 Jasminium, Magarpatta City, Hadapsar, Pune 411028, Maharashtra, India 
+
+You accept and agree to the following terms and conditions for Your
+present and future Contributions submitted to jPOS.org. In return,
+jPOS.org shall not use Your Contributions in a way that is
+contrary to the software license in effect at the time of the
+Contribution.  Except for the license granted herein to jPOS.org
+and recipients of software distributed by jPOS.org, You reserve
+all right, title, and interest in and to Your Contributions.
+
+1. Definitions.
+
+   "You" (or "Your") shall mean the copyright owner or legal entity
+   authorized by the copyright owner that is making this Agreement
+   with jPOS.org. For legal entities, the entity making a
+   Contribution and all other entities that control, are controlled
+   by, or are under common control with that entity are considered to
+   be a single Contributor. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "Contribution" shall mean any original work of authorship,
+   including any modifications or additions to an existing work, that
+   is intentionally submitted by You to jPOS.org for inclusion
+   in, or documentation of, any of the products owned or managed by
+   jPOS.org (the "Work"). For the purposes of this definition,
+   "submitted" means any form of electronic, verbal, or written
+   communication sent to jPOS.org or its representatives,
+   including but not limited to communication on electronic mailing
+   lists, source code control systems, and issue tracking systems that
+   are managed by, or on behalf of, jPOS.org for the purpose of
+   discussing and improving the Work, but excluding communication that
+   is conspicuously marked or otherwise designated in writing by You
+   as "Not a Contribution."
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this Agreement, You hereby grant to jPOS.org and to
+   recipients of software distributed by jPOS.org a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare derivative works of,
+   publicly display, publicly perform, sublicense, and distribute Your
+   Contributions and such derivative works.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this Agreement, You hereby grant to jPOS.org and to
+   recipients of software distributed by jPOS.org a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have
+   made, use, offer to sell, sell, import, and otherwise transfer the
+   Work, where such license applies only to those patent claims
+   licensable by You that are necessarily infringed by Your
+   Contribution(s) alone or by combination of Your Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If any
+   entity institutes patent litigation against You or any other entity
+   (including a cross-claim or counterclaim in a lawsuit) alleging
+   that your Contribution, or the Work to which you have contributed,
+   constitutes direct or contributory patent infringement, then any
+   patent licenses granted to that entity under this Agreement for
+   that Contribution or Work shall terminate as of the date such
+   litigation is filed.
+
+4. You represent that you are legally entitled to grant the above
+   license. If your employer(s) has rights to intellectual property
+   that you create that includes your Contributions, you represent
+   that you have received permission to make Contributions on behalf
+   of that employer, that your employer has waived such rights for
+   your Contributions to jPOS.org, or that your employer has
+   executed a separate Corporate CLA with jPOS.org.
+
+5. You represent that each of Your Contributions is Your original
+   creation (see section 7 for submissions on behalf of others).  You
+   represent that Your Contribution submissions include complete
+   details of any third-party license or other restriction (including,
+   but not limited to, related patents and trademarks) of which you
+   are personally aware and which are associated with any part of Your
+   Contributions.
+
+6. You are not expected to provide support for Your Contributions,
+   except to the extent You desire to provide support. You may provide
+   support for free, for a fee, or not at all. Unless required by
+   applicable law or agreed to in writing, You provide Your
+   Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+   OF ANY KIND, either express or implied, including, without
+   limitation, any warranties or conditions of TITLE, NON-
+   INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation,
+   You may submit it to jPOS.org separately from any
+   Contribution, identifying the complete details of its source and of
+   any license or other restriction (including, but not limited to,
+   related patents, trademarks, and license agreements) of which you
+   are personally aware, and conspicuously marking the work as
+   "Submitted on behalf of a third-party: [named here]".
+
+8. You agree to notify jPOS.org of any facts or circumstances of
+   which you become aware that would make these representations
+   inaccurate in any respect.
+
+Date: Nov 1 2012
+Please sign: 
+


### PR DESCRIPTION
Diff before commit http://screencast.com/t/S07t37fZx
Modified the jpos framework to support ISO message logging to enbale pci
compliant logging via configuration of the packager itself.
An additional optional attribute called "display"is added in the
packager dtd which can take values 0 = default, 1 = protect, 2=wipe

This removes the dependency of adding an additional ProtectedLogListener
(logs messages received and sent) and configuring a ProtectDebugLog (to
protect the iso messages in the context).
These are kind of duplicate configuration to support PCI compliant
logging that can lead to errors.
The older way did not give us control to log unique field (e.g. if field
61 for incoming request from Interface 1 needed to be protected but
field 61 for incoming request from Interface 2 did not need to be
protected. Thus we did not have control of the individual fine grained
control fields.

This change is at the packager level hence we can protect different
fields in different interfaces.
