### PR TITLE
Continue logging if log rotation fails.

### DIFF
--- a/jpos/src/test/java/org/jpos/util/LogFileTestUtils.java
+++ b/jpos/src/test/java/org/jpos/util/LogFileTestUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2003 - 2013 Tyro Payments Limited.
+ * 125 York St, Sydney NSW 2000.
+ * All rights reserved.
+ */
+package org.jpos.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Scanner;
+import java.util.zip.GZIPInputStream;
+
+public class LogFileTestUtils {
+    public static String getStringFromCompressedFile(File file) throws IOException {
+        GZIPInputStream in = new GZIPInputStream(new FileInputStream(file));
+        try {
+            return getStringFromInputStream(in);
+        } finally {
+            in.close();
+        }
+    }
+
+    public static String getStringFromFile(File file) throws IOException {
+        FileInputStream in = new FileInputStream(file);
+        try {
+            return getStringFromInputStream(in);
+        } finally {
+            in.close();
+        }
+    }
+
+    public static String getStringFromInputStream(InputStream inStream) {
+       Scanner in = new Scanner(inStream);
+       StringBuilder logFileContentsBuilder = new StringBuilder();
+       while (in.hasNextLine()) {
+           logFileContentsBuilder.append(in.nextLine()).append('\n');
+       }
+       in.close();
+       return logFileContentsBuilder.toString();
+   }
+}

--- a/jpos/src/test/java/org/jpos/util/LogRotationTestDirectory.java
+++ b/jpos/src/test/java/org/jpos/util/LogRotationTestDirectory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2003 - 2013 Tyro Payments Limited.
+ * 125 York St, Sydney NSW 2000.
+ * All rights reserved.
+ */
+package org.jpos.util;
+
+import java.io.File;
+
+public class LogRotationTestDirectory {
+
+    private File directory;
+
+    public LogRotationTestDirectory() {
+    }
+
+    public synchronized File getDirectory() {
+        if (directory == null) {
+            directory = new File(System.getProperty("java.io.tmpdir"), "jposLogRotationTestDir");
+            directory.mkdirs();
+        }
+        return directory;
+    }
+
+    public File getFile(String filename) {
+        return new File(getDirectory(), filename);
+    }
+
+    public void preventNewFileCreation() {
+        getDirectory().setExecutable(false);
+    }
+
+    public void allowNewFileCreation() {
+        getDirectory().setExecutable(true);
+    }
+
+    public synchronized void delete() {
+        if (directory != null) {
+            for (File log : directory.listFiles()) {
+                System.err.println("Deleting " + log);
+                log.deleteOnExit();
+                log.delete();
+            }
+
+            directory.delete();
+        }
+    }
+}


### PR DESCRIPTION
We discovered that if the user executing a jPOS applications runs out of file handles then jPOS stops logging the next time the log tries to roll. It's a bit of a disaster scenario, but it's the kind of scenario where continuing to log is really really useful.

I've changed logRotate() in DailyLogListener and RotateLogListener so that they try to create a new file _before_ closing the current one, and to continue logging to the current file if rotation fails.

**I haven't tested this on Windows at all.** (Would have tried, but I don't have a Windows dev setup.)

I'm pretty sure the tests won't work because I simulate the 'out of file handles' condition by making the parent directory of the log files not-executable, which stops Linux changing the directory file. So I think someone will need to provide a Windows-based implementation of preventNewFileCreation() and allowNewFileCreation() in LogRotationTestDirectory and switch based on some System property that reveals the platform.

The implementation _may_ work on Windows or may not - it depends on the ability of the OS to continue appending to an open file handle even after the file has been renamed. Not sure if Windows supports this or not. I imagine it could also cause issues if anyone is writing their log files to a location that's not local storage.
