### PR TITLE
Pin mailer api

### DIFF
--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -59,19 +59,23 @@ public class BaseSMAdapter
         setConfiguration(cfg);
     }
 
+    @Override
     public void setConfiguration (Configuration cfg) throws ConfigurationException {
         this.cfg = cfg;
     }
 
+    @Override
     public void setLogger (Logger logger, String realm) {
         this.logger = logger;
         this.realm = realm;
     }
 
+    @Override
     public Logger getLogger () {
         return  logger;
     }
 
+    @Override
     public String getRealm () {
         return  realm;
     }
@@ -103,6 +107,7 @@ public class BaseSMAdapter
         return  (SMAdapter)NameRegistrar.get("s-m-adapter." + name);
     }
 
+    @Override
     public SecureDESKey generateKey (short keyLength, String keyType) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "Key Length", keyLength), new SimpleMsg("parameter",
@@ -123,7 +128,7 @@ public class BaseSMAdapter
         return  result;
     }
 
-
+    @Override
     public byte[] generateKeyCheckValue (SecureDESKey kd) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "Key with untrusted check value", kd)
@@ -143,6 +148,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public SecureDESKey importKey (short keyLength, String keyType, byte[] encryptedKey,
             SecureDESKey kek, boolean checkParity) throws SMException {
         SimpleMsg[] cmdParameters =  {
@@ -165,6 +171,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public byte[] exportKey (SecureDESKey key, SecureDESKey kek) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "Key", key), new SimpleMsg("parameter", "Key-Encrypting Key",
@@ -185,6 +192,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public EncryptedPIN encryptPIN (String pin, String accountNumber, boolean extract) throws SMException {
         accountNumber = extract ? EncryptedPIN.extractAccountNumberPart(accountNumber) : accountNumber;
         SimpleMsg[] cmdParameters =  {
@@ -205,10 +213,12 @@ public class BaseSMAdapter
         }
         return  result;
     }
+    @Override
     public EncryptedPIN encryptPIN (String pin, String accountNumber) throws SMException {
         return encryptPIN(pin, accountNumber, true);
     }
 
+    @Override
     public String decryptPIN (EncryptedPIN pinUnderLmk) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "PIN under LMK", pinUnderLmk),
@@ -228,6 +238,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public EncryptedPIN importPIN (EncryptedPIN pinUnderKd1, SecureDESKey kd1) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "PIN under Data Key 1", pinUnderKd1), new SimpleMsg("parameter",
@@ -248,6 +259,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public EncryptedPIN translatePIN (EncryptedPIN pinUnderKd1, SecureDESKey kd1,
             SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
         SimpleMsg[] cmdParameters =  {
@@ -271,6 +283,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public EncryptedPIN importPIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
             SecureDESKey bdk) throws SMException {
         SimpleMsg[] cmdParameters =  {
@@ -293,6 +306,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public EncryptedPIN translatePIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
             SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
         SimpleMsg[] cmdParameters =  {
@@ -316,6 +330,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public EncryptedPIN exportPIN (EncryptedPIN pinUnderLmk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "PIN under LMK", pinUnderLmk), new SimpleMsg("parameter",
@@ -337,11 +352,13 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public EncryptedPIN generatePIN(String accountNumber, int pinLen)
             throws SMException {
       return generatePIN(accountNumber, pinLen, null);
     }
 
+    @Override
     public EncryptedPIN generatePIN(String accountNumber, int pinLen, List<String> excludes)
             throws SMException {
       List<Loggeable> cmdParameters = new ArrayList<Loggeable>();
@@ -389,11 +406,13 @@ public class BaseSMAdapter
       }
     }
 
+    @Override
     public String calculatePVV(EncryptedPIN pinUnderLMK, SecureDESKey pvkA,
                                SecureDESKey pvkB, int pvkIdx) throws SMException {
       return calculatePVV(pinUnderLMK, pvkA, pvkB, pvkIdx, null);
     }
 
+    @Override
     public String calculatePVV(EncryptedPIN pinUnderLMK, SecureDESKey pvkA,
                                SecureDESKey pvkB, int pvkIdx,
                                List<String> excludes) throws SMException {
@@ -420,12 +439,14 @@ public class BaseSMAdapter
       return result;
     }
 
+    @Override
     public String calculatePVV(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
                                SecureDESKey pvkA, SecureDESKey pvkB, int pvkIdx)
             throws SMException {
       return calculatePVV(pinUnderKd1, kd1, pvkA, pvkB, pvkIdx, null);
     }
 
+    @Override
     public String calculatePVV(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
                                SecureDESKey pvkA, SecureDESKey pvkB, int pvkIdx,
                                List<String> excludes) throws SMException {
@@ -453,6 +474,7 @@ public class BaseSMAdapter
       return result;
     }
 
+    @Override
     public boolean verifyPVV(EncryptedPIN pinUnderKd1, SecureDESKey kd1, SecureDESKey pvkA,
                           SecureDESKey pvkB, int pvki, String pvv) throws SMException {
 
@@ -480,12 +502,14 @@ public class BaseSMAdapter
       }
     }
 
+    @Override
     public String calculateIBMPINOffset(EncryptedPIN pinUnderLmk, SecureDESKey pvk,
                            String decTab, String pinValData, int minPinLen)
             throws SMException {
       return calculateIBMPINOffset(pinUnderLmk, pvk, decTab, pinValData, minPinLen, null);
     }
 
+    @Override
     public String calculateIBMPINOffset(EncryptedPIN pinUnderLmk, SecureDESKey pvk,
                            String decTab, String pinValData, int minPinLen,
                            List<String> excludes) throws SMException {
@@ -514,6 +538,7 @@ public class BaseSMAdapter
       return result;
     }
 
+    @Override
     public String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
                            SecureDESKey pvk, String decTab, String pinValData, int minPinLen)
             throws SMException {
@@ -521,6 +546,7 @@ public class BaseSMAdapter
               pinValData, minPinLen, null);
     }
 
+    @Override
     public String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
                            SecureDESKey pvk, String decTab, String pinValData, int minPinLen,
                            List<String> excludes) throws SMException {
@@ -550,6 +576,7 @@ public class BaseSMAdapter
       return result;
     }
 
+    @Override
     public boolean verifyIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1, SecureDESKey pvk,
                                       String offset, String decTab, String pinValData,
                                       int minPinLen) throws SMException {
@@ -580,6 +607,7 @@ public class BaseSMAdapter
       }
     }
 
+    @Override
     public EncryptedPIN deriveIBMPIN(String accountNo, SecureDESKey pvk,
                                      String decTab, String pinValData,
                                      int minPinLen, String offset) throws SMException {
@@ -606,6 +634,7 @@ public class BaseSMAdapter
       return result;
     }
 
+    @Override
     public String calculateCVV(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
                                Date expDate, String serviceCode) throws SMException {
 
@@ -631,6 +660,7 @@ public class BaseSMAdapter
       return result;
     }
 
+    @Override
     public boolean verifyCVV(String accountNo , SecureDESKey cvkA, SecureDESKey cvkB,
                             String cvv, Date expDate, String serviceCode) throws SMException {
 
@@ -656,6 +686,7 @@ public class BaseSMAdapter
       }
     }
 
+    @Override
     public boolean verifydCVV(String accountNo, SecureDESKey imkac, String dcvv,
                      Date expDate, String serviceCode, byte[] atc, MKDMethod mkdm)
                      throws SMException {
@@ -698,6 +729,7 @@ public class BaseSMAdapter
      * @return
      * @throws SMException
      */
+    @Override
     public boolean verifyCVC3(SecureDESKey imkcvc3, String accountNo, String acctSeqNo,
                      byte[] atc, byte[] upn, byte[] data, MKDMethod mkdm, String cvc3)
                      throws SMException {
@@ -726,6 +758,7 @@ public class BaseSMAdapter
       }
     }
 
+    @Override
     public boolean verifyARQC(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc
             ,byte[] upn, byte[] transData) throws SMException {
@@ -755,6 +788,7 @@ public class BaseSMAdapter
       }
     }
 
+    @Override
     public byte[] generateARPC(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
@@ -789,6 +823,7 @@ public class BaseSMAdapter
       }
     }
 
+    @Override
     public byte[] verifyARQCGenerateARPC(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,byte[] transData, ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
@@ -824,6 +859,7 @@ public class BaseSMAdapter
       }
     }
 
+    @Override
     public byte[] generateSM_MAC(MKDMethod mkdm, SKDMethod skdm
             ,SecureDESKey imksmi, String accountNo, String acctSeqNo
             ,byte[] atc, byte[] arqc, byte[] data) throws SMException {
@@ -852,6 +888,7 @@ public class BaseSMAdapter
       }
     }
 
+    @Override
     public Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MAC(MKDMethod mkdm
            ,SKDMethod skdm, PaddingMethod padm, SecureDESKey imksmi
            ,String accountNo, String acctSeqNo, byte[] atc, byte[] arqc
@@ -898,6 +935,7 @@ public class BaseSMAdapter
       }
     }
 
+    @Override
     public byte[] generateCBC_MAC (byte[] data, SecureDESKey kd) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "data", data), new SimpleMsg("parameter", "data key",
@@ -918,6 +956,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public byte[] generateEDE_MAC (byte[] data, SecureDESKey kd) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "data", data), new SimpleMsg("parameter", "data key",
@@ -938,6 +977,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public SecureDESKey translateKeyFromOldLMK (SecureDESKey kd) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "Key under old LMK", kd)
@@ -957,6 +997,7 @@ public class BaseSMAdapter
         return  result;
     }
 
+    @Override
     public void eraseOldLMK () throws SMException {
         SimpleMsg[] cmdParameters =  {
         };

--- a/jpos/src/main/java/org/jpos/security/SMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/SMAdapter.java
@@ -207,7 +207,7 @@ public interface SMAdapter {
 
     /**
      * Proprietary PIN Block format.
-     *
+     * <p>
      * Most Security Modules use a proprietary PIN Block format
      * when encrypting the PIN under the LMK of the Security Module
      * hence this format (FORMAT00).
@@ -236,7 +236,8 @@ public interface SMAdapter {
 
 
     /**
-     * Generates key check value.<br>
+     * Generates key check value.
+     *
      * @param kd SecureDESKey with untrusted or fake Key Check Value
      * @return key check value bytes
      * @throws SMException
@@ -274,7 +275,7 @@ public interface SMAdapter {
     /**
      * Encrypts a clear pin under LMK.
      *
-     * CAUTION: The use of clear pin presents a significant security risk
+     * <p>CAUTION: The use of clear pin presents a significant security risk
      * @param pin clear pin as entered by card holder
      * @param accountNumber account number, including BIN and the check digit
      * @return PIN under LMK
@@ -285,7 +286,7 @@ public interface SMAdapter {
     /**
      * Encrypts a clear pin under LMK.
      *
-     * CAUTION: The use of clear pin presents a significant security risk
+     * <p>CAUTION: The use of clear pin presents a significant security risk
      * @param pin clear pin as entered by card holder
      * @param accountNumber if <code>extract</code> is false then account number, including BIN and the check digit
      *        or if parameter <code>extract</code> is true then 12 right-most digits of the account number, excluding the check digit
@@ -297,7 +298,7 @@ public interface SMAdapter {
 
     /**
      * Decrypts an Encrypted PIN (under LMK).
-     * CAUTION: The use of clear pin presents a significant security risk
+     * <p>CAUTION: The use of clear pin presents a significant security risk
      * @param pinUnderLmk
      * @return clear pin as entered by card holder
      * @throws SMException
@@ -336,7 +337,7 @@ public interface SMAdapter {
      * Imports a PIN from encryption under a transaction key to encryption
      * under LMK.
      *
-     * The transaction key is derived from the Key Serial Number and the Base Derivation Key using DUKPT (Derived Unique Key per Transaction). See ANSI X9.24 for more information.
+     * <p>The transaction key is derived from the Key Serial Number and the Base Derivation Key using DUKPT (Derived Unique Key per Transaction). See ANSI X9.24 for more information.
      * @param pinUnderDuk pin encrypted under a transaction key
      * @param ksn Key Serial Number (also called Key Name, in ANSI X9.24) needed to derive the transaction key
      * @param bdk Base Derivation Key, used to derive the transaction key underwhich the pin is encrypted
@@ -352,7 +353,7 @@ public interface SMAdapter {
      * Translates a PIN from encryption under a transaction key to
      * encryption under a KD (Data Key).
      *
-     * The transaction key is derived from the Key Serial Number and the Base Derivation Key using DUKPT (Derived Unique Key per Transaction). See ANSI X9.24 for more information.
+     * <p>The transaction key is derived from the Key Serial Number and the Base Derivation Key using DUKPT (Derived Unique Key per Transaction). See ANSI X9.24 for more information.
      * @param pinUnderDuk pin encrypted under a DUKPT transaction key
      * @param ksn Key Serial Number (also called Key Name, in ANSI X9.24) needed to derive the transaction key
      * @param bdk Base Derivation Key, used to derive the transaction key underwhich the pin is encrypted
@@ -435,7 +436,7 @@ public interface SMAdapter {
      * Calculate PVV (VISA PIN Verification Value of PIN under LMK)
      * with exclude list
      *
-     * NOTE: {@code pvkA} and {@code pvkB} should be single length keys
+     * <p>NOTE: {@code pvkA} and {@code pvkB} should be single length keys
      * but at least one of them may be double length key
      *
      * @param pinUnderLmk PIN under LMK
@@ -453,7 +454,7 @@ public interface SMAdapter {
     /**
      * Calculate PVV (VISA PIN Verification Value of PIN under LMK)
      *
-     * NOTE: {@code pvkA} and {@code pvkB} should be single length keys
+     * <p>NOTE: {@code pvkA} and {@code pvkB} should be single length keys
      * but at least one of them may be double length key
      *
      * @param pinUnderLmk PIN under LMK
@@ -474,7 +475,7 @@ public interface SMAdapter {
     /**
      * Calculate PVV (VISA PIN Verification Value of customer selected PIN)
      *
-     * NOTE: {@code pvkA} and {@code pvkB} should be single length keys
+     * <p>NOTE: {@code pvkA} and {@code pvkB} should be single length keys
      * but at least one of them may be double length key
      *
      * @param pinUnderKd1 the encrypted PIN
@@ -494,7 +495,7 @@ public interface SMAdapter {
     /**
      * Calculate PVV (VISA PIN Verification Value of customer selected PIN)
      *
-     * NOTE: {@code pvkA} and {@code pvkB} should be single length keys
+     * <p>NOTE: {@code pvkA} and {@code pvkB} should be single length keys
      * but at least one of them may be double length key
      *
      * @param pinUnderKd1 the encrypted PIN
@@ -517,7 +518,7 @@ public interface SMAdapter {
     /**
      * Verify PVV (VISA PIN Verification Value of an LMK encrypted PIN)
      *
-     * NOTE: {@code pvkA} and {@code pvkB} should be single
+     * <p>NOTE: {@code pvkA} and {@code pvkB} should be single
      * length keys but at least one of them may be double length key
      *
      * @param pinUnderKd1 pin block under {@code kd1}
@@ -537,7 +538,7 @@ public interface SMAdapter {
     /**
      * Calculate an PIN Offset using the IBM 3624 method
      *
-     * Using that method is not recomendated. PVV method is prefrred,
+     * <p>Using that method is not recomendated. PVV method is prefrred,
      * but it may be need in some legacy systms
      * @param pinUnderLmk PIN under LMK
      * @param pvk        accepts single, double, triple size key length.
@@ -561,7 +562,7 @@ public interface SMAdapter {
     /**
      * Calculate an PIN Offset using the IBM 3624 method
      *
-     * Using that method is not recomendated. PVV method is prefrred,
+     * <p>Using that method is not recomendated. PVV method is prefrred,
      * but it may be need in some legacy systms
      * @param pinUnderLmk PIN under LMK
      * @param pvk        accepts single, double, triple size key length.
@@ -588,7 +589,7 @@ public interface SMAdapter {
     /**
      * Calculate an PIN Offset using the IBM 3624 method of customer selected PIN
      *
-     * Using that method is not recomendated. PVV method is prefrred,
+     * <p>Using that method is not recomendated. PVV method is prefrred,
      * but it may be need in some legacy systms
      * @param pinUnderKd1 the encrypted PIN
      * @param kd1 Data Key under which the pin is encrypted
@@ -604,7 +605,7 @@ public interface SMAdapter {
      * @return IBM PIN Offset
      * @throws SMException
      */
-    public String calculateIBMPINOffset(EncryptedPIN pinUnderkd1, SecureDESKey kd1,
+    public String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
                           SecureDESKey pvk, String decTab, String pinValData,
                           int minPinLen) throws SMException;
 
@@ -613,7 +614,7 @@ public interface SMAdapter {
     /**
      * Calculate an PIN Offset using the IBM 3624 method of customer selected PIN
      *
-     * Using that method is not recomendated. PVV method is prefrred,
+     * <p>Using that method is not recomendated. PVV method is prefrred,
      * but it may be need in some legacy systms
      * @param pinUnderKd1 the encrypted PIN
      * @param kd1 Data Key under which the pin is encrypted
@@ -632,7 +633,7 @@ public interface SMAdapter {
      * @throws WeakPINException if passed PIN is on {@code excludes} list
      * @throws SMException
      */
-    public String calculateIBMPINOffset(EncryptedPIN pinUnderkd1, SecureDESKey kd1,
+    public String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
                           SecureDESKey pvk, String decTab, String pinValData,
                           int minPinLen, List<String> excludes) throws SMException;
 
@@ -665,7 +666,7 @@ public interface SMAdapter {
     /**
      * Derive a PIN Using the IBM 3624 method
      *
-     * That method derive pin from pin offset (not exacly that same but working).
+     * <p>That method derive pin from pin offset (not exacly that same but working).
      * Therefore that metod is not recomendated. It is similar to obtain pin
      * from encrypted pinblock, but require (encrypted) decimalisation table
      * handling is more complicated and returned pin may differ from pin what user has selected 
@@ -693,7 +694,7 @@ public interface SMAdapter {
     /**
      * Calaculate a Card Verification Code/Value
      *
-     * NOTE: {@code cvkA} and {@code cvkB} should be single
+     * <p>NOTE: {@code cvkA} and {@code cvkB} should be single
      * length keys but at least one of them may be double length key
      *
      * @param accountNo The account number including BIN and the check digit
@@ -718,7 +719,7 @@ public interface SMAdapter {
     /**
      * Verify a Card Verification Code/Value
      *
-     * NOTE: {@code cvkA} and {@code cvkB} should be single
+     * <p>NOTE: {@code cvkA} and {@code cvkB} should be single
      * length keys but at least one of them may be double length key
      *
      * @param accountNo The account number including BIN and the check digit
@@ -744,7 +745,7 @@ public interface SMAdapter {
     /**
      * Verify a Dynamic Card Verification Value (CVV)
      *
-     * The EMV "Track 2 Equivalent Data", provided in the authorisation
+     * <p>The EMV "Track 2 Equivalent Data", provided in the authorisation
      * message and originating from the contactless smart card, is the source
      * for the following data elements used in this function:
      * <li> {@code accountNo}
@@ -822,10 +823,11 @@ public interface SMAdapter {
 
     /**
      * Verify Application Cryptogram (ARQC or TC/AAC)
-     * <br>
+     * <ul>
      * <li>Authorization Request Cryptogram (ARQC) - Online authorization
      * <li>Transaction certificate (TC) - Offline approval
      * <li>Application Authentication Cryptogram (AAC) - Offline decline
+     * </ul>
      *
      * @param mkdm ICC Master Key Derivation Method. For {@code skdm} equals
      *        {@link SKDMethod#VSDC} and {@link SKDMethod#MCHIP} this parameter
@@ -894,11 +896,11 @@ public interface SMAdapter {
     /**
      * Verify Application Cryptogram (ARQC or TC/AAC) and Genarate
      * Authorisation Response Cryptogram (ARPC)
-     * <br>
+     * <ul>
      * <li>Authorization Request Cryptogram (ARQC) - Online authorization
      * <li>Transaction certificate (TC) - Offline approval
      * <li>Application Authentication Cryptogram (AAC) - Offline decline
-     *
+     * </ul>
      * @param mkdm ICC Master Key Derivation Method. For {@code skdm} equals
      *        {@link SKDMethod#VSDC} and {@link SKDMethod#MCHIP} this parameter
      *        is ignored and {@link MKDMethod#OPTION_A} is always used.
@@ -939,7 +941,7 @@ public interface SMAdapter {
 
     /**
      * Generate Secure Message MAC over suppiled message data
-     * <br/>
+     * <p>
      * This method is used by issuer to generate MAC over message data send
      * from the issuer back to the card
      *
@@ -972,15 +974,16 @@ public interface SMAdapter {
 
     /**
      * Translate PIN and generate MAC over suppiled message data
-     * <br/>
+     * <p>
      * This method is used by issuer to:
+     * <ul>
      * <li>translate standard ATM PIN block format encrypted under zone
      * or terminal key {@code kd1} to an application specific PIN block
      * format, encrypted under a confidentiality session key, derived from
      * {@code imksmc}
      * <li>generate MAC over suppiled message {@code data} and translated
      * PIN block
-     *
+     * </ul>
      * @param mkdm ICC Master Key Derivation Method. For {@code skdm} equals
      *        {@link SKDMethod#VSDC} and {@link SKDMethod#MCHIP} this parameter
      *        is ignored and {@link MKDMethod#OPTION_A} is always used.


### PR DESCRIPTION
Add generic Print PIN and solicitation data API
new printPIN method should give ability to print pin through most known HSM's. Especially on Thales
It enable print pin from passed encrypted PIN block or under internal LMK encryption. Also it's able to pass template of printed document and solicitation data.
Format of template is dependent on used HSM. It should include placeholders to indicate position of PIN and solicitation data. This solicitation data are passed as Map of key and value. Key are included in template as eg. ${pin}, ${postal-code}, but format of this placeholders is also dependendent on implementation of SMAdapter for particular HSM type
