### PR TITLE
corrections are made when the ISO packager is created without arguments

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/IFAE_LLCHAR.java
+++ b/jpos/src/main/java/org/jpos/iso/IFAE_LLCHAR.java
@@ -26,7 +26,7 @@ package org.jpos.iso;
  */
 public class IFAE_LLCHAR extends ISOStringFieldPackager {
     public IFAE_LLCHAR() {
-        super(NullPadder.INSTANCE, AsciiInterpreter.INSTANCE, EbcdicPrefixer.LL);
+        super(NullPadder.INSTANCE, EbcdicInterpreter.INSTANCE, AsciiPrefixer.LL);
     }
     /**
      * @param len - field len

--- a/jpos/src/test/java/org/jpos/iso/IFAE_LLCHARTest.java
+++ b/jpos/src/test/java/org/jpos/iso/IFAE_LLCHARTest.java
@@ -33,10 +33,29 @@ public class IFAE_LLCHARTest extends TestCase
                             packager.pack(field));
     }
 
+    public void testPackWithPackagerWithoutDescription() throws Exception
+    {
+        ISOField field = new ISOField(12, "1234");
+        IFAE_LLCHAR packager = new IFAE_LLCHAR();
+        packager.setLength(12);
+        TestUtils.assertEquals(new byte[] {(byte)0x30, (byte)0x34, (byte)0xF1, (byte)0xF2, (byte)0xF3, (byte)0xF4},
+                            packager.pack(field));
+    }
+    
     public void testUnpack() throws Exception
     {
         byte[] raw = new byte[] {(byte)0x30, (byte)0x34, (byte)0xF1, (byte)0xF2, (byte)0xF3, (byte)0xF4};
         IFAE_LLCHAR packager = new IFAE_LLCHAR(10, "Should be 041234");
+        ISOField field = new ISOField(12);
+        packager.unpack(field, raw, 0);
+        assertEquals("1234", (String) field.getValue());
+    }
+
+    public void testUnpackWithPackagerWithoutDescription() throws Exception
+    {
+        byte[] raw = new byte[] {(byte)0x30, (byte)0x34, (byte)0xF1, (byte)0xF2, (byte)0xF3, (byte)0xF4};
+        IFAE_LLCHAR packager = new IFAE_LLCHAR();
+        packager.setLength(10);
         ISOField field = new ISOField(12);
         packager.unpack(field, raw, 0);
         assertEquals("1234", (String) field.getValue());
@@ -52,4 +71,5 @@ public class IFAE_LLCHARTest extends TestCase
         packager.unpack(unpack, packager.pack(field), 0);
         assertEquals(origin, (String) unpack.getValue());
     }
+
 }


### PR DESCRIPTION
In the previous pull request was added a new ISO field: _IFAE_LLCHAR_. It was working correctly when the ISO packager is created with arguments, you can see in the unit test file _IFAE_LLCHARTest.java_. However, when the ISO packager is created without arguments it fails because its behavior is like the ISO packager _IFEA_LLCHAR_.
I made the changes and add the new unit tests. Also, I tested with my local environment and is working well.