### PR TITLE
Serialization of a Configurable object enabled

### DIFF
--- a/jpos/src/main/java/org/jpos/core/Configurable.java
+++ b/jpos/src/main/java/org/jpos/core/Configurable.java
@@ -19,13 +19,15 @@
 package org.jpos.core;
 
 
+import java.io.Serializable;
+
 /**
  * Object is Configurable
  * @author <a href="mailto:apr@cs.com.uy">Alejandro P. Revilla</a>
  * @version $Revision$ $Date$
  * @since jPOS 1.2
  */
-public interface Configurable {
+public interface Configurable extends Serializable {
    /**
     * @param cfg Configuration object
     * @throws ConfigurationException

--- a/jpos/src/main/java/org/jpos/core/XmlConfigurable.java
+++ b/jpos/src/main/java/org/jpos/core/XmlConfigurable.java
@@ -20,13 +20,15 @@ package org.jpos.core;
 
 import org.jdom2.Element;
 
+import java.io.Serializable;
+
 /**
  * Object is Configurable by an Xml Element
  * @author <a href="mailto:apr@cs.com.uy">Alejandro P. Revilla</a>
  * @version $Revision$ $Date$
  * @since jPOS 1.4.9
  */
-public interface XmlConfigurable {
+public interface XmlConfigurable extends Serializable {
    /**
     * @param e Configuration element
     * @throws ConfigurationException on error


### PR DESCRIPTION
There is need to serialize Configurable and XMLConfigurable objects.
In example to persist them.