### PR TITLE
Improving DailyLogListener class

### DIFF
--- a/jpos/src/main/java/org/jpos/util/DailyLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/DailyLogListener.java
@@ -165,7 +165,7 @@ public class DailyLogListener extends RotateLogListener{
         compress(dest);
     }
 
-	public synchronized void deleteOldLogs() throws IOException {
+	public void deleteOldLogs() throws IOException {
 		if (maxAge <= 0) {
 			logDebug("maxage feature is disabled.");
 			return;
@@ -517,7 +517,7 @@ public class DailyLogListener extends RotateLogListener{
             try {
 				deleteOldLogs();
 			} catch (IOException e) {
-				e.printStackTrace(System.err);
+				logDebugEx("error deleting old logs",e);
 			}
             setLastDate(getDateFmt().format(new Date(scheduledExecutionTime())));
         }


### PR DESCRIPTION
Changes made based on comments of @apr and @alcarraz:

1. _sinchronized_ is not necessary in _DeleteOldLogs()_ function
2. use of _logDebugEx()_ function instead of _printStackTrace()_

Please, let me know any observation.