### PR TITLE
Kafka log listener

### DIFF
--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     compile libraries.slf4j_api
     compile libraries.javassist
     compile libraries.hdrhistogram
+    compile libraries.kafka
+    compile libraries.jacksonDatabind
 
     testCompile libraries.hamcrest
     testCompile libraries.fest_assert
@@ -24,10 +26,10 @@ dependencies {
     }
 
     //  JSONPackager on hold
-    //    compile (libraries.jsonsimple) {
-    //        exclude(module: 'junit')
-    //        exclude(module: 'hamcrest-core')
-    //    }
+    compile (libraries.jsonsimple) {
+        exclude(module: 'junit')
+        exclude(module: 'hamcrest-core')
+    }
     // Integrated OSGI framework
     // compile 'org.apache.felix:org.apache.felix.framework:5.0.0'
 }

--- a/jpos/libraries.gradle
+++ b/jpos/libraries.gradle
@@ -24,7 +24,10 @@ ext {
         sshd: 'org.apache.sshd:sshd-core:1.7.0',
         slf4j_api: "org.slf4j:slf4j-api:1.7.22",
         slf4j_nop: "org.slf4j:slf4j-nop:1.7.22",
-        hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.10'
+        hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.10',
+        kafka: 'org.apache.kafka:kafka-clients:1.1.0',
+        jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.9.5',
+        jsonsimple: 'com.googlecode.json-simple:json-simple:1.1.1'
     ]
 }
 

--- a/jpos/src/dist/deploy/00_logger.xml
+++ b/jpos/src/dist/deploy/00_logger.xml
@@ -3,6 +3,31 @@
 <logger name="Q2" class="org.jpos.q2.qbean.LoggerAdaptor">
   <property name="redirect" value="stdout, stderr" />
   <log-listener class="org.jpos.util.SimpleLogListener" />
+  <log-listener class="org.jpos.util.BufferedLogListener">
+    <property name="max-size" value="100" />
+    <property name="name" value="logger.Q2.buffered" />
+  </log-listener>
+
+  <log-listener class="org.jpos.util.KafkaLogListener">
+    <property name="topic" value="jpos" />
+    <property name="KafkaProducer.bootstrap.servers" value="localhost:9092" />
+    <property name="KafkaProducer.acks" value="all" />
+    <property name="KafkaProducer.key.serializer" value="org.apache.kafka.common.serialization.StringSerializer" />
+    <property name="KafkaProducer.value.serializer" value="org.apache.kafka.common.serialization.StringSerializer" />
+    <property name="KafkaProducer.retries" value="0" />
+    <property name="KafkaProducer.batch.size" value="16384" />
+    <property name="KafkaProducer.linger.ms" value="1" />
+    <property name="KafkaProducer.buffer.memory" value="33554432" />
+  </log-listener>
+
+  <!--
+  <log-listener class="org.jpos.util.SysLogListener">
+     <property name="facility" value="21" />
+     <property name="severity" value="5" />
+     <property name="tags" value="audit, syslog" />
+     <property name="prefix" value="[jPOS]" />
+  </log-listener>
+  -->
 
   <log-listener class="org.jpos.util.DailyLogListener">
     <property name="window" value="86400" /> <!-- optional, default one day -->

--- a/jpos/src/main/java/org/jpos/util/KafkaLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/KafkaLogListener.java
@@ -1,0 +1,144 @@
+package org.jpos.util;
+
+import org.jpos.core.Configurable;
+import org.jpos.core.Configuration;
+import org.jpos.core.ConfigurationException;
+import org.jpos.iso.packager.*;
+import org.jpos.util.*;
+import org.jpos.iso.*;
+import org.jpos.q2.qbean.*;
+import org.apache.kafka.clients.producer.*;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import java.util.*;
+import java.io.*;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+//import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.fasterxml.jackson.databind.SerializationFeature;
+import java.sql.SQLException;
+import org.jdom2.Element;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.json.simple.*;
+
+/**
+ * Kafka Listener
+ *
+ * @author andres@antoniuk.org
+ */
+
+
+public class KafkaLogListener implements LogListener, Configurable {
+    private Configuration  cfg;
+    Producer<String, String> producer;
+    String topic;
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    public KafkaLogListener () {
+        super();
+    }
+
+    public synchronized LogEvent log (LogEvent ev) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        List<Object> payload;
+        try {
+            String[] realm = ev.getRealm().split("/", 2);
+            m.put("Realm", realm[0]);
+            String[] ipport = realm[1].split(":", 2);
+            m.put("IP", ipport[0]);
+            m.put("Port", ipport[1]);
+        } catch (Exception e) {
+            m.put("Realm", ev.getRealm());
+        }
+        m.put("Tag", ev.getTag());
+        m.put("@timestamp", LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()).toString());
+
+        payload = ev.getPayLoad();
+        if (payload.size() > 0) {
+            synchronized (payload) {
+                int i = 0;
+                for (Object o : payload) {
+                    m.put("ElementType" + i, o.getClass());
+                    if (o instanceof String) {
+
+                    }else if (o instanceof ISOMsg){
+                        m.put("ISOMsgOriginalPackager" + i,((ISOMsg)o).getPackager().getDescription());
+                        ISOMsg msg = (ISOMsg)o;
+                        ISOPackager p = msg.getPackager();
+                        m.put("ISOMsg" + i, o.toString());
+                        try {
+                            //msg.setPackager(new JSONPackager(new Base1Packager()));
+                            msg.setPackager(new JSONPackager(new XMLPackager()));
+                            //m.put("ISOMsgNewPackager" + i,((ISOMsg)o).getPackager().getDescription());
+                        }catch(Exception e){
+                            m.put("ISOMsgPackException_setPackager" + i, ((Throwable) e).getMessage());
+                        }
+                        try {
+                            m.put("ISOMsgPack" + i, JSONValue.parse(new String(msg.pack())));
+                        }catch(Exception e){
+                            m.put("ElementContent" + i, o.toString());
+                        }
+                        try {
+                            msg.setPackager(p);
+                        }catch(Exception e){
+                            m.put("ISOMsgPackException_restorePackager" + i, ((Throwable) e).getMessage());
+                        }
+                    }else if (o instanceof SystemMonitor ){
+                        // ignore SystemMonitor
+                        assert true;
+                    }else if (o instanceof Throwable){
+                        m.put("Exception" + i, ((Throwable) o).getMessage());
+                        StringWriter errors = new StringWriter();
+                        ((Throwable) o).printStackTrace(new PrintWriter(errors));
+                        m.put("StackTrace" + i,errors.toString());
+                    }else{
+                        m.put("NonStringContent" + i, o.toString());
+                    }
+                    i = i + 1;
+                }
+            }
+        } else if (payload.size() == 0){
+            m.put("EventDump", ev.toString());
+        }
+
+        try {
+            producer.send(new ProducerRecord<String, String>(topic, objectMapper.writeValueAsString(m)));
+        } catch (JsonProcessingException e) {
+            producer.send(new ProducerRecord<String, String>(topic, e.toString()));;
+        }
+        return ev;
+    }
+
+    public void setConfiguration (Configuration cfg)
+            throws ConfigurationException
+    {
+        this.cfg = cfg;
+        try {
+            Properties props = new Properties();
+            topic = cfg.get ("topic", "test");
+
+            for (String propname : cfg.keySet()){
+                if (propname.startsWith("KafkaProducer.")) {
+                    String kafkaprop = propname.replace("KafkaProducer.", "");
+                    try {
+                        props.put(kafkaprop, cfg.getInt (propname));
+                    } catch (NumberFormatException e) {
+                        props.put(kafkaprop, cfg.get (propname));
+                    }
+                }
+            }
+            producer = new KafkaProducer<>(props);
+            producer.send(new ProducerRecord<String, String>(topic, "{\"message\":\"KafkaLogListener started\"}"));
+        } catch (Exception e) {
+            throw new ConfigurationException (e);
+        }
+    }
+
+    public synchronized void close() {
+        producer.close();
+    }
+}


### PR DESCRIPTION
This is a preliminary version of a new LogListener  this goals:
- Use Kafka as a way to  "concentrate" logs from different jPOS modules/instances/servers
- Events formated as jSON so it's is easy to ingest this events to Elastic via [Logstash Kafka Input](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-kafka.html)

Configuration is done via a new _log-listener_ section on `00_logger.xml` that forwards configuration options to the [Kafka Producer API](https://kafka.apache.org/11/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html)

```
  <log-listener class="org.jpos.util.KafkaLogListener">
    <property name="topic" value="jpos" />
    <property name="KafkaProducer.bootstrap.servers" value="localhost:9092" />
    <property name="KafkaProducer.acks" value="all" />
    <property name="KafkaProducer.key.serializer" value="org.apache.kafka.common.serialization.StringSerializer" />
    <property name="KafkaProducer.value.serializer" value="org.apache.kafka.common.serialization.StringSerializer" />
    <property name="KafkaProducer.retries" value="0" />
    <property name="KafkaProducer.batch.size" value="16384" />
    <property name="KafkaProducer.linger.ms" value="1" />
    <property name="KafkaProducer.buffer.memory" value="33554432" />
  </log-listener>
```

### Testing environment
- Kafka setup following https://kafka.apache.org/quickstart
- Logstash pipeline

```
input {  
  kafka {
    bootstrap_servers => "localhost:9092"
    topics => ["jpos"]
  }
}
filter {
  json {
    source => "message"
  }
  mutate {
    remove_field => [ "message" ]
  }
}
output {
  stdout { 
    codec => rubydebug
  }
  elasticsearch{
    hosts => ["localhost:9200"]
    index => "jposlog-%{+YYYY.MM.dd.hh}"
  }
}
```

- Sample log data in elastic

```
GET jposlog-2018*/_search

{
  "took": 1134,
  "timed_out": false,
  "_shards": {
    "total": 10,
    "successful": 10,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": 206,
    "max_score": 1,
    "hits": [
      {
        "_index": "jposlog-2018.07.19.01",
        "_type": "doc",
        "_id": "nT8QsGQBU4jSE_wmPlfZ",
        "_score": 1,
        "_source": {
          "IP": "52.7.83.125",
          "ElementType_0": "java.lang.String",
          "ElementContent_0": "Try 0 isobridge.jpos.org:9000",
          "@version": "1",
          "@timestamp": "2018-07-19T01:03:31.940Z",
          "Port": "9000",
          "Tag": "connect",
          "Realm": "channel"
        }
      },
      {
        "_index": "jposlog-2018.07.19.12",
        "_type": "doc",
        "_id": "Bz_cr2QBU4jSE_wmNlcw",
        "_score": 1,
        "_source": {
          "IP": "52.7.83.125",
          "ElementType_0": "org.jpos.iso.ISOMsg",
          "ISOMsgPackager_0": "org.jpos.iso.packager.XMLPackager",
          "@version": "1",
          "@timestamp": "2018-07-19T00:06:40.665Z",
          "Port": "9000",
          "Tag": "receive",
          "ISOMsg_org.jpos.iso.packager.XMLPackager_0": {
            "0": "1810",
            "7": "0718210640",
            "11": "800376",
            "12": "800048",
            "37": "152634",
            "38": "249453",
            "39": "00",
            "63b": "576564204A756C2031382032313A30363A343020474D542D30333A30302032303138"
          },
          "Realm": "channel"
        }
      },
      {
        "_index": "jposlog-2018.07.19.12",
        "_type": "doc",
        "_id": "Cj_cr2QBU4jSE_wmNlcw",
        "_score": 1,
        "_source": {
          "ISOMsg_org.jpos.iso.packager.Base1Packager_0": {
            "0": {
              "description": "MESSAGE TYPE INDICATOR",
              "class": "org.jpos.iso.IFB_NUMERIC",
              "value": 1800
            },
            "7": {
              "description": "TRANSMISSION DATE AND TIME",
              "class": "org.jpos.iso.IFB_NUMERIC",
              "value": 718210640
            },
            "11": {
              "description": "SYSTEM TRACE AUDIT NUMBER",
              "class": "org.jpos.iso.IFB_NUMERIC",
              "value": 800698
            },
            "12": {
              "description": "TIME, LOCAL TRANSACTION",
              "class": "org.jpos.iso.IFB_NUMERIC",
              "value": 800376
            },
            "63b": "576564204A756C2031382032313A30363A343020474D542D30333A30302032303138"
          },
          "IP": "127.0.0.1",
          "ElementType_0": "org.jpos.iso.ISOMsg",
          "ISOMsgPackager_0": "org.jpos.iso.packager.Base1Packager",
          "@version": "1",
          "@timestamp": "2018-07-19T00:06:40.719Z",
          "Port": "49476",
          "Tag": "receive",
          "Realm": "channel"
        }
      },
      {
        "_index": "jposlog-2018.07.19.12",
        "_type": "doc",
        "_id": "Ez_cr2QBU4jSE_wmNlcw",
        "_score": 1,
        "_source": {
          "EventDump": """
<log realm="org.jpos.transaction.TransactionManager" at="2018-07-18T21:06:41.288" lifespan="303ms">
  <commit>
    txnmgr-0:idle:5
    <context>
      TIMESTAMP: Wed Jul 18 21:06:40 UYT 2018
      SOURCE: org.jpos.iso.channel.VAPChannel@15ddcd75
      REQUEST: 
       <isomsg>
         <!-- org.jpos.iso.packager.XMLPackager -->
         <header>160102004E0000000000000000000000000000000000</header>
         <field id="0" value="1800"/>
         <field id="7" value="0718210640"/>
         <field id="11" value="800977"/>
         <field id="12" value="800698"/>
         <field id="63" value="576564204A756C2031382032313A30363A343020474D542D30333A30302032303138" type="binary"/>
       </isomsg>
      
      DESTINATION: jPOS-AUTORESPONDER
      RESULT: 
       <result/>
      
      :paused_transaction: 
       id: 5
      
      RESPONSE: 
       <isomsg direction="outgoing">
         <!-- org.jpos.iso.packager.Base1Packager -->
         <header>160102004E0000000000000000000000000000000000</header>
         <field id="0" value="1810"/>
         <field id="7" value="0718210640"/>
         <field id="11" value="800977"/>
         <field id="12" value="800698"/>
         <field id="37" value="431490"/>
         <field id="38" value="484293"/>
         <field id="39" value="00"/>
         <field id="63" value="576564204A756C2031382032313A30363A343020474D542D30333A30302032303138" type="binary"/>
       </isomsg>
      
    </context>
            prepare: o.j.t.p.QueryHost PREPARED PAUSE READONLY NO_JOIN
            prepare: o.j.t.p.SendResponse PREPARED READONLY
             commit: o.j.t.p.SendResponse
     in-transit=0, head=6, tail=6, paused=0, outstanding=0, active-sessions=2/128, tps=3, peak=3, avg=0.18, elapsed=302ms
    <profiler>
      prepare: o.j.t.p.QueryHost [4.6/4.6]
      resume [292.0/296.7]
      prepare: o.j.t.p.SendResponse [0.7/297.5]
       commit: o.j.t.p.SendResponse [4.6/302.1]
      end [3.9/306.1]
    </profiler>
  </commit>
</log>

""",
          "@version": "1",
          "@timestamp": "2018-07-19T00:06:41.291Z",
          "Tag": "info",
          "Realm": "org.jpos.transaction.TransactionManager"
        }
      },

``` 
A nice [view from kibana here](https://1drv.ms/u/s!AkZgFs6QYwEvp5tlruOQuAXcH9CwTw)

---
Notes:
- Originally I plan to add this LogListener as a new JPOS-EE module, but as JSON is needed I consider better to enable JSON packager that was on hold here.

- Need to continue working on LogEvents that do not contain payload, specially on `TransactionManager`

- This is part of my [journey with jPOS and Elastic](https://www.linkedin.com/pulse/my-journey-jpos-elastic-juan-andr%C3%A9s-antoniuk-buchtik/) for monitoring and transactional data analysis.
