### PR TITLE
Standalone BItMap - for LIS5, but perhaps portable?

### DIFF
--- a/jpos/src/dist/cfg/packager/LIS.xml
+++ b/jpos/src/dist/cfg/packager/LIS.xml
@@ -1,0 +1,847 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE isopackager SYSTEM "genericpackager.dtd">
+
+<!-- LIS's field descriptions for GenericPackager -->
+
+<isopackager>
+    <isofield
+            id="0"
+            length="4"
+            name="Message Type Indicator"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="1"
+            length="16"
+            name="BIT Map A"
+            class="org.jpos.iso.IFA_BITMAP"/>
+    <isofield
+            id="2"
+            length="19"
+            name="PAN - Primary Account Number"
+            pad="true"
+            class="org.jpos.iso.IFA_LLCHAR"/>
+    <isofield
+            id="3"
+            length="6"
+            name="Processing Code"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="4"
+            length="12"
+            name="Amount, Transaction"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="6"
+            length="12"
+            name="Amount, Cardholder Billing"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="7"
+            length="10"
+            name="Transmission Date And Time"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="10"
+            length="8"
+            name="Conversion Rate, Cardholder Billing"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="11"
+            length="6"
+            name="System Trace Audit Number"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="12"
+            length="6"
+            name="Time, Local Transaction"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="13"
+            length="4"
+            name="Date, Local Transaction"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="14"
+            length="4"
+            name="Date, Expiration"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="15"
+            length="4"
+            name="Date, Settlement"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="18"
+            length="4"
+            name="Merchant Type"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="19"
+            length="3"
+            name="Acquiring Institution Country Code"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="22"
+            length="3"
+            name="Point Of Service Entry Mode"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="23"
+            length="3"
+            name="Application PAN Sequence Number"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="25"
+            length="2"
+            name="Point Of Service Condition Code"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="26"
+            length="2"
+            name="Point Of Service PIN Capture Code"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+            id="28"
+            length="9"
+            name="Amount, Transaction Fee"
+            pad="true"
+            class="org.jpos.iso.IFA_AMOUNT"/>
+
+    <isofield
+            id="30"
+            length="9"
+            name="Amount, Transaction Processing Fee"
+            pad="true"
+            class="org.jpos.iso.IFA_AMOUNT"/>
+
+    <isofield
+            id="32"
+            length="11"
+            name="Acquiring Institution Identification Code"
+            pad="true"
+            class="org.jpos.iso.IFA_LLNUM"/>
+    <isofield
+            id="33"
+            length="11"
+            name="Forwarding Institution Identification Code"
+            pad="true"
+            class="org.jpos.iso.IFA_LLNUM"/>
+
+    <isofield
+            id="35"
+            length="37"
+            name="Track 2 Data"
+            pad="true"
+            class="org.jpos.iso.IFA_LLNUM"/>
+
+    <isofield
+            id="37"
+            length="12"
+            name="Retrieval Reference Number"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="38"
+            length="6"
+            name="Authorization Identification Response"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="39"
+            length="2"
+            name="Response Code"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="41"
+            length="8"
+            name="Card Acceptor Terminal Identification"
+            class="org.jpos.iso.IF_CHAR"/>
+    <isofield
+            id="42"
+            length="15"
+            name="Card Acceptor Identification Code"
+            class="org.jpos.iso.IF_CHAR"/>
+    <isofield
+            id="43"
+            length="40"
+            name="Card Acceptor Name/Location"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="44"
+            length="25"
+            name="Additional Response Data"
+            class="org.jpos.iso.IFA_LLCHAR"/>
+
+    <isofield
+            id="45"
+            length="76"
+            name="Track 1 Data"
+            class="org.jpos.iso.IFA_LLCHAR"/>
+
+    <isofield
+            id="49"
+            length="3"
+            name="Currency Code, Transaction"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="51"
+            length="3"
+            name="Currency Code, Cardholder Billing"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="52"
+            length="8"
+            name="PIN Data"
+            class="org.jpos.iso.IFA_BINARY"/>
+
+    <isofield
+            id="54"
+            length="120"
+            name="Additional Amounts"
+            class="org.jpos.iso.IFA_LLLBINARY"/>
+
+    <isofield
+            id="60"
+            length="6"
+            name="Additional POS Information"
+            class="org.jpos.iso.IFA_LLLCHAR"/>
+
+    <isofield
+            id="61"
+            length="40"
+            name="POINT OF SERVICE DATA"
+            pad="true"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="64"
+            length="8"
+            name="MAC"
+            class="org.jpos.iso.IFA_BINARY"/>
+
+    <isofield
+            id="65"
+            length="8"
+            name="BITMAP, Tertiary"
+            class="org.jpos.iso.IFA_BITMAPStandalone"/>
+
+    <isofield
+            id="70"
+            length="3"
+            name="Network Management Information Code"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="90"
+            length="42"
+            name="Original Data Elements"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="95"
+            length="42"
+            name="Replacement Amounts"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="96"
+            length="8"
+            name="MAC"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="102"
+            length="28"
+            name="Account Identification 1"
+            class="org.jpos.iso.IFA_LLCHAR"/>
+
+    <isofield
+            id="103"
+            length="28"
+            name="Account Identification 2"
+            class="org.jpos.iso.IFA_LLCHAR"/>
+
+    <isofield
+            id="113"
+            length="11"
+            name="Authorising Agent Institution Id"
+            class="org.jpos.iso.IFA_LLLBINARY"/>
+
+    <isofieldpackager
+            id="121"
+            length="255"
+            name="AUTHORISATION RESPONSE DATA"
+            class="org.jpos.iso.IFA_LLLCHAR"
+            packager="org.jpos.iso.packager.LISSubFieldPackager">
+
+
+        <isofield
+                id="2"
+                length="40"
+                name="Generic Message"
+                class="org.jpos.iso.IFA_LLCHAR"/>
+        <isofield
+                id="3"
+                length="15"
+                name="Issuer Transaction Identifier"
+                class="org.jpos.iso.IFA_LLCHAR"/>
+        <isofield
+                id="4"
+                length="15"
+                name="Issuer Account Number"
+                class="org.jpos.iso.IFA_LLCHAR"/>
+        <isofield
+                id="5"
+                length="8"
+                name="Cheque Clearance Date "
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="6"
+                length="30"
+                name="MasterCard Additional Processing Results"
+                class="org.jpos.iso.IFA_LLCHAR"/>
+        <isofield
+                id="7"
+                length="99"
+                name="Bilateral Discretionary Data"
+                pad="true"
+                class="org.jpos.iso.IFA_LLNUM"/>
+        <isofield
+                id="8"
+                length="228"
+                name="Mini Statement Details"
+                pad="true"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="9"
+                length="2"
+                name="AVS Request"
+                pad="true"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="10"
+                length="1"
+                name="AVS Response"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="11"
+                length="2"
+                name="Merchant Advice Code"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="12"
+                length="1"
+                name="Magnetic Stripe/CVC Invalid"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="13"
+                length="16"
+                name="Magnetic Stripe/CVC Status Change"
+                class="org.jpos.iso.IFA_LLCHAR"/>
+        <isofield
+                id="14"
+                length="12"
+                name="????++++????"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="15"
+                length="6"
+                name="Service Provider ID"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="16"
+                length="1"
+                name="Recurring Payment Indicator"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="17"
+                length="15"
+                name="Cheque Deposit Details"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="18"
+                length="99"
+                name="Bilateral Discretionary Data"
+                class="org.jpos.iso.IF_CHAR"/>
+
+        <isofield
+                id="19"
+                length="19"
+                name="MONILINK security cryptogram"
+                class="org.jpos.iso.IFB_BINARY"/>
+        <isofield
+                id="20"
+                length="3"
+                name="Security Level Indicator"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="21"
+                length="32"
+                name="UCAF"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="22"
+                length="1"
+                name="MasterCard Electronic Acceptance Indicator"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="23"
+                length="2"
+                name="AVS Request"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="24"
+                length="1"
+                name="Magnetic Stripe/CVC Status Change"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="25"
+                length="1"
+                name="Magnetic Stripe/CVC Track Edit Errors"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="26"
+                length="12"
+                name="Bilateral Discretionary Data"
+                class="org.jpos.iso.IFA_NUMERIC"/>
+        <isofield
+                id="27"
+                length="24"
+                name="FCD Commission"
+                class="org.jpos.iso.IFA_NUMERIC"/>
+        <isofield
+                id="28"
+                length="50"
+                name="MasterCard Chip CVR/TVR Bit Error Results"
+                class="org.jpos.iso.IFB_BINARY"/>
+        <isofield
+                id="29"
+                length="16"
+                name="MasterCard Network Data"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="30"
+                length="15"
+                name="Original MasterCard Network Data"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="31"
+                length="32"
+                name="MasterCard Issuer Chip Authentication"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="32"
+                length="1"
+                name="MasterCard Cardholder Verification Method"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="33"
+                length="1"
+                name="CAVV Results Code"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="34"
+                length="20"
+                name="Transaction ID (XID)"
+                class="org.jpos.iso.IFB_BINARY"/>
+        <isofield
+                id="35"
+                length="20"
+                name="Cardholder Authentication Verification Value (CAVV)"
+                class="org.jpos.iso.IFB_BINARY"/>
+        <isofield
+                id="36"
+                length="2"
+                name="Electronic Commerce Indicator (ECI)"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="37"
+                length="47"
+                name="MasterCard MPTU Request Data"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="38"
+                length="199"
+                name="MasterCard Member Defined Data"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="39"
+                length="3"
+                name="MasterCard Payment Transaction Type"
+                class="org.jpos.iso.IF_CHAR"/>
+        <isofield
+                id="40"
+                length="6"
+                name="MasterCard CVM Results"
+                class="org.jpos.iso.IFB_BINARY"/>
+    </isofieldpackager>
+
+    <isofieldpackager
+            id="123"
+            length="255"
+            name="Authorisation Data"
+            class="org.jpos.iso.IFA_LLLCHAR"
+            packager="org.jpos.iso.packager.LISSubFieldPackager">
+
+        <isofield
+                id="1"
+                length="2"
+                name="Product Type"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="2"
+                length="4"
+                name="Product ID"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="3"
+                length="20"
+                name="Product Description"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="5"
+                length="3"
+                name="Funds Type "
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="6"
+                length="1"
+                name="Pre-Authorisation Flag"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="7"
+                length="19"
+                name="Pre-pay Account Number"
+                pad="true"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="8"
+                length="37"
+                name="Pre-pay Track 2 Data"
+                pad="true"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="9"
+                length="40"
+                name="MasterCard On-behalf Services "
+                pad="true"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="10"
+                length="6"
+                name="CVV2 Request Data"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="11"
+                length="1"
+                name="CVV2 Result Code"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="12"
+                length="29"
+                name="Address Verification Data"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="13"
+                length="16"
+                name="New PIN"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="14"
+                length="12"
+                name="Issuer Script Result"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="15"
+                length="6"
+                name="Service Provider ID"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="16"
+                length="1"
+                name="Recurring Payment Indicator"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="17"
+                length="15"
+                name="Cheque Deposit Details"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="18"
+                length="99"
+                name="Bilateral Discretionary Data"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+
+        <isofield
+                id="19"
+                length="19"
+                name="MONILINK security cryptogram"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="20"
+                length="3"
+                name="Security Level Indicator"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="21"
+                length="32"
+                name="UCAF"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="22"
+                length="1"
+                name="MasterCard Electronic Acceptance Indicator"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="23"
+                length="2"
+                name="AVS Request"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="24"
+                length="1"
+                name="Magnetic Stripe/CVC Status Change"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="25"
+                length="1"
+                name="Magnetic Stripe/CVC Track Edit Errors"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="26"
+                length="12"
+                name="Bilateral Discretionary Data"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="27"
+                length="24"
+                name="FCD Commission"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="28"
+                length="50"
+                name="MasterCard Chip CVR/TVR Bit Error Results"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="29"
+                length="16"
+                name="MasterCard Network Data"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="30"
+                length="15"
+                name="Original MasterCard Network Data"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="31"
+                length="32"
+                name="MasterCard Issuer Chip Authentication"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="32"
+                length="1"
+                name="MasterCard Cardholder Verification Method"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="33"
+                length="1"
+                name="CAVV Results Code"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="34"
+                length="20"
+                name="Transaction ID (XID)"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="35"
+                length="20"
+                name="Cardholder Authentication Verification Value (CAVV)"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="36"
+                length="2"
+                name="Electronic Commerce Indicator (ECI)"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="37"
+                length="47"
+                name="MasterCard MPTU Request Data"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="38"
+                length="199"
+                name="MasterCard Member Defined Data"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="39"
+                length="3"
+                name="MasterCard Payment Transaction Type"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+        <isofield
+                id="40"
+                length="6"
+                name="MasterCard CVM Results"
+                class="org.jpos.iso.IFA_LLLCHAR"/>
+    </isofieldpackager>
+
+
+    <isofield
+            id="124"
+            length="99"
+            name="Info Text"
+            class="org.jpos.iso.IFA_LLCHAR"/>
+
+    <isofield
+            id="125"
+            length="99"
+            name="Supporting Information"
+            class="org.jpos.iso.IFA_LLLCHAR"/>
+
+    <isofield
+            id="126"
+            length="6"
+            name="Issuer Trace Id"
+            class="org.jpos.iso.IFA_LLLCHAR"/>
+
+    <isofield
+            id="128"
+            length="8"
+            name="MAC 2"
+            class="org.jpos.iso.IFA_BINARY"/>
+
+    <isofield
+            id="130"
+            length="6"
+            name="Terminal Capability Profile"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="131"
+            length="10"
+            name="Terminal Verification Results"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="132"
+            length="8"
+            name="Unpredicatable Number"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="133"
+            length="16"
+            name="Terminal Serial Number"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="134"
+            length="64"
+            name="Issuer Application Data"
+            class="org.jpos.iso.IFA_LLCHAR"/>
+
+    <isofield
+            id="136"
+            length="16"
+            name="Cryptogram"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="137"
+            length="4"
+            name="Application Transaction Counter"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="138"
+            length="4"
+            name="Application Interchange Profile"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="139"
+            length="32"
+            name="Issuer Authentication Data"
+            class="org.jpos.iso.IFA_LLCHAR"/>
+
+    <isofield
+            id="142"
+            length="255"
+            name="Issuer Script"
+            class="org.jpos.iso.IFA_LLLCHAR"/>
+
+    <isofield
+            id="144"
+            length="2"
+            name="Cryptogram Transaction Type"
+            class="org.jpos.iso.IF_CHAR"/>
+
+    <isofield
+            id="145"
+            length="3"
+            name="Terminal Country Code"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="146"
+            length="6"
+            name="Terminal Transaction Date"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="147"
+            length="12"
+            name="Cryptogram Amount"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="148"
+            length="3"
+            name="Cryptogram Currency Code"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="149"
+            length="12"
+            name="Cryptogram Cashback Amount"
+            pad="true"
+            class="org.jpos.iso.IFA_NUMERIC"/>
+
+    <isofield
+            id="192"
+            length="8"
+            name="MAC 3"
+            class="org.jpos.iso.IFA_BINARY"/>
+</isopackager>

--- a/jpos/src/main/java/org/jpos/iso/IFA_BITMAPStandalone.java
+++ b/jpos/src/main/java/org/jpos/iso/IFA_BITMAPStandalone.java
@@ -1,0 +1,85 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2013 Alejandro P. Revilla
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.BitSet;
+
+/**
+ * ASCII packaged Standalone Bitmap - this bitmap will be able to adjust the pack/unpack process when asked.
+ *  *
+ * @author apr@cs.com.uy
+ * @version $Id$
+ * @see ISOComponent
+ * @see ISOBitMapPackager
+ */
+public class IFA_BITMAPStandalone extends ISOBitMapStandalonePackager {
+   
+    public IFA_BITMAPStandalone() {
+        super();
+    }
+    /**
+     * @param len - field len
+     * @param description symbolic descrption
+     */
+    public IFA_BITMAPStandalone(int len, String description) {
+        super(len, description);
+    }
+    /**
+     * @param c - a component
+     * @return packed component
+     * @exception ISOException
+     */
+    public byte[] pack (ISOComponent c) throws ISOException {
+        byte[] b = ISOUtil.bitSet2byte ((BitSet) c.getValue());
+        return ISOUtil.hexString(b).getBytes();
+    }
+
+    public int getMaxPackedLength() {
+        return getLength() >> 2;
+    }
+    /**
+     * @param c - the Component to unpack
+     * @param b - binary image
+     * @param offset - starting offset within the binary image
+     * @return consumed bytes
+     * @exception ISOException
+     */
+    public int unpack (ISOComponent c, byte[] b, int offset)
+        throws ISOException
+    {
+        int len;
+        BitSet bmap = ISOUtil.hex2BitSet (b, offset, getLength() << 3);
+        c.setValue(bmap);
+        len = (bmap.get(1)) ? 128 : 64; /* changed by Hani */
+        if (getLength() > 16 && bmap.get(65))
+            len = 192;
+        return (len >> 2);
+    }
+    public void unpack (ISOComponent c, InputStream in) 
+        throws IOException, ISOException
+    {
+        BitSet bmap = ISOUtil.hex2BitSet (new BitSet (64), readBytes (in, 16), 0);
+        if (getLength() > 8 && bmap.get (1)) {
+            ISOUtil.hex2BitSet (bmap, readBytes (in, 16), 64);
+        }
+        c.setValue(bmap);
+    }
+}

--- a/jpos/src/main/java/org/jpos/iso/ISOBitMapStandalone.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBitMapStandalone.java
@@ -1,0 +1,121 @@
+/*
+* jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2014 Alejandro P. Revilla
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import org.jpos.iso.packager.XMLPackager;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.BitSet;
+
+/**
+ * implements <b>Leaf</b> for Bitmap field
+ *
+ * @author apr@cs.com.uy
+ * @version $Id$
+ * @see ISOComponent
+ */
+public class ISOBitMapStandalone extends ISOComponent implements Cloneable {
+    protected int fieldNumber;
+    protected BitSet value;
+
+    /**
+     * @param n - the FieldNumber
+     */
+    public ISOBitMapStandalone (int n) {
+        fieldNumber = n;
+    }
+    /**
+     * @param n - fieldNumber
+     * @param v - field value (Bitset)
+     * @see BitSet
+     */
+    public ISOBitMapStandalone (int n, BitSet v) {
+        fieldNumber = n;
+        value = v;
+    }
+    /**
+     * changes this Component field number<br>
+     * Use with care, this method does not change
+     * any reference held by a Composite.
+     * @param fieldNumber new field number
+     */
+    public void setFieldNumber (int fieldNumber) {
+        this.fieldNumber = fieldNumber;
+    }
+
+    @Override
+    public int getFieldNumber() {
+        return fieldNumber;
+    }
+
+    /**
+     * not available on Leaf - always throw ISOException
+     * @exception ISOException
+     */
+    public byte[] pack() throws ISOException {
+        throw new ISOException ("Not available on Leaf");
+    }
+    /**
+     * not available on Leaf - always throw ISOException
+     * @exception ISOException
+     */
+    public int unpack(byte[] b) throws ISOException {
+        throw new ISOException ("Not available on Leaf");
+    }
+    /**
+     * not available on Leaf - always throw ISOException
+     * @exception ISOException
+     */
+    public void unpack(InputStream in) throws ISOException {
+        throw new ISOException ("Not available on Leaf");
+    }
+    /**
+     * @return Object representing this field number
+     */
+    public Object getKey() {
+        return fieldNumber;
+    }
+    /**
+     * @return Object representing this field value
+     */
+    public Object getValue() {
+        return value;
+    }
+    /**
+     * @param obj - Object representing this field value
+     * @exception ISOException
+     */
+    public void setValue(Object obj) throws ISOException {
+        value = (BitSet) obj;
+    }
+    /**
+     * dump this field to PrintStream. The output is sorta
+     * XML, intended to be easily parsed.
+     * @param p - print stream
+     * @param indent - optional indent string
+     */
+    public void dump (PrintStream p, String indent) {
+        p.println (indent +"<"+XMLPackager.ISOFIELD_TAG + " " +
+            XMLPackager.ID_ATTR +"=\""+XMLPackager.TYPE_BITMAP+"\" "+
+            XMLPackager.VALUE_ATTR +"=\"" +value+"\" "+
+            XMLPackager.TYPE_ATTR +"=\"" + XMLPackager.TYPE_BITMAP+ "\"/>"
+        );
+    }
+}

--- a/jpos/src/main/java/org/jpos/iso/ISOBitMapStandalonePackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBitMapStandalonePackager.java
@@ -1,0 +1,110 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2014 Alejandro P. Revilla
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import java.util.BitSet;
+
+/**
+ * IF*_BITMAPStandalone classes extend this class instead of ISOFieldPackager
+ * so packagers can check if this field is present needs special handling on pack/unpack.
+ *  *
+ * @author apr@cs.com.uy
+ * @author marksalter@talktalk.net
+ * 
+ * @version $Id$
+ *
+ * @see ISOFieldPackager
+ */
+public abstract class ISOBitMapStandalonePackager extends ISOFieldPackager {
+
+	private ISOBitMapStandalone bmap;
+	private int key = 65;
+	
+	public ISOBitMapStandalonePackager() {
+        super();
+    }
+    public ISOBitMapStandalonePackager(int len, String description) {
+        super(len, description);
+    }
+    public ISOComponent createComponent(int fieldNumber) {
+    	key = fieldNumber;
+    	bmap = new ISOBitMapStandalone(key);
+        return (ISOComponent)bmap;
+    }
+	public void adjustBitMapForUnpack(BitSet bitset) {
+		
+		
+		if (key == 0) {
+			// nothing to add, we have not been created.
+		} else {
+		
+			/*
+			 * Loop though our bits, adjusting by our field value and setting as 
+			 * on in bmap.
+			 */
+			int base = (key - 1) << 1 ;
+			int set = 0;
+			
+			BitSet myBmap = (BitSet) this.bmap.getValue();
+			
+	    	for (int i = myBmap.cardinality(); i > 0; i--) {
+	    		set = myBmap.nextSetBit(set+1);
+	    		bitset.set(set+base);
+	    	}
+		}
+		
+		
+	}
+	public int getMaxField() {
+		return ((key - 1) << 1) + getLength() * 8 ;
+	}
+	public void adjustBitMapForPack(BitSet bitset) {
+		if (key == 0) {
+			/*
+			 * we don't have a key, so we have nothing to add to this bitmap exchange.
+			 */
+		} else {
+			
+			
+			
+			/*
+			 * Loop though bitset, unsetting 'our' bits and setting our bits on (relative to base).
+			 */
+			int base = (key - 1) << 1 ;
+			
+			BitSet myBmap = new BitSet();
+			
+			 for (int set = bitset.nextSetBit(base); set >= 0; set = bitset.nextSetBit(set+1)) {
+					myBmap.set(set-base);
+					bitset.clear(set);
+			 }
+			
+			
+			try {
+				if (bmap == null) {
+					bmap = new ISOBitMapStandalone(key);
+				}
+				bmap.setValue(myBmap);
+			} catch (ISOException ex) {
+				ex.printStackTrace();
+			}
+		}
+		
+	}
+}


### PR DESCRIPTION
I need to consider the potential moveable nature of this BitMap field and form a method of keeping track of it/them in the ISOBasePacker processing, since field 65 (for LIS) is currently hardcoded.
