### PR TITLE
Avoid possible NPE when throwing ISOExceptions

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
@@ -330,10 +330,17 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                         evt.addMessage(e);
                     }
                     // jPOS-3
-                    e = new ISOException (
-                        String.format ("%s (%s) unpacking field=%d, consumed=%d",
-                        e.getMessage(), e.getNested().toString(), i, consumed)
-                    );
+                    if (e.getNested() == null) {
+                        e = new ISOException(
+                            String.format("%s unpacking field=%d, consumed=%d",
+                            e.getMessage(), i, consumed)
+                        );
+                    } else {
+                        e = new ISOException(
+                            String.format("%s (%s) unpacking field=%d, consumed=%d",
+                            e.getMessage(), e.getNested().toString(), i, consumed)
+                        );
+                    }
                     throw e;
                 }
             } // for each field


### PR DESCRIPTION
While testing what would happen if a field was present in the bitmap but not configured in the "isopackager" XML file, I noticed that the original exception was lost because of an NPE. All I got in the end was a confusing message `null` instead of the more helpful `field packager '8' is null`. This should now be fixed :)