### PR TITLE
Converted into functional interface 

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOResponseListener.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOResponseListener.java
@@ -17,9 +17,11 @@
  */
 
 package org.jpos.iso;
-
+@FunctionalInterface
 public interface ISOResponseListener {
     void responseReceived (ISOMsg resp, Object handBack);
-    void expired (Object handBack);
+    default void expired (Object handBack){
+        responseReceived(null, handBack);
+    }
 }
 


### PR DESCRIPTION
Converted into functional interface by providing a default implementation of expired() method.