### PR TITLE
Enhances DUKPT functionality.

### DIFF
--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -816,7 +816,7 @@ public class BaseSMAdapter
       LogEvent evt = new LogEvent(this, "s-m-operation");
       evt.addMessage(new SimpleMsg("command", "Verify CVC3", cmdParameters));
       try {
-        boolean r = verifyCVC3Impl( imkcvc3, accountNo, acctSeqNo, atc, upn, data, mkdm, cvc3);
+        boolean r = verifyCVC3Impl(imkcvc3, accountNo, acctSeqNo, atc, upn, data, mkdm, cvc3);
         evt.addMessage(new SimpleMsg("result", "Verification status", r ? "valid" : "invalid"));
         return r;
       } catch (Exception e) {
@@ -846,7 +846,7 @@ public class BaseSMAdapter
       LogEvent evt = new LogEvent(this, "s-m-operation");
       evt.addMessage(new SimpleMsg("command", "Verify ARQC/TC/AAC", cmdParameters));
       try {
-        boolean r = verifyARQCImpl( mkdm, skdm, imkac, accoutNo, acctSeqNo, arqc, atc, upn, transData);
+        boolean r = verifyARQCImpl(mkdm, skdm, imkac, accoutNo, acctSeqNo, arqc, atc, upn, transData);
         evt.addMessage(new SimpleMsg("result", "Verification status", r ? "valid" : "invalid"));
         return r;
       } catch (Exception e) {
@@ -880,8 +880,8 @@ public class BaseSMAdapter
       LogEvent evt = new LogEvent(this, "s-m-operation");
       evt.addMessage(new SimpleMsg("command", "Genarate ARPC", cmdParameters));
       try {
-        byte[] result = generateARPCImpl( mkdm, skdm, imkac, accoutNo, acctSeqNo
-                           ,arqc, atc, upn, arpcMethod, arc, propAuthData );
+        byte[] result = generateARPCImpl(mkdm, skdm, imkac, accoutNo, acctSeqNo
+            , arqc, atc, upn, arpcMethod, arc, propAuthData);
         evt.addMessage(new SimpleMsg("result", "Generated ARPC", result));
         return result;
       } catch (Exception e) {
@@ -916,8 +916,8 @@ public class BaseSMAdapter
       LogEvent evt = new LogEvent(this, "s-m-operation");
       evt.addMessage(new SimpleMsg("command", "Genarate ARPC", cmdParameters));
       try {
-        byte[] result = verifyARQCGenerateARPCImpl( mkdm, skdm, imkac, accoutNo,
-                acctSeqNo, arqc, atc, upn, transData, arpcMethod, arc, propAuthData );
+        byte[] result = verifyARQCGenerateARPCImpl(mkdm, skdm, imkac, accoutNo,
+                                                   acctSeqNo, arqc, atc, upn, transData, arpcMethod, arc, propAuthData);
         evt.addMessage(new SimpleMsg("result", "ARPC", result == null ? "" : ISOUtil.hexString(result)));
         return result;
       } catch (Exception e) {
@@ -946,7 +946,7 @@ public class BaseSMAdapter
       LogEvent evt = new LogEvent(this, "s-m-operation");
       evt.addMessage(new SimpleMsg("command", "Generate Secure Messaging MAC", cmdParameters));
       try {
-        byte[] mac = generateSM_MACImpl( mkdm, skdm, imksmi, accountNo, acctSeqNo, atc, arqc, data);
+        byte[] mac = generateSM_MACImpl(mkdm, skdm, imksmi, accountNo, acctSeqNo, atc, arqc, data);
         evt.addMessage(new SimpleMsg("result", "Generated MAC", mac!=null ? ISOUtil.hexString(mac) : ""));
         return mac;
       } catch (Exception e) {
@@ -1177,9 +1177,24 @@ public class BaseSMAdapter
 
     /**
      * Your SMAdapter should override this method if it has this functionality
+     * @deprecated
      * @param pinUnderDuk
      * @param ksn
      * @param bdk
+     * @return imported pin
+     * @throws SMException
+     */
+    protected EncryptedPIN importPINImpl (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            SecureDESKey bdk) throws SMException {
+        return importPINImpl(pinUnderDuk,ksn,bdk,false);
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality
+     * @param pinUnderDuk
+     * @param ksn
+     * @param bdk
+     * @param tdes
      * @return imported pin
      * @throws SMException
      */
@@ -1190,10 +1205,27 @@ public class BaseSMAdapter
 
     /**
      * Your SMAdapter should override this method if it has this functionality
+     * @deprecated
      * @param pinUnderDuk
      * @param ksn
      * @param bdk
      * @param kd2
+     * @param destinationPINBlockFormat
+     * @return translated pin
+     * @throws SMException
+     */
+    protected EncryptedPIN translatePINImpl (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
+        return translatePINImpl(pinUnderDuk,ksn,bdk,kd2,destinationPINBlockFormat,false);
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality
+     * @param pinUnderDuk
+     * @param ksn
+     * @param bdk
+     * @param kd2
+     * @param tdes
      * @param destinationPINBlockFormat
      * @return translated pin
      * @throws SMException

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -292,6 +292,12 @@ public class BaseSMAdapter
     @Override
     public EncryptedPIN importPIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
             SecureDESKey bdk) throws SMException {
+        return importPIN(pinUnderDuk,ksn,bdk,false);
+    }
+
+    @Override
+    public EncryptedPIN importPIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            SecureDESKey bdk, boolean tdes) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "PIN under Derived Unique Key", pinUnderDuk), new SimpleMsg("parameter",
                     "Key Serial Number", ksn), new SimpleMsg("parameter", "Base Derivation Key",
@@ -301,7 +307,7 @@ public class BaseSMAdapter
         evt.addMessage(new SimpleMsg("command", "Import PIN", cmdParameters));
         EncryptedPIN result = null;
         try {
-            result = importPINImpl(pinUnderDuk, ksn, bdk);
+            result = importPINImpl(pinUnderDuk, ksn, bdk, tdes);
             evt.addMessage(new SimpleMsg("result", "PIN under LMK", result));
         } catch (Exception e) {
             evt.addMessage(e);
@@ -315,6 +321,12 @@ public class BaseSMAdapter
     @Override
     public EncryptedPIN translatePIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
             SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
+        return translatePIN(pinUnderDuk,ksn,bdk,kd2,destinationPINBlockFormat,false);
+    }
+
+    @Override
+    public EncryptedPIN translatePIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat,boolean tdes) throws SMException {
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "PIN under Derived Unique Key", pinUnderDuk), new SimpleMsg("parameter",
                     "Key Serial Number", ksn), new SimpleMsg("parameter", "Base Derivation Key",
@@ -325,7 +337,7 @@ public class BaseSMAdapter
         evt.addMessage(new SimpleMsg("command", "Translate PIN", cmdParameters));
         EncryptedPIN result = null;
         try {
-            result = translatePINImpl(pinUnderDuk, ksn, bdk, kd2, destinationPINBlockFormat);
+            result = translatePINImpl(pinUnderDuk, ksn, bdk, kd2, destinationPINBlockFormat,tdes);
             evt.addMessage(new SimpleMsg("result", "PIN under Data Key 2", result));
         } catch (Exception e) {
             evt.addMessage(e);
@@ -1172,7 +1184,7 @@ public class BaseSMAdapter
      * @throws SMException
      */
     protected EncryptedPIN importPINImpl (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk) throws SMException {
+            SecureDESKey bdk, boolean tdes) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1187,7 +1199,8 @@ public class BaseSMAdapter
      * @throws SMException
      */
     protected EncryptedPIN translatePINImpl (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
+            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat,
+            boolean tdes) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/SMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/SMAdapter.java
@@ -362,6 +362,7 @@ public interface SMAdapter {
      * under LMK.
      *
      * <p>The transaction key is derived from the Key Serial Number and the Base Derivation Key using DUKPT (Derived Unique Key per Transaction). See ANSI X9.24 for more information.
+     * @deprecated Use signature that specifies tdes flag.
      * @param pinUnderDuk pin encrypted under a transaction key
      * @param ksn Key Serial Number (also called Key Name, in ANSI X9.24) needed to derive the transaction key
      * @param bdk Base Derivation Key, used to derive the transaction key underwhich the pin is encrypted
@@ -371,6 +372,39 @@ public interface SMAdapter {
     public EncryptedPIN importPIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
             SecureDESKey bdk) throws SMException;
 
+    /**
+     * Imports a PIN from encryption under a transaction key to encryption
+     * under LMK.
+     *
+     * <p>The transaction key is derived from the Key Serial Number and the Base Derivation Key using DUKPT (Derived Unique Key per Transaction). See ANSI X9.24 for more information.
+     * @param pinUnderDuk pin encrypted under a transaction key
+     * @param ksn Key Serial Number (also called Key Name, in ANSI X9.24) needed to derive the transaction key
+     * @param bdk Base Derivation Key, used to derive the transaction key underwhich the pin is encrypted
+     * @param tdes Use Triple DES to calculate derived transaction key.
+     * @return pin encrypted under LMK
+     * @throws SMException
+     */
+    public EncryptedPIN importPIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            SecureDESKey bdk, boolean tdes) throws SMException;
+
+
+
+    /**
+     * Translates a PIN from encryption under a transaction key to
+     * encryption under a KD (Data Key).
+     *
+     * <p>The transaction key is derived from the Key Serial Number and the Base Derivation Key using DUKPT (Derived Unique Key per Transaction). See ANSI X9.24 for more information.
+     * @deprecated Use signature that specifies tdes flag.
+     * @param pinUnderDuk pin encrypted under a DUKPT transaction key
+     * @param ksn Key Serial Number (also called Key Name, in ANSI X9.24) needed to derive the transaction key
+     * @param bdk Base Derivation Key, used to derive the transaction key underwhich the pin is encrypted
+     * @param kd2 the destination Data Key (also called session key) under which the pin will be encrypted
+     * @param destinationPINBlockFormat the PIN Block Format of the translated encrypted PIN
+     * @return pin encrypted under kd2
+     * @throws SMException
+     */
+    public EncryptedPIN translatePIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException;
 
 
     /**
@@ -383,11 +417,12 @@ public interface SMAdapter {
      * @param bdk Base Derivation Key, used to derive the transaction key underwhich the pin is encrypted
      * @param kd2 the destination Data Key (also called session key) under which the pin will be encrypted
      * @param destinationPINBlockFormat the PIN Block Format of the translated encrypted PIN
+     * @param tdes Use Triple DES to calculate derived transaction key.
      * @return pin encrypted under kd2
      * @throws SMException
      */
     public EncryptedPIN translatePIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException;
+            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat,boolean tdes) throws SMException;
 
 
 


### PR DESCRIPTION
- Moves up 'tdes' signature to SMAdapter, deprecating actual signature.
- Adds exportPIN to DUKPT to assist in creating a pinblock to be used in a simulated client app (EFTPOS device)