### PR TITLE
SMAdapter.translateKeyScheme and JCESecurityModule implementation

### DIFF
--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -155,6 +155,28 @@ public class BaseSMAdapter
     }
 
     @Override
+    public SecureDESKey translateKeyScheme (SecureDESKey key, KeyScheme destKeyScheme)
+            throws SMException {
+        SimpleMsg[] cmdParameters =  {
+            new SimpleMsg("parameter", "Key", key)
+           ,new SimpleMsg("parameter", "Destination Key Scheme", destKeyScheme)
+        };
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Translate Key Scheme", cmdParameters));
+        SecureDESKey result = null;
+        try {
+            result = translateKeySchemeImpl(key, destKeyScheme);
+            evt.addMessage(new SimpleMsg("result", "Translate Key Scheme", result));
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw  e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            Logger.log(evt);
+        }
+        return  result;
+    }
+
+    @Override
     public SecureDESKey importKey (short keyLength, String keyType, byte[] encryptedKey,
             SecureDESKey kek, boolean checkParity) throws SMException {
         SimpleMsg[] cmdParameters =  {
@@ -1184,6 +1206,18 @@ public class BaseSMAdapter
      * @throws SMException
      */
     protected byte[] generateKeyCheckValueImpl (SecureDESKey kd) throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality
+     * @param key
+     * @param destKeyScheme
+     * @return translated key with {@code destKeyScheme} scheme
+     * @throws SMException
+     */
+    public SecureDESKey translateKeySchemeImpl (SecureDESKey key, KeyScheme destKeyScheme)
+            throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1031,7 +1031,7 @@ public class BaseSMAdapter
         evt.addMessage(new SimpleMsg("command", "Encrypt Data", cmdParameters));
         byte[] encData = null;
         try {
-            encData = encryptDataImpl(cipherMode, kd, iv, data);
+            encData = encryptDataImpl(cipherMode, kd, data, iv);
             List<Loggeable> r = new ArrayList<Loggeable>();
             r.add(new SimpleMsg("result", "Encrypted Data", encData));
             if(iv != null)
@@ -1073,7 +1073,7 @@ public class BaseSMAdapter
         evt.addMessage(new SimpleMsg("command", "Decrypt Data", cmdParameters));
         byte[] decData = null;
         try {
-            decData = decryptDataImpl(cipherMode, kd, iv, data);
+            decData = decryptDataImpl(cipherMode, kd, data, iv);
             List<Loggeable> r = new ArrayList<Loggeable>();
             r.add(new SimpleMsg("result", "Decrypted Data", decData));
             if(iv != null)
@@ -1706,7 +1706,7 @@ public class BaseSMAdapter
      * @return encrypted data
      * @throws SMException
      */
-    public byte[] encryptDataImpl(CipherMode cipherMode, SecureDESKey kd
+    protected byte[] encryptDataImpl(CipherMode cipherMode, SecureDESKey kd
             ,byte[] data, byte[] iv) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1720,7 +1720,7 @@ public class BaseSMAdapter
      * @return decrypted data
      * @throws SMException
      */
-    public byte[] decryptDataImpl(CipherMode cipherMode, SecureDESKey kd
+    protected byte[] decryptDataImpl(CipherMode cipherMode, SecureDESKey kd
             ,byte[] data, byte[] iv) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }

--- a/jpos/src/main/java/org/jpos/security/KeyScheme.java
+++ b/jpos/src/main/java/org/jpos/security/KeyScheme.java
@@ -19,10 +19,41 @@
 package org.jpos.security;
 
 /**
+ * Key Encription Scheme.
+ *
  * @author Robert Demski
- * @version $Revision$ $Date$
  */
 public enum KeyScheme {
-    Z,X,U,Y,T
+
+    /**
+     * Encryption of a single length DES key using X9.17 methods.
+     * <p>
+     * Used for encryption of keys under a variant LMK..
+     */
+    Z,
+
+    /**
+     * Encryption of a double length key using X9.17 methods.
+     */
+    X,
+
+    /**
+     * Encryption of a double length DES key using the variant method.
+     * <p>
+     * Used for encryption of keys under a variant LMK.
+     */
+    U,
+
+    /**
+     * Encryption of a triple length key using X9.17 methods.
+     */
+    Y,
+
+    /**
+     * Encryption of a triple length DES key using the variant method.
+     * <p>
+     * Used for encryption of keys under a variant LMK.
+     */
+    T
 }
 

--- a/jpos/src/main/java/org/jpos/security/SMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/SMAdapter.java
@@ -271,6 +271,22 @@ public interface SMAdapter {
 
 
     /**
+     * Translate Key Scheme to more secure encription.
+     * <p>
+     * Converts an DES key encrypted using X9.17 methods to a more secure
+     * key using the variant method.
+     *
+     * @param key key to be translated to {@code destKeyScheme} scheme
+     * @param keyScheme destination key scheme
+     * @return translated key with {@code destKeyScheme} scheme
+     * @throws SMException
+     */
+    public SecureDESKey translateKeyScheme (SecureDESKey key, KeyScheme keyScheme)
+      throws SMException;
+
+
+
+    /**
      * Imports a key from encryption under a KEK (Key-Encrypting Key)
      * to protection under the security module.
      *

--- a/jpos/src/main/java/org/jpos/security/SecureDESKey.java
+++ b/jpos/src/main/java/org/jpos/security/SecureDESKey.java
@@ -21,35 +21,39 @@ package  org.jpos.security;
 import org.jpos.iso.ISOUtil;
 
 import java.io.PrintStream;
-import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * <p>
  * The SecureDESKey class represents: <br>
  * Single, double or triple length DES keys that are secured by a security module.
  * This is typically the DES key encrypted under one of the Local Master Keys of the
  * security module.
- * </p>
  * <p>
  * SecureDESKey has an extra property "Key Check Value". It allows assuring that
  * two SecureDESKeys owned by two different parties map
  * to the same clear key. This can be a useful manual check for successful key
  * exchange.
- * </p>
  * <p>
  * NOTE: The security of SecureDESKey is totally dependent on the security of
  * the used security module.
- * </p>
+ *
  * @author Hani S. Kirollos
- * @version $Revision$ $Date$
+ * @author Robert Demski
  * @see SMAdapter
  */
 public class SecureDESKey extends SecureKey {
 
     private static final long serialVersionUID = -9145281998779008306L;
+
+    /**
+     * Regular expression pattern representing key type string value.
+     */
+    private static final Pattern KEY_TYPE_PATTERN = Pattern.compile("([^:;]*)([:;])?([^:;])?([^:;])?");
+
     /**
      * The keyCheckValue allows identifying which clear key does this
-     * secure key represent.<br>
+     * secure key represent.
      */
     protected byte[] keyCheckValue = null;
 
@@ -115,6 +119,8 @@ public class SecureDESKey extends SecureKey {
      * Constructs an SecureDESKey
      * @param keyLength
      * @param keyType
+     * @param variant
+     * @param scheme
      * @param keyHexString secure key represented as HexString instead of byte[]
      * @param keyCheckValueHexString key check value represented as HexString instead of byte[]
      */
@@ -161,19 +167,21 @@ public class SecureDESKey extends SecureKey {
          * Some variant derivation if it hasn't been explicity stated
          */
         variant = 0;
-        StringTokenizer st = new StringTokenizer(keyType,":;");
-        if (st.hasMoreTokens())
-            st.nextToken();
-        if (st.hasMoreTokens())
+        Matcher m = KEY_TYPE_PATTERN.matcher(keyType);
+        m.find();
+        if (m.group(3) != null)
             try {
-                variant = Byte.valueOf(st.nextToken().substring(0,1));
-            } catch (Exception ex){}
+                variant = Byte.valueOf(m.group(3));
+            } catch (NumberFormatException ex){
+                throw new NumberFormatException("Value "+m.group(4)+" is not valid key variant");
+            }
         return variant;
     }
 
     /**
      * Key Type Scheme is useful for stating whitch scheme variant of key type should be used.
      * ... TO COMPLITE ...<BR>
+     * @param scheme
      */
     public void setScheme(KeyScheme scheme){
         this.scheme = scheme;
@@ -193,13 +201,14 @@ public class SecureDESKey extends SecureKey {
             case SMAdapter.LENGTH_DES3_3KEY:
                 scheme = KeyScheme.Y; break;
         }
-        StringTokenizer st = new StringTokenizer(keyType,":;");
-        if (st.hasMoreTokens())
-            st.nextToken();
-        if (st.hasMoreTokens())
+        Matcher m = KEY_TYPE_PATTERN.matcher(keyType);
+        m.find();
+        if (m.group(4) != null)
             try {
-                scheme = KeyScheme.valueOf(st.nextToken().substring(1,2));
-            } catch (Exception ex){}
+                scheme = KeyScheme.valueOf(m.group(4));
+            } catch (IllegalArgumentException ex){
+                throw new IllegalArgumentException("Value "+m.group(4)+" is not valid key scheme");
+            }
         return scheme;
     }
 
@@ -209,6 +218,7 @@ public class SecureDESKey extends SecureKey {
      * @param indent indention string, usually suppiled by Logger
      * @see org.jpos.util.Loggeable
      */
+    @Override
     public void dump (PrintStream p, String indent) {
         String inner = indent + "  ";
         p.print(indent + "<secure-des-key");

--- a/jpos/src/test/java/org/jpos/security/SecureDESKeyTest.java
+++ b/jpos/src/test/java/org/jpos/security/SecureDESKeyTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -31,112 +30,92 @@ import org.junit.Test;
 
 public class SecureDESKeyTest {
 
+    static final byte[] kcv  = new byte[0];
+    static final byte[] kcv1 = new byte[1];
+    static final short  length = (short) 100;
+    static final String keyType = "Key-Type123";
+    static final String keyHEX  = "testKeyHEX";
+    static final String kcvHEX  = "testKeyKCV_HEX";
+
     @Test
     public void testConstructor() throws Throwable {
-        SecureDESKey secureDESKey = new SecureDESKey((short) 100, "testSecureDESKeyKeyType", "testSecureDESKeyKeyHexString",
-                "testSecureDESKeyKeyCheckValueHexString");
-        assertEquals("secureDESKey.keyType", "testSecureDESKeyKeyType", secureDESKey.keyType);
-        assertEquals("secureDESKey.keyCheckValue.length", 19, secureDESKey.keyCheckValue.length);
-        assertEquals("secureDESKey.keyBytes.length", 14, secureDESKey.keyBytes.length);
-        assertEquals("secureDESKey.keyLength", (short) 100, secureDESKey.keyLength);
+        SecureDESKey key = new SecureDESKey(length, keyType, keyHEX,kcvHEX);
+        assertEquals(keyType, key.getKeyType());
+        assertEquals(7, key.getKeyCheckValue().length);
+        assertEquals(5, key.getKeyBytes().length);
+        assertEquals(length, key.getKeyLength());
     }
 
     @Test
     public void testConstructor1() throws Throwable {
         byte[] keyBytes = new byte[2];
-        byte[] keyCheckValue = new byte[0];
-        SecureDESKey secureDESKey = new SecureDESKey((short) 100, "testSecureDESKeyKeyType", keyBytes, keyCheckValue);
-        assertEquals("secureDESKey.keyType", "testSecureDESKeyKeyType", secureDESKey.keyType);
-        assertSame("secureDESKey.keyCheckValue", keyCheckValue, secureDESKey.keyCheckValue);
-        assertSame("secureDESKey.keyBytes", keyBytes, secureDESKey.keyBytes);
-        assertEquals("secureDESKey.keyLength", (short) 100, secureDESKey.keyLength);
+        SecureDESKey key = new SecureDESKey(length, keyType, keyBytes, kcv);
+        assertEquals(keyType, key.getKeyType());
+        assertSame(kcv, key.getKeyCheckValue());
+        assertSame(keyBytes, key.getKeyBytes());
+        assertEquals(length, key.getKeyLength());
     }
 
     @Test
     public void testConstructor2() throws Throwable {
-        SecureDESKey secureDESKey = new SecureDESKey();
-        assertNull("secureDESKey.keyCheckValue", secureDESKey.keyCheckValue);
-        assertNull("secureDESKey.keyBytes", secureDESKey.keyBytes);
+        SecureDESKey key = new SecureDESKey();
+        assertNull(key.getKeyCheckValue());
+        assertNull(key.getKeyBytes());
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testConstructorThrowsNullPointerException() throws Throwable {
-        try {
-            new SecureDESKey((short) 100, "testSecureDESKeyKeyType", (String) null, "testSecureDESKeyKeyCheckValueHexString");
-            fail("Expected NullPointerException to be thrown");
-        } catch (NullPointerException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
-        }
+        new SecureDESKey(length, keyType, null, "testSecureDESKeyKeyCheckValueHexString");
     }
 
     @Test
     public void testConstructorUnevenHexDigits() throws Throwable {
-        new SecureDESKey((short) 100, "testSecureDESKeyKeyType", "testSecureDESKeyKeyHexString",
-                "testSecureDESKeyKeyCheckValueHexString1");
+        new SecureDESKey(length, keyType, keyHEX, kcvHEX);
         assertTrue("Test completed without Exception", true);
     }
 
     @Test
     public void testDump() throws Throwable {
-        byte[] keyCheckValue = new byte[0];
         byte[] keyBytes = new byte[1];
-        PrintStream p = new PrintStream(new ByteArrayOutputStream(), true, "UTF-16");
-        new SecureDESKey((short) 100, "testSecureDESKeyKeyType", keyBytes, keyCheckValue).dump(p, "testSecureDESKeyIndent");
+        PrintStream p = new PrintStream(new ByteArrayOutputStream());
+        new SecureDESKey(length, keyType, keyBytes, kcv).dump(p, "testIndent");
         assertTrue("Test completed without Exception", true);
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testDumpThrowsNullPointerException() throws Throwable {
-        byte[] keyCheckValue = new byte[1];
-        PrintStream p = new PrintStream(new ByteArrayOutputStream(), true, "UTF-16");
-        try {
-            new SecureDESKey((short) 100, "testSecureDESKeyKeyType", (byte[]) null, keyCheckValue).dump(p, "testSecureDESKeyIndent");
-            fail("Expected NullPointerException to be thrown");
-        } catch (NullPointerException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
-        }
+        PrintStream p = new PrintStream(new ByteArrayOutputStream());
+        new SecureDESKey(length, keyType, null, kcv1).dump(p, "");
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testDumpThrowsNullPointerException1() throws Throwable {
         byte[] keyBytes = new byte[2];
-        byte[] keyCheckValue = new byte[0];
-        try {
-            new SecureDESKey((short) 100, "testSecureDESKeyKeyType", keyBytes, keyCheckValue).dump(null, "testSecureDESKeyIndent");
-            fail("Expected NullPointerException to be thrown");
-        } catch (NullPointerException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
-        }
+        new SecureDESKey(length, keyType, keyBytes, kcv).dump(null, "");
     }
 
     @Test
     public void testGetKeyCheckValue() throws Throwable {
-        SecureDESKey secureDESKey = new SecureDESKey((short) 100, "testSecureDESKeyKeyType", "testSecureDESKeyKeyHexString",
-                "testSecureDESKeyKeyCheckValueHexString");
-        byte[] keyCheckValue = new byte[0];
-        secureDESKey.setKeyCheckValue(keyCheckValue);
-        byte[] result = secureDESKey.getKeyCheckValue();
-        assertSame("result", keyCheckValue, result);
+        SecureDESKey key = new SecureDESKey(length, keyType, keyHEX, kcvHEX);
+        key.setKeyCheckValue(kcv);
+        assertSame(kcv, key.getKeyCheckValue());
     }
 
     @Test
     public void testGetKeyCheckValue1() throws Throwable {
-        SecureDESKey secureDESKey = new SecureDESKey((short) 100, "testSecureDESKeyKeyType", "testSecureDESKeyKeyHexString",
-                "testSecureDESKeyKeyCheckValueHexString");
-        byte[] keyCheckValue = new byte[1];
-        secureDESKey.setKeyCheckValue(keyCheckValue);
-        byte[] result = secureDESKey.getKeyCheckValue();
-        assertSame("result", keyCheckValue, result);
-        assertEquals("keyCheckValue[0]", (byte) 0, keyCheckValue[0]);
+        SecureDESKey key = new SecureDESKey(length, keyType, keyHEX, kcvHEX);
+        key.setKeyCheckValue(kcv1);
+        assertSame(kcv1, key.getKeyCheckValue());
+        assertEquals((byte) 0, kcv1[0]);
     }
 
     @Test
     public void testSetKeyCheckValue() throws Throwable {
-        byte[] keyCheckValue = new byte[1];
         byte[] keyBytes = new byte[3];
-        SecureDESKey secureDESKey = new SecureDESKey((short) 100, "testSecureDESKeyKeyType", keyBytes, keyCheckValue);
-        byte[] keyCheckValue2 = new byte[0];
-        secureDESKey.setKeyCheckValue(keyCheckValue2);
-        assertSame("secureDESKey.keyCheckValue", keyCheckValue2, secureDESKey.keyCheckValue);
+        SecureDESKey key = new SecureDESKey(length, keyType, keyBytes, kcv1);
+        byte[] kcv2 = new byte[0];
+        key.setKeyCheckValue(kcv2);
+        assertSame(kcv2, key.getKeyCheckValue());
     }
+
 }

--- a/jpos/src/test/java/org/jpos/security/SecureDESKeyTest.java
+++ b/jpos/src/test/java/org/jpos/security/SecureDESKeyTest.java
@@ -63,6 +63,31 @@ public class SecureDESKeyTest {
         assertNull(key.getKeyBytes());
     }
 
+    @Test
+    public void testConstructorExtType() throws Throwable {
+        byte[] keyBytes = new byte[2];
+        String kt = "Key-Type123:4U";
+        SecureDESKey key = new SecureDESKey(length, kt, keyBytes, kcv);
+        assertEquals(kt, key.getKeyType());
+        assertSame(kcv, key.getKeyCheckValue());
+        assertSame(keyBytes, key.getKeyBytes());
+        assertEquals(length, key.getKeyLength());
+        assertEquals(4, key.getVariant());
+        assertEquals(KeyScheme.U, key.getScheme());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorExtType_InvalidVariant() throws Throwable {
+        byte[] keyBytes = new byte[2];
+        new SecureDESKey(length, "Key-Type123:JU", keyBytes, kcv);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorExtType_InvalidScheme() throws Throwable {
+        byte[] keyBytes = new byte[2];
+        new SecureDESKey(length, "Key-Type123:3H", keyBytes, kcv);
+    }
+
     @Test(expected = NullPointerException.class)
     public void testConstructorThrowsNullPointerException() throws Throwable {
         new SecureDESKey(length, keyType, null, "testSecureDESKeyKeyCheckValueHexString");


### PR DESCRIPTION
HSM enables to convert double and triple length DES key encrypted
using X9.17 methods to more secure key using the variant method.
In theory is possible do it using export a key under a ZMK and
import it again under LMK with more secure encryption scheme,
but very often exporting and importing X9.17 keys is locked.
Translate Key Scheme to variant methods is enabled by default.

Also others cleaning patches;)