### PR TITLE
Fix incorrect javadoc

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/BaseChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/BaseChannel.java
@@ -457,7 +457,7 @@ public abstract class BaseChannel extends Observable
 
    /**
     * allow subclasses to override default packager
-    * on outgoing messages
+    * on incoming messages
     * @param image incoming message image
     * @return ISOPackager
     */
@@ -466,7 +466,7 @@ public abstract class BaseChannel extends Observable
     }
     /**
      * allow subclasses to override default packager
-     * on outgoing messages
+     * on incoming messages
      * @param header message header
      * @param image incoming message image
      * @return ISOPackager


### PR DESCRIPTION
Methods:
	- getDynamicPackager(byte[] image)
	- getDynamicPackager(byte[] header, byte[] image)

allows overriding default packager on incoming messages, whereas
javadoc stated that on outgoing messages.