### PR TITLE
Allow schema to pass in hex separator value.

### DIFF
--- a/jpos/src/main/java/org/jpos/util/FSDMsg.java
+++ b/jpos/src/main/java/org/jpos/util/FSDMsg.java
@@ -306,7 +306,7 @@ public class FSDMsg implements Loggeable, Cloneable {
             return true;
         else if (isDummySeparator (separator))
             return true;
-        else if (Long.parseLong(separator,16)>0 && Long.parseLong(separator,16)<256) {
+        else if (Character.isDefined(Integer.parseInt(separator,16))) {
             setSeparator(separator, (char)Long.parseLong(separator,16));
             return true;
         }


### PR DESCRIPTION
By doing this we can pass in any field separator instead of using a restricted set or having to extend the class.
So say I need to generate a csv file, I can have each line details configured as 

``` xml
<Schema>
    <field id="prod-description" type="A" separator="2C" length="50" /><!--0x2c is a comma-->
    <field id="currency-code" type="A"  separator="2C"  length="20"/>
    <field id="upc" type="A"  separator="2C"  length="20" />
    <field id="request-type" type="A" separator="DS"  length="20" />
</Schema>
```

This will output 
prodDescription,currencyCode,upc,itc.

Packing and unpacking seems to work in my local tests.
