### PR TITLE
Added boolean rotate-on-startup configuration to RotateLogListener

### DIFF
--- a/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
@@ -66,7 +66,7 @@ public class RotateLogListenerTest {
     @Test
     public void testConstructorThrowsNullPointerException() throws Throwable {
         try {
-            new RotateLogListener(null, 100, 1000, 100L);
+            new RotateLogListener(null, 100, 1000, 100L, false);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
             // xpected


### PR DESCRIPTION
Added boolean rotate-on-startup configuration to RotateLogListener.

DailyLogListener which uses its own logRotate method is not aware or impacted by this configuration.