### PR TITLE
There is no reason to declare never thrown ISOException

### DIFF
--- a/jpos/src/main/java/org/jpos/core/CardHolder.java
+++ b/jpos/src/main/java/org/jpos/core/CardHolder.java
@@ -108,24 +108,20 @@ public class CardHolder implements Cloneable, Serializable, Loggeable {
         throws InvalidCardException
     {
         super();
-        try {
-            if (m.hasField(35))
-                parseTrack2 ((String) m.getValue(35));
-            else if (m.hasField(2)) {
-                setPAN ((String) m.getValue(2));
-                if (m.hasField (14))
-                    setEXP ((String) m.getValue(14));
-            } else {
-                throw new InvalidCardException("required fields not present");
-            }
-            if (m.hasField(45)) {
-                setTrack1((String) m.getValue(45));
-            }
-            if (m.hasField(55)) {
-                setSecurityCode (m.getString(55));
-            }
-        } catch (ISOException e) {
-            throw new InvalidCardException();
+        if (m.hasField(35))
+            parseTrack2((String) m.getValue(35));
+        else if (m.hasField(2)) {
+            setPAN((String) m.getValue(2));
+            if (m.hasField(14))
+                setEXP((String) m.getValue(14));
+        } else {
+            throw new InvalidCardException("required fields not present");
+        }
+        if (m.hasField(45)) {
+            setTrack1((String) m.getValue(45));
+        }
+        if (m.hasField(55)) {
+            setSecurityCode(m.getString(55));
         }
     }
 

--- a/jpos/src/main/java/org/jpos/iso/ISOMsg.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOMsg.java
@@ -213,14 +213,20 @@ public class ISOMsg extends ISOComponent
             dirty = true;
         }
     }
-   /**
-    * Creates an ISOField associated with fldno within this ISOMsg
-    * @param fldno field number
-    * @param value field value
-    * @throws ISOException on error
-    */
-    public void set(int fldno, String value) throws ISOException {
-        if (value != null) {
+
+    /**
+     * Creates an ISOField associated with fldno within this ISOMsg.
+     *
+     * @param fldno field number
+     * @param value field value
+     */
+    public void set(int fldno, String value) {
+        if (value == null) {
+            unset(fldno);
+            return;
+        }
+
+        try {
             if (!(packager instanceof ISOBasePackager)) {
                 // No packager is available, we can't tell what the field
                 // might be, so treat as a String!
@@ -235,18 +241,16 @@ public class ISOMsg extends ISOComponent
                     set(new ISOField(fldno, value));
                 }
             }
-        }
-        else
-            unset(fldno);
+        } catch (ISOException ex) {}; //NOPMD: never happens for the given arguments of set methods
     }
 
-   /**
-    * Creates an ISOField associated with fldno within this ISOMsg
-    * @param fpath dot-separated field path (i.e. 63.2)
-    * @param value field value
-    * @throws ISOException on error
-    */
-    public void set (String fpath, String value) throws ISOException {
+    /**
+     * Creates an ISOField associated with fldno within this ISOMsg.
+     *
+     * @param fpath dot-separated field path (i.e. 63.2)
+     * @param value field value
+     */
+    public void set(String fpath, String value) {
         StringTokenizer st = new StringTokenizer (fpath, ".");
         ISOMsg m = this;
         for (;;) {
@@ -256,18 +260,20 @@ public class ISOMsg extends ISOComponent
                 if (obj instanceof ISOMsg)
                     m = (ISOMsg) obj;
                 else
-                    /* 
+                    /**
                      * we need to go deeper, however, if the value == null then
                      * there is nothing to do (unset) at the lower levels, so break now and save some processing.
                      */
                     if (value == null) {
                         break;
                     } else {
-                        // We have a value to set, so adding a level to hold it is sensible.
-                        m.set (m = new ISOMsg (fldno));
+                        try {
+                            // We have a value to set, so adding a level to hold it is sensible.
+                            m.set(m = new ISOMsg (fldno));
+                        } catch (ISOException ex) {} //NOPMD: never happens for the given arguments of set methods
                     }
             } else {
-                m.set (fldno, value);
+                m.set(fldno, value);
                 break;
             }
         }
@@ -305,15 +311,14 @@ public class ISOMsg extends ISOComponent
              }
          }
      }
-    
-   
-   /**
-    * Creates an ISOField associated with fldno within this ISOMsg
-    * @param fpath dot-separated field path (i.e. 63.2)
-    * @param value binary field value
-    * @throws ISOException on error
-    */
-    public void set (String fpath, byte[] value) throws ISOException {
+
+    /**
+     * Creates an ISOField associated with fldno within this ISOMsg.
+     *
+     * @param fpath dot-separated field path (i.e. 63.2)
+     * @param value binary field value
+     */
+    public void set(String fpath, byte[] value) {
         StringTokenizer st = new StringTokenizer (fpath, ".");
         ISOMsg m = this;
         for (;;) {
@@ -323,24 +328,31 @@ public class ISOMsg extends ISOComponent
                 if (obj instanceof ISOMsg)
                     m = (ISOMsg) obj;
                 else
-                    m.set (m = new ISOMsg (fldno));
+                    try {
+                        m.set(m = new ISOMsg (fldno));
+                    } catch (ISOException ex) {} //NOPMD: never happens for the given arguments of set methods
             } else {
-                m.set (fldno, value);
+                m.set(fldno, value);
                 break;
             }
         }
     }
-   /**
-    * Creates an ISOBinaryField associated with fldno within this ISOMsg
-    * @param fldno field number
-    * @param value field value
-    * @throws ISOException on error
-    */
-    public void set (int fldno, byte[] value) throws ISOException {
-        if (value != null)
-            set (new ISOBinaryField (fldno, value));
-        else
-            unset (fldno);
+
+    /**
+     * Creates an ISOBinaryField associated with fldno within this ISOMsg.
+     *
+     * @param fldno field number
+     * @param value field value
+     */
+    public void set(int fldno, byte[] value) {
+        if (value == null) {
+            unset(fldno);
+            return;
+        }
+
+        try {
+            set(new ISOBinaryField(fldno, value));
+        } catch (ISOException ex) {}; //NOPMD: never happens for the given arguments of set methods
     }
 
 
@@ -361,12 +373,13 @@ public class ISOMsg extends ISOComponent
         for (int fld : flds)
             unset(fld);
     }
+
     /**
      * Unset a field referenced by a fpath if it exists, otherwise ignore.
+     *
      * @param fpath dot-separated field path (i.e. 63.2)
-     * @throws ISOException on error
-    */
-    public void unset (String fpath) throws ISOException {
+     */
+    public void unset(String fpath) {
         StringTokenizer st = new StringTokenizer (fpath, ".");
         ISOMsg m = this;
         ISOMsg lastm = m;
@@ -382,7 +395,7 @@ public class ISOMsg extends ISOComponent
                     m = (ISOMsg) obj;
                 }
                 else {
-                    // No real way of unset further subfield, exit.  Perhaps should be ISOException?
+                    // No real way of unset further subfield, exit.
                     break;
                 }
             } else {
@@ -521,11 +534,14 @@ public class ISOMsg extends ISOComponent
      * Return the object value associated with the given field number
      * @param fldno the Field Number
      * @return the field Object
-     * @throws ISOException on error
      */
-    public Object getValue(int fldno) throws ISOException {
+    public Object getValue(int fldno) {
         ISOComponent c = getComponent(fldno);
-        return c != null ? c.getValue() : null;
+        try {
+            return c != null ? c.getValue() : null;
+        } catch (ISOException ex) {
+            return null; //never happens for the given arguments of getValue method
+        }
     }
     /**
      * Return the object value associated with the given field path
@@ -588,15 +604,11 @@ public class ISOMsg extends ISOComponent
     public String getString (int fldno) {
         String s = null;
         if (hasField (fldno)) {
-            try {
-                Object obj = getValue(fldno);
-                if (obj instanceof String)
-                    s = (String) obj;
-                else if (obj instanceof byte[])
-                    s = ISOUtil.hexString ((byte[]) obj);
-            } catch (ISOException e) {
-                return null; // make PMD happy by returning here and avoiding an empty catch
-            }
+            Object obj = getValue(fldno);
+            if (obj instanceof String)
+                s = (String) obj;
+            else if (obj instanceof byte[])
+                s = ISOUtil.hexString((byte[]) obj);
         }
         return s;
     }
@@ -626,15 +638,11 @@ public class ISOMsg extends ISOComponent
     public byte[] getBytes (int fldno) {
         byte[] b = null;
         if (hasField (fldno)) {
-            try {
-                Object obj = getValue(fldno);
-                if (obj instanceof String)
-                    b = ((String) obj).getBytes(ISOUtil.CHARSET);
-                else if (obj instanceof byte[])
-                    b = (byte[]) obj;
-            } catch (ISOException ignored) {
-                return null;
-            }
+            Object obj = getValue(fldno);
+            if (obj instanceof String)
+                b = ((String) obj).getBytes(ISOUtil.CHARSET);
+            else if (obj instanceof byte[])
+                b = (byte[]) obj;
         }
         return b;
     }

--- a/jpos/src/main/java/org/jpos/iso/filter/ChannelInfoFilter.java
+++ b/jpos/src/main/java/org/jpos/iso/filter/ChannelInfoFilter.java
@@ -55,33 +55,30 @@ public class ChannelInfoFilter implements ISOFilter, Configurable {
         socketInfoField  = cfg.get("socket-info", null);
     }
 
+    @Override
     public ISOMsg filter (ISOChannel channel, ISOMsg m, LogEvent evt) {
-        try {
-            if (channelNameField != null)
-                m.set (channelNameField, channel.getName());
-            if (socketInfoField != null && channel instanceof BaseChannel) {
-                Socket socket = ((BaseChannel)channel).getSocket();
-                InetSocketAddress remoteAddr = 
-                    (InetSocketAddress) socket.getRemoteSocketAddress();
-                InetSocketAddress localAddr = 
-                    (InetSocketAddress) socket.getLocalSocketAddress();
+        if (channelNameField != null)
+            m.set(channelNameField, channel.getName());
+        if (socketInfoField != null && channel instanceof BaseChannel) {
+            Socket socket = ((BaseChannel) channel).getSocket();
+            InetSocketAddress remoteAddr =
+                (InetSocketAddress) socket.getRemoteSocketAddress();
+            InetSocketAddress localAddr =
+                (InetSocketAddress) socket.getLocalSocketAddress();
 
-                StringBuilder sb = new StringBuilder();
-                if (socketInfoField.equals(channelNameField)) {
-                    sb.append (channel.getName());
-                    sb.append (' ');
-                }
-                sb.append (localAddr.getAddress().getHostAddress());
-                sb.append (':');
-                sb.append (Integer.toString (localAddr.getPort()));
-                sb.append (' ');
-                sb.append (remoteAddr.getAddress().getHostAddress());
-                sb.append (':');
-                sb.append (Integer.toString (remoteAddr.getPort()));
-                m.set (socketInfoField, sb.toString());
+            StringBuilder sb = new StringBuilder();
+            if (socketInfoField.equals(channelNameField)) {
+                sb.append(channel.getName());
+                sb.append(' ');
             }
-        } catch (ISOException e) {
-            evt.addMessage (e);
+            sb.append(localAddr.getAddress().getHostAddress());
+            sb.append(':');
+            sb.append(Integer.toString (localAddr.getPort()));
+            sb.append(' ');
+            sb.append(remoteAddr.getAddress().getHostAddress());
+            sb.append(':');
+            sb.append(Integer.toString (remoteAddr.getPort()));
+            m.set (socketInfoField, sb.toString());
         }
         return m;
     }

--- a/jpos/src/main/java/org/jpos/iso/gui/ISOMsgPanel.java
+++ b/jpos/src/main/java/org/jpos/iso/gui/ISOMsgPanel.java
@@ -74,12 +74,17 @@ public class ISOMsgPanel extends JPanel {
         TableModel dataModel = new AbstractTableModel() {
 
             private static final long serialVersionUID = 8917029825751856951L;
+
+            @Override
             public int getColumnCount() {
                 return 3;
             }
+
+            @Override
             public int getRowCount() {
                 return validFields.size();
             }
+
             @Override
             public String getColumnName(int columnIndex) {
                 switch (columnIndex) {
@@ -93,39 +98,36 @@ public class ISOMsgPanel extends JPanel {
                         return "";
                 }
             }
+
+            @Override
             public Object getValueAt(int row, int col) {
                 switch (col) {
                     case 0 :
                         return validFields.elementAt(row);
                     case 1 :
-                        try {
-                            int index =
-                                    (Integer) validFields.elementAt(row);
+                        int index = (Integer) validFields.elementAt(row);
 
-                            Object obj = m.getValue(index);
-                            if (obj instanceof String) {
-                                String s = obj.toString();
-                                switch (index) {
-                                    case 2 :
-                                    case 35:
-                                    case 45:
-                                        s = ISOUtil.protect (s);
-                                        break;
-                                    case 14:
-                                        s = "----";
-                                }
-                                return s;
+                        Object obj = m.getValue(index);
+                        if (obj instanceof String) {
+                            String s = obj.toString();
+                            switch (index) {
+                                case 2 :
+                                case 35:
+                                case 45:
+                                    s = ISOUtil.protect(s);
+                                    break;
+                                case 14:
+                                    s = "----";
                             }
-                            else if (obj instanceof byte[])
-                                return ISOUtil.hexString((byte[]) obj);
-                            else if (obj instanceof ISOMsg)
-                                return "<ISOMsg>";
-                        } catch (ISOException e) {
-                            e.printStackTrace();
-                        }   
+                            return s;
+                        }
+                        else if (obj instanceof byte[])
+                            return ISOUtil.hexString((byte[]) obj);
+                        else if (obj instanceof ISOMsg)
+                            return "<ISOMsg>";
                         break;
                     case 2 :
-                        int i= (Integer) validFields.elementAt(row);
+                        int i = (Integer) validFields.elementAt(row);
                         ISOPackager p = m.getPackager();
                         return p.getFieldDescription(m,i);
                 }
@@ -148,22 +150,18 @@ public class ISOMsgPanel extends JPanel {
                     (ListSelectionModel)e.getSource();
                 if (!lsm.isSelectionEmpty()) {
                     int selectedRow = lsm.getMinSelectionIndex();
-                    try {
-                        int index = (Integer)
-                                validFields.elementAt(selectedRow);
+                    int index = (Integer)
+                            validFields.elementAt(selectedRow);
 
-                        Object obj = m.getValue(index);
-                        if (obj instanceof ISOMsg) {
-                            ISOMsg sm = (ISOMsg) obj;
-                            JFrame f = new JFrame("ISOMsg field "+index);
-                            ISOMsgPanel p = new ISOMsgPanel(sm, false);
-                            f.getContentPane().add(p);
-                            f.pack();
-                            f.show();
-                        }
-                    } catch (ISOException ex) {
-                        ex.printStackTrace();
-                    }   
+                    Object obj = m.getValue(index);
+                    if (obj instanceof ISOMsg) {
+                        ISOMsg sm = (ISOMsg) obj;
+                        JFrame f = new JFrame("ISOMsg field "+index);
+                        ISOMsgPanel p = new ISOMsgPanel(sm, false);
+                        f.getContentPane().add(p);
+                        f.pack();
+                        f.show();
+                    }
                 }
             }
         });

--- a/jpos/src/main/java/org/jpos/tlv/ISOMsgRef.java
+++ b/jpos/src/main/java/org/jpos/tlv/ISOMsgRef.java
@@ -227,12 +227,12 @@ public class ISOMsgRef {
         }
 
         @Override
-        public void set(int fldno, String value) throws ISOException {
+        public void set(int fldno, String value) {
             delegate.set(fldno, value);
         }
 
         @Override
-        public void set(String fpath, String value) throws ISOException {
+        public void set(String fpath, String value) {
             delegate.set(fpath, value);
         }
 
@@ -242,12 +242,12 @@ public class ISOMsgRef {
         }
 
         @Override
-        public void set(String fpath, byte[] value) throws ISOException {
+        public void set(String fpath, byte[] value) {
             delegate.set(fpath, value);
         }
 
         @Override
-        public void set(int fldno, byte[] value) throws ISOException {
+        public void set(int fldno, byte[] value) {
             delegate.set(fldno, value);
         }
 
@@ -257,7 +257,7 @@ public class ISOMsgRef {
         }
 
         @Override
-        public void unset(String fpath) throws ISOException {
+        public void unset(String fpath) {
             delegate.unset(fpath);
         }
 
@@ -272,7 +272,7 @@ public class ISOMsgRef {
         }
 
         @Override
-        public Object getValue(int fldno) throws ISOException {
+        public Object getValue(int fldno) {
             return delegate.getValue(fldno);
         }
 


### PR DESCRIPTION
In `ISOMsg` methods `set` and `unset` declare never thrown `ISOException`.
This leads to the introduction of many lines of boilerplate code at
calling that methods.
An example:
```java
  ISOMsg m = new ISOMsg("1120");
  try {
      m.set(39, "000");
  } catch (ISOException iggore) {} //NOPMD: never thrown
```
This change removes that unnececary declarations. **As a side effect it
can cause not compiling code.** It may be necessary to remove unnecesary
handling of `ISOException` (As a result simplifying that calls). Examples in
`CardHolder.java`, `ChannelInfoFilter.java` and `ISOMsgPanel.java`