### PR TITLE
Honour comment about considering not null return values as true

### DIFF
--- a/jpos/src/main/java/org/jpos/bsh/BSHRequestListener.java
+++ b/jpos/src/main/java/org/jpos/bsh/BSHRequestListener.java
@@ -90,7 +90,7 @@ public class BSHRequestListener extends Log
 
                     // any non-null and non-boolean value is considered "true-ish"
                     // a null return is considered false
-                    if (ret != null && ret instanceof Boolean && ((Boolean) ret).booleanValue()) {
+                    if (ret != null && (!(ret instanceof Boolean) || (Boolean)ret)) {
                         return true;
                     }
 


### PR DESCRIPTION
Thanks @barspi for pointing that out

also use auto(un)boxing for the boolean case.

Sorry by the mistake

143: BSHRequestListener not honouring multiple souces

Task-Url: http://github.com/jpos/jPOS/issues/143