### PR TITLE
If a mux is not connected, the mod makes a message go through the follow...

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/iso/MUXPool.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/MUXPool.java
@@ -102,7 +102,7 @@ public class MUXPool extends QBeanSupport implements MUX {
                 int j = (mnumber+i) % mux.length;
                 if (mux[j].isConnected())
                     return mux[j];
-                msgno.set(msgno.incrementAndGet());
+                msgno.incrementAndGet();
             }
             ISOUtil.sleep (1000);
         } while (System.currentTimeMillis() < maxWait);


### PR DESCRIPTION
...ing connected mux twice.

I have a bunch of muxes in my mux pool. 

``` xml
<mux class="org.jpos.q2.iso.MUXPool" logger="Q2" name="xyz-mux">
 <muxes>xyz1-mux xyz2-mux xyz3-mux xyz4-mux</muxes>
 <strategy>round-robin</strategy>
</mux>
```

xyz1-mux is not connected. Say messages 1 needs to be sent, the mod check picks up xyz1 but its not connected so sends it through xyz2. Message 2 satisfies the mod check and sends it through 2 again.
me
