### PR TITLE
Fix thread allocation error with race conditions and improve thread naming

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/iso/QServer.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QServer.java
@@ -102,7 +102,7 @@ public class QServer
         }
 
         ThreadPool pool = null;
-        pool = new ThreadPool (minSessions ,maxSessions);
+        pool = new ThreadPool (minSessions ,maxSessions, getName() + "-ThreadPool");
         pool.setLogger (log.getLogger(), getName() + ".pool");
 
         server = new ISOServer (port, (ServerChannel) channel, pool);

--- a/jpos/src/main/java/org/jpos/util/BlockingQueue.java
+++ b/jpos/src/main/java/org/jpos/util/BlockingQueue.java
@@ -95,6 +95,11 @@ public class BlockingQueue {
     public synchronized int consumerCount() {
         return consumers;
     }
+
+    public synchronized int consumerDeficit() {
+        return queue.size() - consumers;
+    }
+    
     public synchronized boolean ready() {
         return !closed;
     }

--- a/jpos/src/main/java/org/jpos/util/ThreadPool.java
+++ b/jpos/src/main/java/org/jpos/util/ThreadPool.java
@@ -25,54 +25,64 @@ import org.jpos.util.BlockingQueue.Closed;
 import org.jpos.util.NameRegistrar.NotFoundException;
 
 import java.io.PrintStream;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Implements a ThreadPool with the ability to run simple Runnable
  * tasks as well as Jobs (supervised Runnable tasks)
- * @since 1.1
+ *
  * @author apr@cs.com.uy
+ * @since 1.1
  */
-public class ThreadPool extends ThreadGroup implements LogSource, Loggeable, Configurable, ThreadPoolMBean
-{
-    private static int poolNumber=0;
-    private static int threadNumber=0;
+public class ThreadPool extends ThreadGroup implements LogSource, Loggeable, Configurable, ThreadPoolMBean {
+    private static AtomicInteger poolNumber = new AtomicInteger(0);
+    private static AtomicInteger threadNumber = new AtomicInteger(0);
     private int maxPoolSize = 1;
     private int available;
     private int running = 0;
-    private int active  = 0;
+    private int active = 0;
     private BlockingQueue pool = new BlockingQueue();
     private Logger logger;
     private String realm;
     private int jobs = 0;
+    private final String namePrefix;
     public static final int DEFAULT_MAX_THREADS = 100;
+
     public interface Supervised {
-        public boolean expired ();
+        public boolean expired();
     }
 
     private class PooledThread extends Thread {
         Object currentJob = null;
+        private final Object startMonitor = new Object();
+        private Boolean started = Boolean.FALSE;
 
         public PooledThread() {
-            super (ThreadPool.this,
-                "PooledThread-" + threadNumber++);
+            super(ThreadPool.this,
+                    ThreadPool.this.namePrefix + ".PooledThread-" + threadNumber.getAndIncrement());
             setDaemon(true);
         }
-        public void run () {
+
+        public void run() {
             String name = getName();
+            synchronized (startMonitor) {
+                started = Boolean.TRUE;
+                startMonitor.notifyAll();
+            }
             try {
                 while (pool.ready()) {
                     Object job = pool.dequeue();
                     if (job instanceof Runnable) {
-                        setName (name + "-running");
+                        setName(name + "-running");
                         synchronized (this) {
                             currentJob = job;
                         }
                         try {
                             active++;
                             ((Runnable) job).run();
-                            setName (name + "-idle");
+                            setName(name + "-idle");
                         } catch (Throwable t) {
-                            setName (name + "-idle-"+t.getMessage());
+                            setName(name + "-idle-" + t.getMessage());
                         }
                         synchronized (this) {
                             currentJob = null;
@@ -90,159 +100,183 @@ public class ThreadPool extends ThreadGroup implements LogSource, Loggeable, Con
             } catch (Closed e) {
             }
         }
-        public synchronized void supervise () {
-            if (currentJob != null && currentJob instanceof Supervised) 
-                if ( ((Supervised)currentJob).expired() )
+
+        public synchronized void supervise() {
+            if (currentJob != null && currentJob instanceof Supervised)
+                if (((Supervised) currentJob).expired())
                     this.interrupt();
+        }
+
+        public void awaitStartup() {
+            synchronized (startMonitor) {
+                if (!started) {
+                    try {
+                        startMonitor.wait();
+                    } catch (InterruptedException e) {
+                    }
+                }
+            }
         }
     }
 
     /**
-     * @param poolSize starting pool size
+     * @param poolSize    starting pool size
      * @param maxPoolSize maximum number of threads on this pool
      */
-    public ThreadPool (int poolSize, int maxPoolSize) {
-        this(poolSize, maxPoolSize, "ThreadPool-" + poolNumber++);
+    public ThreadPool(int poolSize, int maxPoolSize) {
+        this(poolSize, maxPoolSize, "ThreadPool");
     }
+
     /**
-     * @param name pool name
-     * @param poolSize starting pool size
+     * @param name        pool name
+     * @param poolSize    starting pool size
      * @param maxPoolSize maximum number of threads on this pool
      */
-    public ThreadPool (int poolSize, int maxPoolSize, String name) {
-        super (name + "-" + poolNumber++);
-        this.maxPoolSize = maxPoolSize > 0 ? maxPoolSize : DEFAULT_MAX_THREADS ;
+    public ThreadPool(int poolSize, int maxPoolSize, String name) {
+        super(name + "-" + poolNumber.getAndIncrement());
+        this.maxPoolSize = maxPoolSize > 0 ? maxPoolSize : DEFAULT_MAX_THREADS;
         this.available = this.maxPoolSize;
-        init (poolSize);
+        this.namePrefix = name;
+        init(poolSize);
     }
-    
-    private void init(int poolSize){
-        while (running < Math.min (poolSize > 0 ? poolSize : 1, maxPoolSize)) {
+
+    private void init(int poolSize) {
+        while (running < Math.min(poolSize > 0 ? poolSize : 1, maxPoolSize)) {
             running++;
             new PooledThread().start();
         }
     }
+
     /**
      * Default constructor for ThreadPool
      */
-    public ThreadPool () {
+    public ThreadPool() {
         this(1, DEFAULT_MAX_THREADS);
     }
-    public void close () {
+
+    public void close() {
         pool.close();
     }
-    public synchronized void execute (Runnable action) throws Closed
-    {
+
+    public synchronized void execute(Runnable action) throws Closed {
         if (!pool.ready())
             throw new Closed();
 
         if (++jobs % this.maxPoolSize == 0 || pool.consumerCount() <= 0)
             supervise();
 
-        synchronized (pool) {
-        	if (running < maxPoolSize && pool.consumerCount() <= 0) {
-            	new PooledThread().start();
-	            running++;
-    	    }
-    	}
+        if (running < maxPoolSize && pool.consumerDeficit() >= 0) {
+            PooledThread pooledThread = new PooledThread();
+            pooledThread.start();
+            pooledThread.awaitStartup();
+            running++;
+        }
         available--;
         pool.enqueue (action);
     }
-    public void dump (PrintStream p, String indent) {
+
+    public void dump(PrintStream p, String indent) {
         String inner = indent + "  ";
-        p.println (indent + "<thread-pool name=\""+getName()+"\">");
+        p.println(indent + "<thread-pool name=\"" + getName() + "\">");
         if (!pool.ready())
-            p.println (inner  + "<closed/>");
-        p.println (inner  + "<jobs>" + getJobCount() + "</jobs>");
-        p.println (inner  + "<size>" + getPoolSize() + "</size>");
-        p.println (inner  + "<max>"  + getMaxPoolSize() + "</max>");
-        p.println (inner  + "<active>" + getActiveCount() + "</active>");
-        p.println (inner  + "<idle>"  + getIdleCount() + "</idle>");
-        p.println (inner  + "<active>"  + getActiveCount() + "</active>");
-        p.println (inner  + "<pending>" + getPendingCount() + "</pending>");
-        p.println (indent + "</thread-pool>");
+            p.println(inner + "<closed/>");
+        p.println(inner + "<jobs>" + getJobCount() + "</jobs>");
+        p.println(inner + "<size>" + getPoolSize() + "</size>");
+        p.println(inner + "<max>" + getMaxPoolSize() + "</max>");
+        p.println(inner + "<active>" + getActiveCount() + "</active>");
+        p.println(inner + "<idle>" + getIdleCount() + "</idle>");
+        p.println(inner + "<active>" + getActiveCount() + "</active>");
+        p.println(inner + "<pending>" + getPendingCount() + "</pending>");
+        p.println(indent + "</thread-pool>");
     }
 
     /**
      * @return number of jobs processed by this pool
      */
-    public int getJobCount () {
+    public int getJobCount() {
         return jobs;
     }
+
     /**
      * @return number of running threads
      */
-    public int getPoolSize () {
+    public int getPoolSize() {
         return running;
     }
+
     /**
      * @return max number of active threads allowed
      */
-    public int getMaxPoolSize () {
+    public int getMaxPoolSize() {
         return maxPoolSize;
     }
+
     /**
      * @return number of active threads
      */
-    public int getActiveCount () {
+    public int getActiveCount() {
         return active;
     }
+
     /**
      * @return number of idle threads
      */
-    public int getIdleCount () {
-        return pool.consumerCount ();
+    public int getIdleCount() {
+        return pool.consumerCount();
     }
+
     /**
      * @return number of available threads
      */
-    synchronized public int getAvailableCount () {
+    synchronized public int getAvailableCount() {
         return available;
     }
 
     /**
      * @return number of Pending jobs
      */
-    public int getPendingCount () {
-        return pool.pending ();
+    public int getPendingCount() {
+        return pool.pending();
     }
 
-    public void supervise () {
+    public void supervise() {
         Thread[] t = new Thread[maxPoolSize];
-        int cnt = enumerate (t);
-        for (int i=0; i<cnt; i++) 
+        int cnt = enumerate(t);
+        for (int i = 0; i < cnt; i++)
             if (t[i] instanceof PooledThread)
                 ((PooledThread) t[i]).supervise();
     }
 
-    public void setLogger (Logger logger, String realm) {
+    public void setLogger(Logger logger, String realm) {
         this.logger = logger;
-        this.realm  = realm;
+        this.realm = realm;
     }
-    public String getRealm () {
+
+    public String getRealm() {
         return realm;
     }
+
     public Logger getLogger() {
         return logger;
     }
-    
-   /** 
-    * @param cfg Configuration object
-    * @throws ConfigurationException
-    */
+
+    /**
+     * @param cfg Configuration object
+     * @throws ConfigurationException
+     */
     public void setConfiguration(Configuration cfg) throws ConfigurationException {
         maxPoolSize = cfg.getInt("max-size", DEFAULT_MAX_THREADS);
-        init (cfg.getInt("initial-size"));
+        init(cfg.getInt("initial-size"));
     }
-    
-    /** 
+
+    /**
      * Retrieves a thread pool from NameRegistrar given its name, unique identifier.
      *
      * @param name Name of the thread pool to retrieve, must be the same as the name property of the thread-pool tag in the QSP config file
-     * @throws NotFoundException thrown when there is not a thread-pool registered under this name.
      * @return returns the retrieved instance of thread pool
-     */    
+     * @throws NotFoundException thrown when there is not a thread-pool registered under this name.
+     */
     public static ThreadPool getThreadPool(java.lang.String name) throws NotFoundException {
-        return (ThreadPool)NameRegistrar.get("thread.pool." + name);
+        return (ThreadPool) NameRegistrar.get("thread.pool." + name);
     }
 }

--- a/jpos/src/main/java/org/jpos/util/ThreadPool.java
+++ b/jpos/src/main/java/org/jpos/util/ThreadPool.java
@@ -30,59 +30,53 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Implements a ThreadPool with the ability to run simple Runnable
  * tasks as well as Jobs (supervised Runnable tasks)
- *
- * @author apr@cs.com.uy
  * @since 1.1
+ * @author apr@cs.com.uy
  */
 public class ThreadPool extends ThreadGroup implements LogSource, Loggeable, Configurable, ThreadPoolMBean {
+    
     private static AtomicInteger poolNumber = new AtomicInteger(0);
     private static AtomicInteger threadNumber = new AtomicInteger(0);
     private int maxPoolSize = 1;
     private int available;
     private int running = 0;
-    private int active = 0;
+    private int active  = 0;
     private BlockingQueue pool = new BlockingQueue();
     private Logger logger;
     private String realm;
     private int jobs = 0;
     private final String namePrefix;
     public static final int DEFAULT_MAX_THREADS = 100;
-
+    
     public interface Supervised {
-        public boolean expired();
+        public boolean expired ();
     }
 
     private class PooledThread extends Thread {
         Object currentJob = null;
-        private final Object startMonitor = new Object();
-        private Boolean started = Boolean.FALSE;
 
         public PooledThread() {
-            super(ThreadPool.this,
+            super (ThreadPool.this,
                     ThreadPool.this.namePrefix + ".PooledThread-" + threadNumber.getAndIncrement());
             setDaemon(true);
         }
 
-        public void run() {
+        public void run () {
             String name = getName();
-            synchronized (startMonitor) {
-                started = Boolean.TRUE;
-                startMonitor.notifyAll();
-            }
             try {
                 while (pool.ready()) {
                     Object job = pool.dequeue();
                     if (job instanceof Runnable) {
-                        setName(name + "-running");
+                        setName (name + "-running");
                         synchronized (this) {
                             currentJob = job;
                         }
                         try {
                             active++;
                             ((Runnable) job).run();
-                            setName(name + "-idle");
+                            setName (name + "-idle");
                         } catch (Throwable t) {
-                            setName(name + "-idle-" + t.getMessage());
+                            setName (name + "-idle-"+t.getMessage());
                         }
                         synchronized (this) {
                             currentJob = null;
@@ -100,65 +94,49 @@ public class ThreadPool extends ThreadGroup implements LogSource, Loggeable, Con
             } catch (Closed e) {
             }
         }
-
-        public synchronized void supervise() {
-            if (currentJob != null && currentJob instanceof Supervised)
-                if (((Supervised) currentJob).expired())
+        public synchronized void supervise () {
+            if (currentJob != null && currentJob instanceof Supervised) 
+                if ( ((Supervised)currentJob).expired() )
                     this.interrupt();
         }
-
-        public void awaitStartup() {
-            synchronized (startMonitor) {
-                if (!started) {
-                    try {
-                        startMonitor.wait();
-                    } catch (InterruptedException e) {
-                    }
-                }
-            }
-        }
     }
 
     /**
-     * @param poolSize    starting pool size
+     * @param poolSize starting pool size
      * @param maxPoolSize maximum number of threads on this pool
      */
-    public ThreadPool(int poolSize, int maxPoolSize) {
+    public ThreadPool (int poolSize, int maxPoolSize) {
         this(poolSize, maxPoolSize, "ThreadPool");
     }
-
     /**
-     * @param name        pool name
-     * @param poolSize    starting pool size
+     * @param name pool name
+     * @param poolSize starting pool size
      * @param maxPoolSize maximum number of threads on this pool
      */
-    public ThreadPool(int poolSize, int maxPoolSize, String name) {
+    public ThreadPool (int poolSize, int maxPoolSize, String name) {
         super(name + "-" + poolNumber.getAndIncrement());
-        this.maxPoolSize = maxPoolSize > 0 ? maxPoolSize : DEFAULT_MAX_THREADS;
+        this.maxPoolSize = maxPoolSize > 0 ? maxPoolSize : DEFAULT_MAX_THREADS ;
         this.available = this.maxPoolSize;
         this.namePrefix = name;
-        init(poolSize);
+        init (poolSize);
     }
-
-    private void init(int poolSize) {
-        while (running < Math.min(poolSize > 0 ? poolSize : 1, maxPoolSize)) {
+    
+    private void init(int poolSize){
+        while (running < Math.min (poolSize > 0 ? poolSize : 1, maxPoolSize)) {
             running++;
             new PooledThread().start();
         }
     }
-
     /**
      * Default constructor for ThreadPool
      */
-    public ThreadPool() {
+    public ThreadPool () {
         this(1, DEFAULT_MAX_THREADS);
     }
-
-    public void close() {
+    public void close () {
         pool.close();
     }
-
-    public synchronized void execute(Runnable action) throws Closed {
+    public synchronized void execute(Runnable action) throws Closed {        
         if (!pool.ready())
             throw new Closed();
 
@@ -166,117 +144,107 @@ public class ThreadPool extends ThreadGroup implements LogSource, Loggeable, Con
             supervise();
 
         if (running < maxPoolSize && pool.consumerDeficit() >= 0) {
-            PooledThread pooledThread = new PooledThread();
-            pooledThread.start();
-            pooledThread.awaitStartup();
+            new PooledThread().start();
             running++;
         }
         available--;
         pool.enqueue (action);
     }
-
-    public void dump(PrintStream p, String indent) {
+    public void dump (PrintStream p, String indent) {
         String inner = indent + "  ";
-        p.println(indent + "<thread-pool name=\"" + getName() + "\">");
+        p.println (indent + "<thread-pool name=\""+getName()+"\">");
         if (!pool.ready())
-            p.println(inner + "<closed/>");
-        p.println(inner + "<jobs>" + getJobCount() + "</jobs>");
-        p.println(inner + "<size>" + getPoolSize() + "</size>");
-        p.println(inner + "<max>" + getMaxPoolSize() + "</max>");
-        p.println(inner + "<active>" + getActiveCount() + "</active>");
-        p.println(inner + "<idle>" + getIdleCount() + "</idle>");
-        p.println(inner + "<active>" + getActiveCount() + "</active>");
-        p.println(inner + "<pending>" + getPendingCount() + "</pending>");
-        p.println(indent + "</thread-pool>");
+            p.println (inner  + "<closed/>");
+        p.println (inner  + "<jobs>" + getJobCount() + "</jobs>");
+        p.println (inner  + "<size>" + getPoolSize() + "</size>");
+        p.println (inner  + "<max>"  + getMaxPoolSize() + "</max>");
+        p.println (inner  + "<active>" + getActiveCount() + "</active>");
+        p.println (inner  + "<idle>"  + getIdleCount() + "</idle>");
+        p.println (inner  + "<active>"  + getActiveCount() + "</active>");
+        p.println (inner  + "<pending>" + getPendingCount() + "</pending>");
+        p.println (indent + "</thread-pool>");
     }
 
     /**
      * @return number of jobs processed by this pool
      */
-    public int getJobCount() {
+    public int getJobCount () {
         return jobs;
     }
-
     /**
      * @return number of running threads
      */
-    public int getPoolSize() {
+    public int getPoolSize () {
         return running;
     }
-
     /**
      * @return max number of active threads allowed
      */
-    public int getMaxPoolSize() {
+    public int getMaxPoolSize () {
         return maxPoolSize;
     }
-
     /**
      * @return number of active threads
      */
-    public int getActiveCount() {
+    public int getActiveCount () {
         return active;
     }
-
     /**
      * @return number of idle threads
      */
-    public int getIdleCount() {
-        return pool.consumerCount();
+    public int getIdleCount () {
+        return pool.consumerCount ();
     }
-
     /**
      * @return number of available threads
      */
-    synchronized public int getAvailableCount() {
+    synchronized public int getAvailableCount () {
         return available;
     }
 
     /**
      * @return number of Pending jobs
      */
-    public int getPendingCount() {
-        return pool.pending();
+    public int getPendingCount () {
+        return pool.pending ();
     }
 
-    public void supervise() {
+    public void supervise () {
         Thread[] t = new Thread[maxPoolSize];
-        int cnt = enumerate(t);
-        for (int i = 0; i < cnt; i++)
+        int cnt = enumerate (t);
+        for (int i=0; i<cnt; i++) 
             if (t[i] instanceof PooledThread)
                 ((PooledThread) t[i]).supervise();
     }
 
-    public void setLogger(Logger logger, String realm) {
+    public void setLogger (Logger logger, String realm) {
         this.logger = logger;
-        this.realm = realm;
+        this.realm  = realm;
     }
-
-    public String getRealm() {
+    public String getRealm () {
         return realm;
     }
-
     public Logger getLogger() {
         return logger;
     }
-
-    /**
-     * @param cfg Configuration object
-     * @throws ConfigurationException
-     */
+    
+   /** 
+    * @param cfg Configuration object
+    * @throws ConfigurationException
+    */
     public void setConfiguration(Configuration cfg) throws ConfigurationException {
         maxPoolSize = cfg.getInt("max-size", DEFAULT_MAX_THREADS);
-        init(cfg.getInt("initial-size"));
+        init (cfg.getInt("initial-size"));
     }
-
-    /**
+    
+    /** 
      * Retrieves a thread pool from NameRegistrar given its name, unique identifier.
      *
      * @param name Name of the thread pool to retrieve, must be the same as the name property of the thread-pool tag in the QSP config file
-     * @return returns the retrieved instance of thread pool
      * @throws NotFoundException thrown when there is not a thread-pool registered under this name.
-     */
+     * @return returns the retrieved instance of thread pool
+     */    
     public static ThreadPool getThreadPool(java.lang.String name) throws NotFoundException {
-        return (ThreadPool) NameRegistrar.get("thread.pool." + name);
+        return (ThreadPool)NameRegistrar.get("thread.pool." + name);
     }
 }

--- a/jpos/src/test/java/org/jpos/util/ThreadPoolTest.java
+++ b/jpos/src/test/java/org/jpos/util/ThreadPoolTest.java
@@ -137,20 +137,17 @@ public class ThreadPoolTest {
     public void testConcurrentThreadAllocation() throws Throwable {
         ThreadPool pool = new ThreadPool(1, 200, "Test-ThreadPool");
         Server server = new Server(pool);
-
         Thread serverThread = new Thread(server);
         serverThread.start();
-
-        Thread.sleep(3000);
+        serverThread.join(3000);
+        serverThread.interrupt();
         
         assertEquals("pool.getActiveCount()", 100, pool.getActiveCount());
         
         synchronized (server) {
             server.notifyAll();
         }
-
-        serverThread.join(3000);
-        serverThread.interrupt();
+        pool.close();
     }
 
     private static class Job implements Runnable {
@@ -182,8 +179,9 @@ public class ThreadPoolTest {
 
         @Override
         public void run() {
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 100; i++) {
                 pool.execute(new Job(i, this));
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/util/ThreadPoolTest.java
+++ b/jpos/src/test/java/org/jpos/util/ThreadPoolTest.java
@@ -19,18 +19,18 @@
 package org.jpos.util;
 
 import org.jpos.iso.ISOUtil;
-import org.junit.Test;
-import org.mockito.internal.matchers.Matches;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.mockito.internal.matchers.Matches;
 
 public class ThreadPoolTest {
 
     static class TestTask implements Runnable {
-        public void run() {
-            ISOUtil.sleep(500);
-        }
+      public void run() {
+        ISOUtil.sleep(500);
+      }
     }
 
     @Test
@@ -129,7 +129,7 @@ public class ThreadPoolTest {
         ISOUtil.sleep(20);
         Thread[] tl = new Thread[threadPool.activeCount()];
         threadPool.enumerate(tl);
-        for (Thread t : tl)
+        for (Thread t :tl )
             assertThat(t.getName(), new Matches("ThreadPool.PooledThread-\\d+-(running|idle)"));
     }
 

--- a/jpos/src/test/java/org/jpos/util/ThreadPoolTest.java
+++ b/jpos/src/test/java/org/jpos/util/ThreadPoolTest.java
@@ -139,9 +139,11 @@ public class ThreadPoolTest {
         Server server = new Server(pool);
         Thread serverThread = new Thread(server);
         serverThread.start();
-        serverThread.join(3000);
+
+        serverThread.join(1000);
         serverThread.interrupt();
-        
+
+        Thread.sleep(1000);
         assertEquals("pool.getActiveCount()", 100, pool.getActiveCount());
         
         synchronized (server) {


### PR DESCRIPTION
Bug scenario:
1. An ISO server receiving 2 connections on the same port
2. When the ISO Server is deployed, there are client channels trying to connect every 1 second. Race condition issue possible when both connections come in around the same time.
3. The ISO server receives both connections and creates the Session object, but the thread pool creates only 1 thread