### PR TITLE
Use default logger when no log source logger or listeners

### DIFF
--- a/jpos/src/main/java/org/jpos/util/Logger.java
+++ b/jpos/src/main/java/org/jpos/util/Logger.java
@@ -82,7 +82,7 @@ public class Logger implements LogProducer {
         }
         if (source != null)
             l = source.getLogger();
-        if (l == null || !l.hasListeners ()) {
+        if (l == null) {
             l = getLogger(Q2.LOGGER_NAME);
         }
         if (l != null && l.hasListeners ()) {


### PR DESCRIPTION
If a log event is created using the LogEvent (tag:String) constructor, the Logger.log(evt) does not log anything. 
This change will use the default logger when no log source logger or listeners
