### PR TITLE
Adde Displa attr n dump fix

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/Display.java
+++ b/jpos/src/main/java/org/jpos/iso/Display.java
@@ -1,0 +1,8 @@
+package org.jpos.iso;
+
+public class Display {
+
+    public static final int WIPE    = 2;
+    public static final int PROTECT = 1;
+    public static final int NOP     = 0;
+}


### PR DESCRIPTION
Dump method was not honoring schema ordering and not dumping constants.
Add attribute Display to support protect/wipe of fields in dump/toXML
and added a hexdump method to dump data based on display attribute.
