### PR TITLE
Update ISOTaggedField.java

### DIFF
--- a/jpos/src/main/java/org/jpos/tlv/ISOTaggedField.java
+++ b/jpos/src/main/java/org/jpos/tlv/ISOTaggedField.java
@@ -142,7 +142,10 @@ public class ISOTaggedField extends ISOComponent {
             delegate.dump(ps, "");
 
             String s = new String(baos.toByteArray());
-            if (s.endsWith("\r") || s.endsWith("\n") || s.endsWith("\r\n")) {
+            if ( s.endsWith("\r\n")) {
+                s = s.substring(0, s.length() - 2);
+            }
+            else if (s.endsWith("\r") || s.endsWith("\n") ) {
                 s = s.substring(0, s.length() - 1);
             }
             p.print(s);


### PR DESCRIPTION
On a windows system, the end tag is not aligned correctly due to the removal of only one char from the \r\n sequence.