### PR TITLE
Replace TransactionManager thread management with thread pool

### DIFF
--- a/jpos/src/test/java/org/jpos/transaction/TransactionManagerTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/TransactionManagerTest.java
@@ -578,7 +578,6 @@ public class TransactionManagerTest {
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
             assertNull("ex.getMessage()", ex.getMessage());
-            assertNull("transactionManager.threads", transactionManager.threads);
             assertNull("transactionManager.getConfiguration()", transactionManager.getConfiguration());
             assertEquals("transactionManager.tail", 0L, transactionManager.tail);
             assertNull("transactionManager.psp", transactionManager.psp);
@@ -595,7 +594,6 @@ public class TransactionManagerTest {
         } catch (NullPointerException ex) {
             assertNull("ex.getMessage()", ex.getMessage());
             assertNull("transactionManager.psp", transactionManager.psp);
-            assertNull("transactionManager.threads", transactionManager.threads);
             assertNull("transactionManager.getConfiguration()", transactionManager.getConfiguration());
             assertEquals("transactionManager.tail", 0L, transactionManager.tail);
             assertNull("transactionManager.groups", transactionManager.groups);


### PR DESCRIPTION
Please read commits descriptions
It is for review and discuss here.

ISSUES:
 1 A bit unclear configuration of queuing methods (backward capability)
 2 Input space has to be LocalSpace to register listener
 3 Removed 'hack' to stop thread with Boolean.FALSE
 4 Removed checking pool size and resheduling task in future
