### PR TITLE
Clean shutdown of DirPoll when file processing is in progress

### DIFF
--- a/jpos/src/test/java/org/jpos/q2/iso/DirPollAdaptorTest.java
+++ b/jpos/src/test/java/org/jpos/q2/iso/DirPollAdaptorTest.java
@@ -203,8 +203,11 @@ public class DirPollAdaptorTest {
     @Test
     public void testStartService() throws Throwable {
         DirPollAdaptor dirPollAdaptor = new DirPollAdaptor();
-        dirPollAdaptor.startService();
-        assertNull("dirPollAdaptor.dirPoll", dirPollAdaptor.dirPoll);
+        try {
+            dirPollAdaptor.startService();
+        } catch (IllegalStateException e) {
+            assertNull("dirPollAdaptor.dirPoll", dirPollAdaptor.dirPoll);
+        }
     }
 
     @Test


### PR DESCRIPTION
DirPollAdaptor does not wait for the dirPoll thread to finish during shutdown. This can cause a dirty shutdown if the dirPoll thread were in the midst of processing a file. 
This change makes the shutdown wait for the dirPoll thread to exit in a graceful manner to good extent and then interrupts the thread if still running
