### PR TITLE
Allow schema attribute separator to use in new separators

### DIFF
--- a/jpos/src/main/java/org/jpos/util/FSDMsg.java
+++ b/jpos/src/main/java/org/jpos/util/FSDMsg.java
@@ -306,6 +306,10 @@ public class FSDMsg implements Loggeable, Cloneable {
             return true;
         else if (isDummySeparator (separator))
             return true;
+        else if (Character.isDefined(Integer.parseInt(separator,16))) {
+            	setSeparator(separator, (char)Long.parseLong(separator,16));
+            	return true;
+        	}          
         else
             throw new RuntimeException("FSDMsg.isSeparated(String) found that "+
                     separator+" has not been defined as a separator!");


### PR DESCRIPTION
The schema could take in standard field separators defined in FSDMsg. In order to use new separators one would have to extend FSDMsg.
By allowing the separator attribute to pass in a hex value of a field separator we can use the existing FSDMsg more generically.
I needed to create extract file in CSV format.

``` xml

<Schema>
    <field id="prod-description" type="A" separator="2C" length="50" />
    <field id="currency-code" type="A"  separator="2C"  length="20"/>
    <field id="upc" type="A"  separator="2C"  length="20" />
    <field id="request-type" type="A" separator="DS"  length="20" />
</Schema>
```

This allows the fields to be terminated by a comma (0x2c).

Packing and unpacking works for my tests.
