### PR TITLE
Add server connection listener support via configuration

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/iso/QServer.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QServer.java
@@ -1,6 +1,6 @@
 /*
  * jPOS Project [http://jpos.org]
- * Copyright (C) 2000-2013 Alejandro P. Revilla
+ * Copyright (C) 2000-2012 Alejandro P. Revilla
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -19,15 +19,16 @@
 package org.jpos.q2.iso;
 
 import java.util.Iterator;
+import java.util.StringTokenizer;
 
 import org.jdom.Element;
 import org.jpos.core.ConfigurationException;
 import org.jpos.iso.ISOChannel;
-import org.jpos.iso.ISOMsg;
-import org.jpos.iso.ISOPackager;
-import org.jpos.iso.ISORequestListener;
 import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOMsg;
+import org.jpos.iso.ISORequestListener;
 import org.jpos.iso.ISOServer;
+import org.jpos.iso.ISOServerEventsListener;
 import org.jpos.iso.ISOServerSocketFactory;
 import org.jpos.iso.ISOSource;
 import org.jpos.iso.ServerChannel;
@@ -58,42 +59,46 @@ public class QServer
     private int minSessions = 1;
     private String channelString, packagerString, socketFactoryString;
     private ISOChannel channel = null;
-    private ISOPackager packager = null;
     private ISOServer server;
     protected LocalSpace sp;
     private String inQueue;
     private String outQueue;
+    private String sendMethod;
 
     public QServer () {
         super ();
     }
-    
+
+    @Override
     public void initService() throws ConfigurationException {
         Element e = getPersist ();
-        sp        = grabSpace (e.getChild ("space")); 
+        sp        = grabSpace (e.getChild ("space"));
     }
 
     private void newChannel () throws ConfigurationException {
         Element persist = getPersist ();
         Element e = persist.getChild ("channel");
-        if (e == null)
+        if (e == null) {
             throw new ConfigurationException ("channel element missing");
+        }
 
         ChannelAdaptor adaptor = new ChannelAdaptor ();
         channel = adaptor.newChannel (e, getFactory ());
     }
 
-    private void initServer () 
+    private void initServer ()
         throws ConfigurationException
     {
-        if (port == 0)
+        if (port == 0) {
             throw new ConfigurationException ("Port value not set");
+        }
         newChannel();
-        if (channel == null)
+        if (channel == null) {
             throw new ConfigurationException ("ISO Channel is null");
+        }
 
         if (!(channel instanceof ServerChannel)) {
-            throw new ConfigurationException (channelString + 
+            throw new ConfigurationException (channelString +
                   "does not implement ServerChannel");
         }
 
@@ -111,9 +116,10 @@ public class QServer
             }
             server.setSocketFactory(sFac);
         }
-        getFactory().setConfiguration (server, getPersist());     
+        getFactory().setConfiguration (server, getPersist());
         addServerSocketFactory();
-        addListeners ();
+        addListeners ();// ISORequestListener
+        addISOServerConnectionListeners();
         NameRegistrar.register (getName(), this);
         new Thread (server).start();
     }
@@ -125,7 +131,7 @@ public class QServer
              * We have an 'in' queue to monitor for messages we will
              *  send out through server in our (SpaceListener)notify(Object, Object) method.
              */
-          
+
             sp.addListener(inQueue, this);
 
         }
@@ -137,7 +143,7 @@ public class QServer
             /*
              * We have an 'out' queue to send any messages to that are received
              * by the our requestListner(this).
-             * 
+             *
              * Note, if additional ISORequestListeners are registered with the server after
              *  this point, then they won't see anything as our process(ISOSource, ISOMsg)
              *  always return true.
@@ -146,19 +152,35 @@ public class QServer
 
         }
     }
+    @Override
     public void startService () {
         try {
             initServer ();
             initIn();
             initOut();
+            initWhoToSendTo();
         } catch (Exception e) {
             getLog().warn ("error starting service", e);
         }
     }
-    public void stopService () {
-        if (server != null)
-            server.shutdown ();
+    private void initWhoToSendTo() {
+
+        Element persist = getPersist();
+        sendMethod = persist.getChildText("send-request");
+        if (sendMethod==null) {
+            sendMethod="LAST";
+        }
+
+
     }
+
+    @Override
+    public void stopService () {
+        if (server != null) {
+            server.shutdown ();
+        }
+    }
+    @Override
     public void destroyService () {
         NameRegistrar.unregister (getName());
         NameRegistrar.unregister ("server." + getName());
@@ -167,6 +189,7 @@ public class QServer
     /**
      * @jmx:managed-attribute description="Server port"
      */
+    @Override
     public synchronized void setPort (int port) {
         this.port = port;
         setAttr (getAttrs (), "port", Integer.valueOf(port));
@@ -176,6 +199,7 @@ public class QServer
     /**
      * @jmx:managed-attribute description="Server port"
      */
+    @Override
     public int getPort () {
         return port;
     }
@@ -183,6 +207,7 @@ public class QServer
     /**
      * @jmx:managed-attribute description="Packager"
      */
+    @Override
     public synchronized void setPackager (String packager) {
         packagerString = packager;
         setAttr (getAttrs (), "packager", packagerString);
@@ -192,6 +217,7 @@ public class QServer
     /**
      * @jmx:managed-attribute description="Packager"
      */
+    @Override
     public String getPackager () {
         return packagerString;
     }
@@ -199,6 +225,7 @@ public class QServer
     /**
      * @jmx:managed-attribute description="Channel"
      */
+    @Override
     public synchronized void setChannel (String channel) {
         channelString = channel;
         setAttr (getAttrs (), "channel", channelString);
@@ -208,6 +235,7 @@ public class QServer
     /**
      * @jmx:managed-attribute description="Channel"
      */
+    @Override
     public String getChannel () {
         return channelString;
     }
@@ -215,6 +243,7 @@ public class QServer
     /**
      * @jmx:managed-attribute description="Maximum Nr. of Sessions"
      */
+    @Override
     public synchronized void setMaxSessions (int maxSessions) {
         this.maxSessions = maxSessions;
         setAttr (getAttrs (), "maxSessions", Integer.valueOf(maxSessions));
@@ -223,12 +252,14 @@ public class QServer
     /**
      * @jmx:managed-attribute description="Maximum Nr. of Sessions"
      */
+    @Override
     public int getMaxSessions () {
         return maxSessions;
     }
     /**
      * @jmx:managed-attribute description="Minimum Nr. of Sessions"
      */
+    @Override
     public synchronized void setMinSessions (int minSessions) {
         this.minSessions = minSessions;
         setAttr (getAttrs (), "minSessions", Integer.valueOf(minSessions));
@@ -237,49 +268,55 @@ public class QServer
     /**
      * @jmx:managed-attribute description="Minimum Nr. of Sessions"
      */
+    @Override
     public int getMinSessions () {
         return minSessions;
     }
     /**
-     * @jmx:managed-attribute description="Socket Factory" 
+     * @jmx:managed-attribute description="Socket Factory"
      */
+    @Override
     public synchronized void setSocketFactory (String sFactory) {
         socketFactoryString = sFactory;
         setAttr (getAttrs(),"socketFactory", socketFactoryString);
         setModified (true);
     }
     /**
-     * @jmx:managed-attribute description="Socket Factory" 
+     * @jmx:managed-attribute description="Socket Factory"
      */
+    @Override
     public String getSocketFactory() {
         return socketFactoryString;
-    }    
+    }
 
+    @Override
     public String getISOChannelNames() {
         return server.getISOChannelNames();
     }
+    @Override
     public String getCountersAsString () {
         return server.getCountersAsString ();
     }
+    @Override
     public String getCountersAsString (String isoChannelName) {
         return server.getCountersAsString (isoChannelName);
     }
     private void addServerSocketFactory () throws ConfigurationException {
         QFactory factory = getFactory ();
         Element persist = getPersist ();
-        
+
         Element serverSocketFactoryElement = persist.getChild ("server-socket-factory");
-        
+
         if (serverSocketFactoryElement != null) {
             ISOServerSocketFactory serverSocketFactory = (ISOServerSocketFactory) factory.newInstance (serverSocketFactoryElement.getAttributeValue ("class"));
             factory.setLogger        (serverSocketFactory, serverSocketFactoryElement);
             factory.setConfiguration (serverSocketFactory, serverSocketFactoryElement);
             server.setSocketFactory(serverSocketFactory);
         }
-            
+
     }
-    
-    private void addListeners () 
+
+    private void addListeners ()
         throws ConfigurationException
     {
         QFactory factory = getFactory ();
@@ -288,14 +325,33 @@ public class QServer
         ).iterator();
         while (iter.hasNext()) {
             Element l = (Element) iter.next();
-            ISORequestListener listener = (ISORequestListener) 
+            ISORequestListener listener = (ISORequestListener)
                 factory.newInstance (l.getAttributeValue ("class"));
             factory.setLogger        (listener, l);
             factory.setConfiguration (listener, l);
             server.addISORequestListener (listener);
         }
     }
-    
+
+    private void addISOServerConnectionListeners()
+         throws ConfigurationException
+    {
+
+        QFactory factory = getFactory ();
+        Iterator iter = getPersist().getChildren (
+            "server-connection-listener"
+        ).iterator();
+        while (iter.hasNext()) {
+            Element l = (Element) iter.next();
+            ISOServerEventsListener listener = (ISOServerEventsListener)
+                factory.newInstance (l.getAttributeValue ("class"));
+            factory.setLogger        (listener, l);
+            factory.setConfiguration (listener, l);
+            server.addServerEventListener(listener);
+        }
+    }
+
+
     private LocalSpace grabSpace (Element e) throws ConfigurationException
     {
         String uri = e != null ? e.getText() : "";
@@ -310,19 +366,51 @@ public class QServer
      * This method will be invoked through the SpaceListener interface we registered once
      * we noticed we had an 'in' queue.
      */
+    @Override
     public void notify(Object key, Object value) {
-        Object obj = sp.inp (key);
+
+        Object obj = sp.inp(key);
         if (obj instanceof ISOMsg) {
             ISOMsg m = (ISOMsg) obj;
-            try {
-                ISOChannel c = server.getLastConnectedISOChannel();
-                if (c == null)
-                    throw new ISOException ("Server has no active connections");
-                if (!c.isConnected())
-                    throw new ISOException ("Client disconnected");
-                c.send(m);
-            } catch (Exception e) { 
-                getLog().warn ("notify", e);
+            if ("LAST".equals(sendMethod)) {
+                try {
+                    ISOChannel c = server.getLastConnectedISOChannel();
+                    if (c == null) {
+                        throw new ISOException("Server has no active connections");
+                    }
+                    if (!c.isConnected()) {
+                        throw new ISOException("Client disconnected");
+                    }
+                    c.send(m);
+                }
+                catch (Exception e) {
+                    getLog().warn("notify", e);
+                }
+            }
+            else if ("ALL".equals(sendMethod)) {
+                String channelNames = getISOChannelNames();
+                if (channelNames!=null) {
+                    StringTokenizer tok =new StringTokenizer(channelNames, " ");
+                    while (tok.hasMoreTokens()) {
+                        try {
+                            ISOChannel c = server.getISOChannel(tok.nextToken());
+                            if (c == null) {
+                                throw new ISOException("Server has no active connections");
+                            }
+                            if (!c.isConnected()) {
+                                throw new ISOException("Client disconnected");
+                            }
+                            c.send(m);
+                        }
+                        catch (Exception e) {
+                            getLog().warn("notify", e);
+                        }
+
+
+
+                    }
+                }
+
             }
         }
     }
@@ -331,6 +419,7 @@ public class QServer
      * This method will be invoke through the ISORequestListener interface, *if*
      * this QServer has an 'out' queue to handle.
      */
+    @Override
     public boolean process(ISOSource source, ISOMsg m) {
         sp.out(outQueue, m);
         return true;
@@ -338,4 +427,4 @@ public class QServer
 
 }
 
-   
+


### PR DESCRIPTION
1. Added support of adding server config event listeners via server
   config.
2. Added element to supprt sending of server intiated request to be sent
   to all connected channels or send it to last connected channel via
   default behavior for backwards compatibility.
   e.g. <server-connection-listener class="com.ols.xxx.Test"/>
   Test class needs to implement the ISOServerEventsListener interface.
