### PR TITLE
Custom Exception Handler Pipelines

### DIFF
--- a/jpos/src/main/java/org/jpos/core/handlers/exception/ExceptionHandler.java
+++ b/jpos/src/main/java/org/jpos/core/handlers/exception/ExceptionHandler.java
@@ -1,0 +1,35 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2018 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.core.handlers.exception;
+
+/**
+ * @author Alwyn Schoeman
+ * @since 2.1.2
+ */
+public interface ExceptionHandler {
+
+    /**
+     * Implement custom exception handling that can be injected into jPos via configuration.
+     *
+     * @param e Exception
+     * @return Same or modified exception.
+     * @throws Exception In case the handler would like to throw an exception.  This should stop further handlers from processing.
+     */
+    Exception handle(Exception e) throws Exception;
+}

--- a/jpos/src/main/java/org/jpos/core/handlers/exception/ExceptionHandlerAware.java
+++ b/jpos/src/main/java/org/jpos/core/handlers/exception/ExceptionHandlerAware.java
@@ -1,0 +1,133 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2018 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.core.handlers.exception;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface that modifies an implementing class to add an exception handling pipeline.
+ *
+ * <p>
+ *     The main pipeline consists of multiple sub-pipelines:
+ *     <ul>
+ *         <li>A pipeline for which handlers are called regardless of the type of exception handled.</li>
+ *         <li>A pipeline per targeted exception type.</li>
+ *     </ul>
+ *     The targeted pipeline always executes before the default pipeline.
+ * </p>
+ * <p>
+ *     In the event that both of the pipelines are empty, the default behavior is to rethrow the initial exception.
+ * </p>
+ * <p>
+ *     There is no need to implement the methods unless you override the default behavior.
+ * </p>
+ *
+ * @author  Alwyn Schoeman
+ * @since 2.1.2
+ */
+public interface ExceptionHandlerAware {
+
+    // Instantiate pipeline containers, these are static final by convention.
+    List<ExceptionHandler> defaultHandlers = new ArrayList<>();
+    Map<Class<? extends Exception>, List<ExceptionHandler>> specificHandlers = new HashMap<>();
+
+    /**
+     * Add a handler to the default pipeline.
+     * @param handler ExceptionHandler to add.
+     */
+    default void addHandler(ExceptionHandler handler) {
+        defaultHandlers.add(handler);
+    }
+
+    /**
+     * Add a handler to an exception specific pipeline.
+     * @param handler ExceptionHandler to add.
+     * @param clazz Exception handler pipeline to add it to.
+     */
+    default void addHandler(ExceptionHandler handler, Class<? extends Exception> clazz) {
+        List<ExceptionHandler> handlers = specificHandlers.computeIfAbsent(clazz, f -> new ArrayList<>() );
+        if (handler != null) {
+            handlers.add(handler);
+        }
+    }
+
+    /**
+     * Remove a handler from the default pipeline.
+     * @param handler ExceptionHandler to remove.
+     */
+    default void removeHandler(ExceptionHandler handler) {
+        defaultHandlers.remove(handler);
+    }
+
+    /**
+     * Remove a handler from an exception specific handler pipeline.
+     * @param handler ExceptionHandler to remove.
+     * @param clazz Exception pipeline to remove it from.
+     */
+    default void removeHandler(ExceptionHandler handler, Class<? extends Exception> clazz) {
+        final List<ExceptionHandler> exceptionHandlers = specificHandlers.get(clazz);
+        if (exceptionHandlers != null) {
+            exceptionHandlers.remove(handler);
+        }
+    }
+
+    /**
+     * Remove all handler for a specific exception handling pipeline.
+     * @param clazz Exception pipeline to remove.
+     */
+    default void removeHandlers(Class<? extends Exception> clazz) {
+        specificHandlers.remove(clazz);
+    }
+
+    /**
+     * Execute the pipeline by starting with the specific pipeline for the exception
+     * followed by the default pipeline.
+     * <br>
+     * In the event of both pipelines being empty, the original exception is rethrown.
+     * @param e Initial exception.
+     * @return Same, modified or new exception.
+     * @throws Exception In the event of a handler throwing an exception.  Processing by further handlers would be cancelled.
+     */
+    default Exception handle(Exception e) throws Exception {
+        int strike = 1;
+        Exception exception = e;
+        final List<ExceptionHandler> exceptionHandlers = specificHandlers.get(e.getClass());
+
+        if (exceptionHandlers != null) {
+            for (ExceptionHandler handler : exceptionHandlers) {
+                exception = handler.handle(exception);
+            }
+        } else {
+            strike++;
+        }
+
+        if (defaultHandlers.isEmpty() && (++strike == 3)) {
+            throw e;
+        }
+
+        for (ExceptionHandler handler : defaultHandlers) {
+            exception = handler.handle(exception);
+        }
+
+        return exception;
+    }
+}

--- a/jpos/src/main/java/org/jpos/core/handlers/exception/ExceptionHandlerConfigAware.java
+++ b/jpos/src/main/java/org/jpos/core/handlers/exception/ExceptionHandlerConfigAware.java
@@ -33,7 +33,7 @@ public interface ExceptionHandlerConfigAware {
     default void addExceptionHandlers(ExceptionHandlerAware receiver, Element elem, QFactory fact)
             throws ConfigurationException
     {
-        for (Element o : elem.getChildren("exception-handlers")) {
+        for (Element o : elem.getChildren("exception-handler")) {
             String clazz = o.getAttributeValue("class");
             ExceptionHandler handler = (ExceptionHandler) fact.newInstance(clazz);
             fact.setLogger(handler, o);

--- a/jpos/src/main/java/org/jpos/core/handlers/exception/ExceptionHandlerConfigAware.java
+++ b/jpos/src/main/java/org/jpos/core/handlers/exception/ExceptionHandlerConfigAware.java
@@ -1,0 +1,55 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2018 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.core.handlers.exception;
+
+import org.jdom2.Element;
+import org.jpos.core.ConfigurationException;
+import org.jpos.q2.QFactory;
+
+/**
+ * Adds the logic for parsing exception handler pipeline configurations to any implementing class.
+ *
+ * @author Alwyn Schoeman
+ * @since 2.1.2
+ */
+public interface ExceptionHandlerConfigAware {
+
+    default void addExceptionHandlers(ExceptionHandlerAware receiver, Element elem, QFactory fact)
+            throws ConfigurationException
+    {
+        for (Element o : elem.getChildren("exception-handlers")) {
+            String clazz = o.getAttributeValue("class");
+            ExceptionHandler handler = (ExceptionHandler) fact.newInstance(clazz);
+            fact.setLogger(handler, o);
+            fact.setConfiguration(handler, o);
+            String exception = o.getAttributeValue("exception");
+            if (exception == null) {
+                receiver.addHandler(handler);
+            } else {
+                Class<? extends Exception> exceptionClass;
+                try {
+                    exceptionClass = (Class<? extends Exception>) Class.forName(exception);
+                } catch (Exception e) {
+                    throw new ConfigurationException(exception, e);
+                }
+                receiver.addHandler(handler, exceptionClass);
+            }
+        }
+    }
+}

--- a/jpos/src/main/java/org/jpos/iso/BaseChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/BaseChannel.java
@@ -21,6 +21,8 @@ package org.jpos.iso;
 import org.jpos.core.Configurable;
 import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
+import org.jpos.core.handlers.exception.ExceptionHandler;
+import org.jpos.core.handlers.exception.ExceptionHandlerAware;
 import org.jpos.iso.ISOFilter.VetoException;
 import org.jpos.iso.header.BaseHeader;
 import org.jpos.util.LogEvent;
@@ -33,7 +35,9 @@ import java.io.*;
 import java.net.*;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Observable;
 
 /*
@@ -43,16 +47,16 @@ import java.util.Observable;
 
 /**
  * ISOChannel is an abstract class that provides functionality that
- * allows the transmision and reception of ISO 8583 Messages
+ * allows the transmission and reception of ISO 8583 Messages
  * over a TCP/IP session.
  * <p>
  * This class is not thread-safe.
  * <p>
- * ISOChannel is Observable in order to suport GUI components
+ * ISOChannel is Observable in order to support GUI components
  * such as ISOChannelPanel.
  * <br>
  * It now support the new Logger architecture so we will
- * probably setup ISOChannelPanel to be a LogListener insteado
+ * probably setup ISOChannelPanel to be a LogListener instead
  * of being an Observer in future releases.
  * 
  * @author Alejandro P. Revilla
@@ -68,7 +72,7 @@ import java.util.Observable;
 @SuppressWarnings("unchecked")
 public abstract class BaseChannel extends Observable
     implements FilteredChannel, ClientChannel, ServerChannel, FactoryChannel, 
-               LogSource, Configurable, BaseChannelMBean, Cloneable
+               LogSource, Configurable, BaseChannelMBean, Cloneable, ExceptionHandlerAware
 {
     private Socket socket;
     private String host, localIface;
@@ -104,6 +108,10 @@ public abstract class BaseChannel extends Observable
     private static final int DEFAULT_TIMEOUT = 300000;
     private int nextHostPort = 0;
     private boolean roundRobin = false;
+
+    // Exception handlers
+    private final List<ExceptionHandler> defaultExceptionHandlers = new ArrayList<>();
+    private final Map<Class<? extends Exception>, List<ExceptionHandler>> targetedExceptionHandlers = new HashMap<>();
 
     /**
      * constructor shared by server and client
@@ -229,6 +237,16 @@ public abstract class BaseChannel extends Observable
         setHost (null, 0);
         this.serverSocket = sock;
         name = "";
+    }
+
+    @Override
+    public List<ExceptionHandler> getDefaultExceptionHandlers() {
+        return defaultExceptionHandlers;
+    }
+
+    @Override
+    public Map<Class<? extends Exception>, List<ExceptionHandler>> getTargetedExceptionHandlers() {
+        return targetedExceptionHandlers;
     }
 
     /**

--- a/jpos/src/main/java/org/jpos/q2/iso/ChannelAdaptor.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/ChannelAdaptor.java
@@ -20,6 +20,8 @@ package org.jpos.q2.iso;
 
 import org.jdom2.Element;
 import org.jpos.core.ConfigurationException;
+import org.jpos.core.handlers.exception.ExceptionHandlerAware;
+import org.jpos.core.handlers.exception.ExceptionHandlerConfigAware;
 import org.jpos.iso.*;
 import org.jpos.q2.QBeanSupport;
 import org.jpos.q2.QFactory;
@@ -42,7 +44,7 @@ import java.util.Date;
 @SuppressWarnings("unchecked")
 public class ChannelAdaptor
     extends QBeanSupport
-    implements ChannelAdaptorMBean, Channel, Loggeable
+    implements ChannelAdaptorMBean, Channel, Loggeable, ExceptionHandlerConfigAware
 {
     protected Space sp;
     private ISOChannel channel;
@@ -205,6 +207,11 @@ public class ChannelAdaptor
         if (channel instanceof FilteredChannel) {
             addFilters ((FilteredChannel) channel, e, f);
         }
+
+        if (channel instanceof ExceptionHandlerAware) {
+            addExceptionHandlers((ExceptionHandlerAware) channel, e, f);
+        }
+
         if (getName () != null)
             channel.setName (getName ());
         return channel;
@@ -232,6 +239,9 @@ public class ChannelAdaptor
             }
         }
     }
+
+
+
     protected ISOChannel initChannel () throws ConfigurationException {
         Element persist = getPersist ();
         Element e = persist.getChild ("channel");

--- a/jpos/src/test/java/org/jpos/core/handler/exception/ExceptionHandlerAwareTest.java
+++ b/jpos/src/test/java/org/jpos/core/handler/exception/ExceptionHandlerAwareTest.java
@@ -9,6 +9,11 @@ import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -20,29 +25,32 @@ import static org.mockito.Mockito.when;
 
 public class ExceptionHandlerAwareTest implements ExceptionHandlerAware {
 
+    private final Map<Class<? extends Exception>,List<ExceptionHandler>> targetedExceptionHandlers = new HashMap<>();
+    private final List<ExceptionHandler> defaultExceptionHandlers = new ArrayList<>();
+
     @Before
     public void clearHandlers() {
-        defaultHandlers.clear();
-        specificHandlers.clear();
+        getDefaultExceptionHandlers().clear();
+        getTargetedExceptionHandlers().clear();
     }
 
     @Test
     public void testAddDefaultHandler() {
         addHandler(e -> null);
-        assertEquals(1, defaultHandlers.size());
+        assertEquals(1, getDefaultExceptionHandlers().size());
     }
 
     @Test
-    public void testAddFirstSpecificHandler() {
+    public void testAddFirstTargetedHandler() {
         addHandler(e -> null, ISOException.class);
-        assertEquals(1, specificHandlers.get(ISOException.class).size());
+        assertEquals(1, getTargetedExceptionHandlers().get(ISOException.class).size());
     }
 
     @Test
-    public void testAddAdditionalSpecificHandler() {
+    public void testAddAdditionalTargetedHandler() {
         addHandler(e -> null, ISOException.class);
         addHandler(e -> null, ISOException.class);
-        assertEquals(2, specificHandlers.get(ISOException.class).size());
+        assertEquals(2, getTargetedExceptionHandlers().get(ISOException.class).size());
     }
 
     @Test
@@ -50,23 +58,23 @@ public class ExceptionHandlerAwareTest implements ExceptionHandlerAware {
         ExceptionHandler handler = e -> null;
         addHandler(handler);
         removeHandler(handler);
-        assertEquals(0, defaultHandlers.size());
+        assertEquals(0, getDefaultExceptionHandlers().size());
     }
 
     @Test
-    public void testRemoveSpecificHandler() {
+    public void testRemoveTargetedHandler() {
         ExceptionHandler handler = e -> null;
         addHandler(handler, ISOException.class);
         removeHandler(handler, ISOException.class);
-        assertEquals(0, specificHandlers.get(ISOException.class).size());
+        assertEquals(0, getTargetedExceptionHandlers().get(ISOException.class).size());
     }
 
     @Test
-    public void testRemoveSpecificExceptionHandlers() {
+    public void testRemoveTargetedExceptionHandlers() {
         ExceptionHandler handler = e -> null;
         addHandler(handler, ISOException.class);
         removeHandlers(ISOException.class);
-        assertNull(specificHandlers.get(ISOException.class));
+        assertNull(getTargetedExceptionHandlers().get(ISOException.class));
     }
 
     @Test(expected = ISOException.class)
@@ -138,4 +146,13 @@ public class ExceptionHandlerAwareTest implements ExceptionHandlerAware {
         verify(h3).handle(any());
     }
 
+    @Override
+    public List<ExceptionHandler> getDefaultExceptionHandlers() {
+        return defaultExceptionHandlers;
+    }
+
+    @Override
+    public Map<Class<? extends Exception>, List<ExceptionHandler>> getTargetedExceptionHandlers() {
+        return targetedExceptionHandlers;
+    }
 }

--- a/jpos/src/test/java/org/jpos/core/handler/exception/ExceptionHandlerAwareTest.java
+++ b/jpos/src/test/java/org/jpos/core/handler/exception/ExceptionHandlerAwareTest.java
@@ -1,0 +1,141 @@
+package org.jpos.core.handler.exception;
+
+import org.jpos.core.InvalidCardException;
+import org.jpos.core.handlers.exception.ExceptionHandler;
+import org.jpos.core.handlers.exception.ExceptionHandlerAware;
+import org.jpos.iso.ISOException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class ExceptionHandlerAwareTest implements ExceptionHandlerAware {
+
+    @Before
+    public void clearHandlers() {
+        defaultHandlers.clear();
+        specificHandlers.clear();
+    }
+
+    @Test
+    public void testAddDefaultHandler() {
+        addHandler(e -> null);
+        assertEquals(1, defaultHandlers.size());
+    }
+
+    @Test
+    public void testAddFirstSpecificHandler() {
+        addHandler(e -> null, ISOException.class);
+        assertEquals(1, specificHandlers.get(ISOException.class).size());
+    }
+
+    @Test
+    public void testAddAdditionalSpecificHandler() {
+        addHandler(e -> null, ISOException.class);
+        addHandler(e -> null, ISOException.class);
+        assertEquals(2, specificHandlers.get(ISOException.class).size());
+    }
+
+    @Test
+    public void testRemoveDefaultHandler() {
+        ExceptionHandler handler = e -> null;
+        addHandler(handler);
+        removeHandler(handler);
+        assertEquals(0, defaultHandlers.size());
+    }
+
+    @Test
+    public void testRemoveSpecificHandler() {
+        ExceptionHandler handler = e -> null;
+        addHandler(handler, ISOException.class);
+        removeHandler(handler, ISOException.class);
+        assertEquals(0, specificHandlers.get(ISOException.class).size());
+    }
+
+    @Test
+    public void testRemoveSpecificExceptionHandlers() {
+        ExceptionHandler handler = e -> null;
+        addHandler(handler, ISOException.class);
+        removeHandlers(ISOException.class);
+        assertNull(specificHandlers.get(ISOException.class));
+    }
+
+    @Test(expected = ISOException.class)
+    public void testFallbackHandler() throws Exception {
+        try {
+            throw new ISOException();
+        } catch (Exception e) {
+            handle(e);
+        }
+    }
+
+    @Test
+    public void testHandlerOrder() throws Exception {
+        ExceptionHandler h1 = mock(ExceptionHandler.class);
+        ExceptionHandler h2 = mock(ExceptionHandler.class);
+        ExceptionHandler h3 = mock(ExceptionHandler.class);
+        ExceptionHandler h4 = mock(ExceptionHandler.class);
+        ExceptionHandler h5 = mock(ExceptionHandler.class);
+
+        addHandler(h1);
+        addHandler(h2);
+        addHandler(h5, InvalidCardException.class);
+        addHandler(h3, ISOException.class);
+        addHandler(h4, ISOException.class);
+
+        try {
+            throw new ISOException();
+        } catch (Exception e) {
+            handle(e);
+        }
+
+        verifyZeroInteractions(h5);
+        InOrder inOrder = Mockito.inOrder(h1,h2,h3,h4);
+
+        inOrder.verify(h3).handle(any());
+        inOrder.verify(h4).handle(any());
+        inOrder.verify(h1).handle(any());
+        inOrder.verify(h2).handle(any());
+    }
+
+    @Test
+    public void testHandlerExecutionWhenExceptionThrown() throws Exception {
+        ExceptionHandler h1 = mock(ExceptionHandler.class);
+        ExceptionHandler h2 = mock(ExceptionHandler.class);
+        ExceptionHandler h3 = mock(ExceptionHandler.class);
+        ExceptionHandler h4 = mock(ExceptionHandler.class);
+        ExceptionHandler h5 = mock(ExceptionHandler.class);
+
+        when(h3.handle(any())).thenThrow(new ISOException("Hello"));
+
+        addHandler(h1);
+        addHandler(h2);
+        addHandler(h5, InvalidCardException.class);
+        addHandler(h3, ISOException.class);
+        addHandler(h4, ISOException.class);
+
+        try {
+            throw new ISOException();
+        } catch (Exception e) {
+            try {
+                handle(e);
+                fail("Expected ISOException");
+            } catch (ISOException e1) {
+                assertEquals("Hello", e1.getMessage());
+            }
+        }
+
+        verifyZeroInteractions(h1, h2, h4, h5);
+        verify(h3).handle(any());
+    }
+
+}


### PR DESCRIPTION
Adds the ability to:

- Define exception-handlers in any jdom parsed configured QBean with only implementing an interface on the bean.
- Add exception handling logic to anything by adding ExceptionHandlerAware interface.  This requires the implementation of 2 methods and adding storage for the handlers.
- If there are no handlers defined the default behavior is to throw the original exception.

None of this is used yet even though it has been added to BaseChannel.  Can be enabled in any channel by replacing the throw statement with "handle(e)". 