### PR TITLE
Target type inference

### DIFF
--- a/jpos/src/main/java/org/jpos/security/SecureKeyStore.java
+++ b/jpos/src/main/java/org/jpos/security/SecureKeyStore.java
@@ -62,17 +62,16 @@ public interface SecureKeyStore {
     }
 
 
-
     /**
-     * returns the key assiciated with the given alias
+     * Returns the key assiciated with the given alias.
+     *
+     * @param <T> desired type of requested key
      * @param alias the alias name
-     * @return the requested key, or null if the given alias does not exist.
+     * @return the requested key, or {@code null} if the given alias does not exist.
      * @throws SecureKeyStoreException if SecureKeyStore is not initialized or if
      * the operation fails for some other reason.
      */
-    SecureKey getKey(String alias) throws SecureKeyStoreException;
-
-
+    <T extends SecureKey> T getKey(String alias) throws SecureKeyStoreException;
 
     /**
      * Assigns the given key to the given alias.
@@ -86,12 +85,15 @@ public interface SecureKeyStore {
     void setKey(String alias, SecureKey key) throws SecureKeyStoreException;
 
     /**
-     * return map of existing keys assiciated with aliases.
+     * Returns map of existing keys assiciated with aliases.
+     *
+     * @param <T> desired type of requested keys
      * @return map of existing keys assiciated with aliases.
-     * @throws if SecureKeyStore is not initialized or if
+     * @throws SecureKeyStoreException if SecureKeyStore is not initialized or if
      * the operation fails for some other reason.
      */
-    Map<String,SecureKey> getKeys() throws SecureKeyStoreException;
+    <T extends SecureKey> Map<String, T> getKeys() throws SecureKeyStoreException;
+
 }
 
 

--- a/jpos/src/main/java/org/jpos/transaction/Context.java
+++ b/jpos/src/main/java/org/jpos/transaction/Context.java
@@ -87,23 +87,44 @@ public class Context implements Externalizable, Loggeable, Pausable, Cloneable {
     public void evict (Object key) {
         getPMap().remove (key);
     }
+
     /**
-     * Get
+     * Get object instance from transaction context.
+     *
+     * @param <T> desired type of object instance
+     * @param key the key of object instance
+     * @return object instance if exist in context or {@code null} otherwise
      */
-    public Object get (Object key) {
-        return getMap().get (key);
+    public <T> T get(Object key) {
+        @SuppressWarnings("unchecked")
+        T obj = (T) getMap().get(key);
+        return obj;
     }
-    public Object get (Object key, Object defValue) {
-        Object obj = getMap().get (key);
+
+    /**
+     * Get object instance from transaction context.
+     *
+     * @param <T> desired type of object instance
+     * @param key the key of object instance
+     * @param defValue default value returned if there is no value in context
+     * @return object instance if exist in context or {@code defValue} otherwise
+     */
+    public <T> T get(Object key, T defValue) {
+        @SuppressWarnings("unchecked")
+        T obj = (T) getMap().get(key);
         return obj != null ? obj : defValue;
     }
+
     /**
      * Transient remove
      */
-    public synchronized Object remove (Object key) {
-        getPMap().remove (key);
-        return getMap().remove (key);
+    public synchronized <T> T remove(Object key) {
+        getPMap().remove(key);
+        @SuppressWarnings("unchecked")
+        T obj = (T) getMap().get(key);
+        return obj;
     }
+
     public String getString (Object key) {
         Object obj = getMap().get (key);
         if (obj instanceof String)

--- a/jpos/src/main/java/org/jpos/util/NameRegistrar.java
+++ b/jpos/src/main/java/org/jpos/util/NameRegistrar.java
@@ -96,29 +96,46 @@ public class NameRegistrar implements Loggeable {
     }
 
     /**
-     * @param key
-     *            key whose associated value is to be returned.
-     * @throws NotFoundException
-     *             if key not present in registrar
+     * Get a value from the registry.
+     *
+     * @param <T> desired type of entry value.
+     * @param key the key whose associated value is to be returned.
+     * @return a value
+     * @throws NotFoundException if key not present in registrar
      */
-    public static Object get(String key) throws NotFoundException {
-        Object obj = sp.rdp(key);
+    public static <T> T get(String key) throws NotFoundException {
+        @SuppressWarnings("unchecked")
+        T obj = (T) sp.rdp(key);
         if (obj == null) {
             throw new NotFoundException(key);
         }
         return obj;
     }
 
-    public static Object get(String key, long timeout) {
-        return sp.rd (key, timeout);
+    /**
+     * Get a value from the registry - wait for it specified time.
+     *
+     * @param <T> desired type of value.
+     * @param key the key whose associated value is to be returned.
+     * @param timeout the maximum waiting time (in miliseconds) for
+     * the appearance of value in the registry.
+     * @return a value or {@code null} if it does not exist
+     */
+    public static <T> T get(String key, long timeout) {
+        return (T) sp.rd(key, timeout);
     }
 
     /**
-     * @param key
-     *            key whose associated value is to be returned, null if not present.
+     * Get a value from the registry - without casting {@code NotFoundException}.
+     *
+     * @param <T> desired type of value.
+     * @param key the key whose associated value is to be returned.
+     * @return a value or {@code null} if it does not exist
      */
-    public static Object getIfExists(String key) {
-        return sp.rdp(key);
+    public static <T> T getIfExists(String key) {
+        @SuppressWarnings("unchecked")
+        T obj = (T) sp.rdp(key);
+        return obj;
     }
 
     public void dump(PrintStream p, String indent) {

--- a/jpos/src/test/java/org/jpos/q2/qbean/QThreadPoolExecutorTest.java
+++ b/jpos/src/test/java/org/jpos/q2/qbean/QThreadPoolExecutorTest.java
@@ -19,6 +19,8 @@
 package org.jpos.q2.qbean;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -109,28 +111,31 @@ public class QThreadPoolExecutorTest {
     @Test
     public void testStaticGetThreadPoolExecutor() throws NotFoundException {
         executor = new DummyThreadPoolExecutor(1, 1, 1, TimeUnit.SECONDS,
-                new ArrayBlockingQueue<Runnable>(1));
+                new ArrayBlockingQueue<>(1)
+        );
         NameRegistrar.register(qbean.getRegistrationName(), executor);
-        assertThat(NameRegistrar.get(qbean.getRegistrationName())).isEqualTo(
-                executor);
+        ThreadPoolExecutor expected = NameRegistrar.get(qbean.getRegistrationName());
+        assertSame(expected, executor);
 
-        assertThat(
-                QThreadPoolExecutor.getThreadPoolExecutor(QBEAN_DEFAULT_NAME))
-                .isEqualTo(executor);
+        expected = QThreadPoolExecutor.getThreadPoolExecutor(QBEAN_DEFAULT_NAME);
+        assertSame(expected, executor);
     }
 
     @Test
     public void testStaticGetThreadPoolExecutor_SpecifyingExpectedClass()
             throws NotFoundException {
         executor = new DummyThreadPoolExecutor(1, 1, 1, TimeUnit.SECONDS,
-                new ArrayBlockingQueue<Runnable>(1));
+                new ArrayBlockingQueue<>(1)
+        );
         NameRegistrar.register(qbean.getRegistrationName(), executor);
-        assertThat(NameRegistrar.get(qbean.getRegistrationName())).isEqualTo(
-                executor);
+        ThreadPoolExecutor expected = NameRegistrar.get(qbean.getRegistrationName());
+        assertSame(expected, executor);
 
-        assertThat(
-                QThreadPoolExecutor.getThreadPoolExecutor(QBEAN_DEFAULT_NAME,
-                        DummyThreadPoolExecutor.class)).isEqualTo(executor);
+        expected = QThreadPoolExecutor.getThreadPoolExecutor(
+                QBEAN_DEFAULT_NAME
+                , DummyThreadPoolExecutor.class
+        );
+        assertSame(expected, executor);
     }
 
     @Test
@@ -332,16 +337,16 @@ public class QThreadPoolExecutorTest {
     public void testStopService_NoTerminationTimeout() throws Exception {
         executor = mock(ThreadPoolExecutor.class);
         NameRegistrar.register(qbean.getRegistrationName(), executor);
-        assertThat(NameRegistrar.get(qbean.getRegistrationName())).isEqualTo(
-                executor);
+        ThreadPoolExecutor expected = NameRegistrar.get(qbean.getRegistrationName());
+        assertSame(expected, executor);
         when(
                 executor.awaitTermination(Mockito.anyLong(),
                         Mockito.any(TimeUnit.class))).thenReturn(true);
 
         qbean.stopService();
 
-        assertThat(NameRegistrar.getIfExists(qbean.getRegistrationName()))
-                .isNull();
+        expected = NameRegistrar.getIfExists(qbean.getRegistrationName());
+        assertNull(expected);
     }
 
     protected void setQBeanConfig(byte[] config) {

--- a/jpos/src/test/java/org/jpos/security/jceadapter/DUKPTTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/DUKPTTest.java
@@ -144,7 +144,7 @@ public class DUKPTTest extends TestCase
         EncryptedPIN pin = new EncryptedPIN(
                 pinUnderDukpt, SMAdapter.FORMAT01, pan
         );
-        SecureDESKey bdk = (SecureDESKey) ks.getKey(keyName);
+        SecureDESKey bdk = ks.getKey(keyName);
         evt.addMessage(pin);
         evt.addMessage(ksn);
         evt.addMessage(bdk);

--- a/jpos/src/test/java/org/jpos/util/NameRegistrarTest.java
+++ b/jpos/src/test/java/org/jpos/util/NameRegistrarTest.java
@@ -76,7 +76,7 @@ public class NameRegistrarTest {
 
     @Test
     public void testGet() throws Exception {
-        String value = (String) NameRegistrar.get("test1");
+        String value = NameRegistrar.get("test1");
         assertThat(value, is("testValue1"));
     }
 
@@ -87,20 +87,20 @@ public class NameRegistrarTest {
 
     @Test
     public void testGetIfExists() throws Throwable {
-        String value = (String) NameRegistrar.getIfExists("test2");
+        String value = NameRegistrar.getIfExists("test2");
         assertThat(value, is("testValue2"));
     }
 
     @Test
     public void testGetIfExistsWithNotFoundKey() throws Exception {
-        String value = (String) NameRegistrar.getIfExists("NonexistentKey");
+        String value = NameRegistrar.getIfExists("NonexistentKey");
         assertThat(value, is(nullValue()));
     }
 
     @Test(expected = NameRegistrar.NotFoundException.class)
     public void testUnregister() throws Exception {
         NameRegistrar.register("test3", "someTest3Value");
-        assertThat((String) NameRegistrar.get("test3"), is("someTest3Value"));
+        assertThat(NameRegistrar.get("test3"), is("someTest3Value"));
         NameRegistrar.unregister("test3");
         NameRegistrar.get("test3");
     }


### PR DESCRIPTION
Using type inference in generic methods allows to avoid explicit type casting in code, eg.
```java
      @SuppressWarnings("unchecked")
      Integer someMilis = (Integer) ctx.get(CTX_SOME_TIME);
```
Now it can be written as:
```java
      Integer someMilis = ctx.get(CTX_SOME_TIME);
```
