### PR TITLE
Avoid unpacking fields not required in requests

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/packager/GenericSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericSubFieldPackager.java
@@ -75,7 +75,7 @@ public class GenericSubFieldPackager extends GenericPackager
             {
                 if (bmap == null || bmap.get(i)) 
                 {
-                    if (fld[i] != null) {
+                    if (i<fld.length && fld[i] != null) {
                         ISOComponent c = fld[i].createComponent(i);
                         consumed += fld[i].unpack (c, b, consumed);
                         m.set(c);


### PR DESCRIPTION
if bitmap indicates presence of field that we are not interested in , we should be able to not define them in the packager and the presence of them should not throw an exception (ArrayOutofbound) as the isofield (packagers) are not defined.
