### PR TITLE
Add space to error message to make more readable.

### DIFF
--- a/jpos/src/main/java/org/jpos/util/DirPoll.java
+++ b/jpos/src/main/java/org/jpos/util/DirPoll.java
@@ -334,7 +334,7 @@ public class DirPoll extends SimpleLogSource
     private File moveTo(File f, File dir) throws IOException {
         File destination = new File(dir, f.getName());
         if (!f.renameTo(destination))
-            throw new IOException("Unable to move"+f.getName());
+            throw new IOException("Unable to move "+f.getName());
         return destination;
     }
 


### PR DESCRIPTION
<exception name="Unable to movefile.txt">
to
<exception name="Unable to move: file.txt">
