### PR TITLE
Allow faster shutdown of dir polls

### DIFF
--- a/jpos/src/main/java/org/jpos/util/DirPoll.java
+++ b/jpos/src/main/java/org/jpos/util/DirPoll.java
@@ -42,7 +42,7 @@ import java.util.Vector;
  * scanning for incoming requests (of varying priorities)
  * on the request directory and processing them by means of
  * DirPoll.Processor or DirPoll.FileProcessor
- *
+ * 
  * @author <a href="mailto:apr@cs.com.uy">Alejandro P. Revilla</a>
  * @author <a href="mailto:mmilliss@moneyswitch.net">Matthew Milliss</a>
  * @since jPOS 1.2.7
@@ -233,7 +233,7 @@ public class DirPoll extends SimpleLogSource
     //--------------------------------------- FilenameFilter implementation
     public boolean accept(File dir, String name) {
         boolean result;
-        String ext = currentPriority >= 0 ?
+        String ext = currentPriority >= 0 ? 
             ((String) prio.elementAt(currentPriority)) : null;
         if (ext != null) {
             if (isRegexPriorityMatching()) {
@@ -254,7 +254,7 @@ public class DirPoll extends SimpleLogSource
     }
     //--------------------------------------------- Runnable implementation
 
-    public void run() {
+    public void run() { 
         Thread.currentThread().setName ("DirPoll-"+basePath);
         if (prio.isEmpty())
             addPriority("");
@@ -327,7 +327,7 @@ public class DirPoll extends SimpleLogSource
         in.close();
         return b;
     }
-    private void writeResponse (String requestName, byte[] b)
+    private void writeResponse (String requestName, byte[] b) 
         throws IOException
     {
         if (responseSuffix != null) {
@@ -366,7 +366,7 @@ public class DirPoll extends SimpleLogSource
     }
 
     protected File scan() {
-        for (currentPriority=0;
+        for (currentPriority=0; 
             currentPriority < prio.size(); currentPriority++)
         {
             String files[] = requestDir.list(this);
@@ -389,7 +389,7 @@ public class DirPoll extends SimpleLogSource
          * @param request request image
          * @return response (or null)
          */
-        public byte[] process(String name, byte[] request)
+        public byte[] process(String name, byte[] request) 
             throws DirPollException;
     }
     public interface FileProcessor {
@@ -407,21 +407,21 @@ public class DirPoll extends SimpleLogSource
             this.logEvent = null;
         }
         public void run() {
-            LogEvent evt =
+            LogEvent evt = 
                 new LogEvent (
                     DirPoll.this, "dirpoll", request.getName()
                 );
             try {
-                if (processor == null)
-                    throw new DirPollException
+                if (processor == null) 
+                    throw new DirPollException 
                         ("null processor - nothing to do");
                 else if (processor instanceof Processor) {
                     byte[] resp = ((Processor) processor).process (
                         request.getName(), readRequest (request)
                     );
-                    if (resp != null)
+                    if (resp != null) 
                         writeResponse (request.getName(), resp);
-                } else if (processor instanceof FileProcessor)
+                } else if (processor instanceof FileProcessor) 
                     ((FileProcessor) processor).process (request);
 
                 if (shouldArchive) {
@@ -431,8 +431,8 @@ public class DirPoll extends SimpleLogSource
                     }
                 } else {
                     if (!request.delete ())
-                        throw new DirPollException
-                            ("error: can't unlink request " + request.getName());
+                        throw new DirPollException 
+                            ("error: can't unlink request " + request.getName());                    
                 }
 
             } catch (Throwable e) {
@@ -458,7 +458,7 @@ public class DirPoll extends SimpleLogSource
                     evt.addMessage (_e);
                 }
             } finally {
-                if (logEvent != null)
+                if (logEvent != null) 
                     Logger.log (logEvent);
             }
         }
@@ -484,7 +484,7 @@ public class DirPoll extends SimpleLogSource
             this.retry = retry;
         }
     }
-
+    
     public void pause() {
         synchronized (this) {
             if (!paused) {
@@ -505,7 +505,7 @@ public class DirPoll extends SimpleLogSource
             }
         }
     }
-
+    
     public boolean isPaused() {
         synchronized (this) {
             return paused;


### PR DESCRIPTION
Currently, if there are multiple dir polls deployed, Q2 shutdown takes upto 60 seconds for each of them to shutdown. With 4 dir polls deployed, the typical time for a shutdown is > 4 mins. This change makes the shutdown much faster.
