### PR TITLE
Retry when archive.timestamp is set to true

### DIFF
--- a/jpos/src/main/java/org/jpos/util/DirPoll.java
+++ b/jpos/src/main/java/org/jpos/util/DirPoll.java
@@ -429,7 +429,7 @@ public class DirPoll extends SimpleLogSource
                     if ((e instanceof DirPollException && ((DirPollException)e).isRetry())) {
                         ISOUtil.sleep(pollInterval*10); // retry delay (pollInterval defaults to 100ms)
                         evt.addMessage("retrying");
-                        store(request, requestDir);
+                        moveTo(request, requestDir);
                     } else {
                         store(request, badDir);
                     }


### PR DESCRIPTION
If archive.timestamp is set to true, then retries do not work since the filename is suffixed with .timestamp and then the priority filter excludes this file.

Now moving it directly to the request dir - this can throw an error if there is already a file with the same name in run dir which is very unlikely
