### PR TITLE
Dont throw ISOException for a field not present

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOMsg.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOMsg.java
@@ -540,6 +540,11 @@ public class ISOMsg extends ISOComponent
         for (;;) {
             int fldno = Integer.parseInt(st.nextToken());
             obj = m.getValue (fldno);
+             if (obj==null){
+                // The user will always get a null value for an incorrect path or path not present in the message
+                // no point having the ISOException thrown for fields that were not received.
+                break;
+            }
             if (st.hasMoreTokens()) {
                 if (obj instanceof ISOMsg) {
                     m = (ISOMsg) obj;


### PR DESCRIPTION
If a field doesn't exist in the message dont throw an ISOException, instead return null. An example is a field of type say XXX.YY. If XXX is not present don't throw an ISOException, instead return null. If you use a ``` getString(String fpath)``` you dont get an ISOException but if you used getValue you would. Now both behave the same though the method signature is not changed.