### PR TITLE
In order to enable Configuration serialization.

### DIFF
--- a/jpos/src/main/java/org/jpos/core/Configuration.java
+++ b/jpos/src/main/java/org/jpos/core/Configuration.java
@@ -19,6 +19,7 @@
 package org.jpos.core;
 
 
+import java.io.Serializable;
 import java.util.Set;
 
 /**
@@ -29,7 +30,7 @@ import java.util.Set;
  * CardAgents relies on a Configuration object to provide
  * runtime configuration parameters such as merchant number, etc.
  */
-public interface Configuration {
+public interface Configuration extends Serializable {
     String get(String propertyName);
     /**
      * @param propertyName  ditto


### PR DESCRIPTION
In order to persist/send through network an Object that contains injected `Configuration` or `Configuration` itself.
