### PR TITLE
Added activeTransactions counter in TransactionManager

### DIFF
--- a/jpos/src/main/java/org/jpos/transaction/TransactionManagerMBean.java
+++ b/jpos/src/main/java/org/jpos/transaction/TransactionManagerMBean.java
@@ -32,6 +32,8 @@ public interface TransactionManagerMBean extends QBeanSupportMBean {
     int getOutstandingTransactions();
     int getActiveSessions();
     int getPausedCounter();
+    int getActiveTransactions();
+    int getMaxSessions();
     String getTPSAsString();
     float getTPSAvg();
     int getTPSPeak();


### PR DESCRIPTION
TransactionManager returns `head - tail` as `in-transit`, which is important information. However, `in-transit` does not correctly reflect the number transactions actually being processed by the TM. So now it maintains a counter and provides a getter for `activeTransactions`.