### PR TITLE
Added functionality and bug fix to PosDatCode.

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/PosDataCode.java
+++ b/jpos/src/main/java/org/jpos/iso/PosDataCode.java
@@ -19,12 +19,18 @@
 package org.jpos.iso;
 
 import java.io.PrintStream;
+
 import org.jpos.util.Loggeable;
 
 @SuppressWarnings("unused")
 public class PosDataCode implements Loggeable {
 
-    public enum ReadingMethod {
+
+    public interface Flag {
+        int getOffset();
+        int intValue();
+    }
+    public enum ReadingMethod implements Flag {
         UNKNOWN                (1, "Unknown"),
         CONTACTLESS            (1 << 1, "Information not taken from card"),  // i.e.: RFID
         PHYSICAL               (1 << 2, "Physical entry"),                   // i.e.: Manual Entry or OCR
@@ -50,8 +56,14 @@ public class PosDataCode implements Loggeable {
         public String toString () {
             return description;
         }
+
+        public static int OFFSET = 0;
+        @Override
+        public int getOffset() {
+            return OFFSET;
+        }
     }
-    public enum VerificationMethod {
+    public enum VerificationMethod implements Flag {
         UNKNOWN                              (1, "Unknown"),
         NONE                                 (1 << 1, "None"),
         MANUAL_SIGNATURE                     (1 << 2, "Manual signature"),
@@ -77,8 +89,14 @@ public class PosDataCode implements Loggeable {
         public String toString () {
             return description;
         }
+
+        public static int OFFSET = 4;
+        @Override
+        public int getOffset() {
+            return OFFSET;
+        }
     }
-    public enum POSEnvironment {
+    public enum POSEnvironment implements Flag {
         UNKNOWN                 (1, "Unknown"),
         ATTENDED                (1 << 1, "Attended POS"),
         UNATTENDED              (1 << 2, "Unattended, details unknown"),
@@ -105,9 +123,16 @@ public class PosDataCode implements Loggeable {
         public String toString () {
             return description;
         }
+
+
+        public static int OFFSET = 8;
+        @Override
+        public int getOffset() {
+            return OFFSET;
+        }
     }
 
-    public enum SecurityCharacteristic {
+    public enum SecurityCharacteristic implements Flag {
         UNKNOWN                                      (1, "Unknown"),
         PRIVATE_NETWORK                              (1 << 1, "Private network"),
         OPEN_NETWORK                                 (1 << 2, "Open network (Internet)"),
@@ -138,9 +163,18 @@ public class PosDataCode implements Loggeable {
         public String toString () {
             return description;
         }
+
+        public static int OFFSET = 12;
+        @Override
+        public int getOffset() {
+            return OFFSET;
+        }
     }
 
     private byte[] b = new byte[16];
+
+    public PosDataCode() {
+    }
 
     public PosDataCode (
             int readingMethod,
@@ -150,7 +184,6 @@ public class PosDataCode implements Loggeable {
     {
         super();
 
-        b = new byte[16];
 
         b[0]  = (byte) readingMethod;
         b[1]  = (byte) (readingMethod >>> 8);
@@ -178,28 +211,28 @@ public class PosDataCode implements Loggeable {
     }
 
     public boolean hasReadingMethods (int readingMethods) {
-        int i = b[3] << 24 | b[2] << 16 | b[1] << 8 | b[0];
+        int i = b[3] << 24 | b[2] << 16  & 0xFF0000 | b[1] << 8  & 0xFF00 | b[0] & 0xFF ;
         return (i & readingMethods) == readingMethods;
     }
     public boolean hasReadingMethod (ReadingMethod method) {
         return hasReadingMethods (method.intValue());
     }
     public boolean hasVerificationMethods (int verificationMethods) {
-        int i = b[7] << 24 | b[6] << 16 | b[5] << 8 | b[4];
+        int i = b[7] << 24 | b[6] << 16 & 0xFF0000 | b[5] << 8  & 0xFF00 | b[4] & 0xFF;
         return (i & verificationMethods) == verificationMethods;
     }
     public boolean hasVerificationMethod (VerificationMethod method) {
         return hasVerificationMethods(method.intValue());
     }
     public boolean hasPosEnvironments (int posEnvironments) {
-        int i = b[11] << 24 | b[10] << 16 | b[9] << 8 | b[8];
+        int i = b[11] << 24  | b[10] << 16 & 0xFF0000 | b[9] << 8 & 0xFF00 | b[8] & 0xFF;
         return (i & posEnvironments) == posEnvironments;
     }
     public boolean hasPosEnvironment (POSEnvironment method) {
         return hasPosEnvironments(method.intValue());
     }
     public boolean hasSecurityCharacteristics (int securityCharacteristics) {
-        int i = b[15] << 24 | b[14] << 16 | b[13] << 8 | b[12];
+        int i = b[15] << 24 | b[14] << 16 & 0xFF0000 | b[13] << 8  & 0xFF00 | b[12] & 0xFF;
         return (i & securityCharacteristics) == securityCharacteristics;
     }
     public boolean hasSecurityCharacteristic (SecurityCharacteristic characteristic) {
@@ -255,4 +288,77 @@ public class PosDataCode implements Loggeable {
         p.printf ("%ssc: %s%n", inner, sb.toString());
         p.println("</pdc>");
     }
+
+
+    /**
+     * Sets or unsets a set of flags according to value
+     * @param value if true flags are set, else unset
+     * @param flags flag set to set or unset
+     */
+    public void setFlags(boolean value, Flag... flags) {
+        if (value) {
+            for (Flag flag  : flags) {
+                for (int v = flag.intValue(), offset = flag.getOffset(); v != 0; v >>>= 8, offset++) {
+                    b[offset] |= (byte) v;
+                }
+            }
+        } else {
+            for (Flag flag  : flags) {
+                for (int v = flag.intValue(), offset = flag.getOffset(); v != 0; v >>>= 8, offset++) {
+                    b[offset] &= (byte) ~v;
+                }
+            }
+        }
+
+    }
+
+    public void setReadingMethods(boolean value, ReadingMethod ... methods ){
+        setFlags(value, methods);
+    }
+
+    public void unsetReadingMethods(ReadingMethod ... methods ) {
+        setReadingMethods(false, methods);
+    }
+
+    public void setReadingMethods(ReadingMethod ... methods ) {
+        setReadingMethods(true, methods);
+    }
+
+    public void setVerificationMethods(boolean value, VerificationMethod ... methods ){
+        setFlags(value, methods);
+    }
+
+    public void unsetVerificationMethods(VerificationMethod ... methods){
+        setVerificationMethods(false, methods);
+    }
+
+    public void setVerificationMethods(VerificationMethod ... methods){
+        setVerificationMethods(true, methods);
+    }
+
+    public void setPOSEnvironments(boolean value, POSEnvironment ... envs){
+        setFlags(value, envs);
+    }
+
+    public void unsetPOSEnvironments(POSEnvironment ... envs){
+        setPOSEnvironments(false, envs);
+    }
+
+    public void setPOSEnvironments(POSEnvironment ... envs){
+        setPOSEnvironments(true, envs);
+    }
+
+    public void setSecurityCharacteristics(boolean value, SecurityCharacteristic ... securityCharacteristics){
+        setFlags(value, securityCharacteristics);
+    }
+
+    public void unsetSecurityCharacteristics(SecurityCharacteristic ... envs){
+        setSecurityCharacteristics(false, envs);
+    }
+
+    public void setSecurityCharacteristics(SecurityCharacteristic ... envs){
+        setSecurityCharacteristics(true, envs);
+    }
+
+
 }

--- a/jpos/src/test/java/org/jpos/iso/PosDataCodeTest.java
+++ b/jpos/src/test/java/org/jpos/iso/PosDataCodeTest.java
@@ -1,0 +1,152 @@
+package org.jpos.iso;
+
+import org.jpos.iso.PosDataCode.POSEnvironment;
+import org.jpos.iso.PosDataCode.ReadingMethod;
+import org.jpos.iso.PosDataCode.SecurityCharacteristic;
+import org.jpos.iso.PosDataCode.VerificationMethod;
+import org.junit.Test;
+
+
+import java.util.BitSet;
+
+import static org.jpos.iso.PosDataCode.POSEnvironment.M_COMMERCE;
+import static org.jpos.iso.PosDataCode.POSEnvironment.RECURRING;
+import static org.jpos.iso.PosDataCode.ReadingMethod.*;
+import static org.jpos.iso.PosDataCode.SecurityCharacteristic.PKI_ENCRYPTION;
+import static org.jpos.iso.PosDataCode.SecurityCharacteristic.PRIVATE_ALG_ENCRYPTION;
+import static org.jpos.iso.PosDataCode.VerificationMethod.OFFLINE_PIN_IN_CLEAR;
+import static org.jpos.iso.PosDataCode.VerificationMethod.ONLINE_PIN;
+import static org.junit.Assert.*;
+
+public class PosDataCodeTest {
+
+    PosDataCode pdc = new PosDataCode();
+
+
+    @Test
+    public void defaultConstructor() {
+    }
+
+    @Test
+    public void constructorWithParams() {
+        PosDataCode pdc = new PosDataCode(0, 0, 0, 0);
+        for (int i = 0x80000000; i != 0; i>>>=1) {
+            assertFalse("No reading method should be set", pdc.hasReadingMethods(i));
+            assertFalse("No verification method should be set", pdc.hasVerificationMethods(i));
+            assertFalse("No pos environment should be set", pdc.hasPosEnvironments(i));
+            assertFalse("No security characteristic should be set", pdc.hasSecurityCharacteristics(i));
+        }
+    }
+
+
+    @Test
+    public void setFlags() {
+        pdc.setFlags(true,
+                ReadingMethod.UNKNOWN, VerificationMethod.UNKNOWN,
+                POSEnvironment.UNKNOWN, SecurityCharacteristic.UNKNOWN);
+        for (int i = 0x80000000; i != 1; i>>>=1) {
+            assertFalse("Only UNKNOWN reading method should be set", pdc.hasReadingMethods(i));
+            assertFalse("Only UNKNOWN verification method should be set", pdc.hasVerificationMethods(i));
+            assertFalse("Only UNKNOWN pos environment should be set", pdc.hasPosEnvironments(i));
+            assertFalse("Only UNKNOWN security characteristic should be set",
+                    pdc.hasSecurityCharacteristics(i));
+        }
+        assertTrue("UNKNOWN reading method should be set", pdc.hasReadingMethods(1));
+        assertTrue("UNKNOWN verification method should be set", pdc.hasVerificationMethods(1));
+        assertTrue("UNKNOWN pos environment should be set", pdc.hasPosEnvironments(1));
+        assertTrue("UNKNOWN security characteristic should be set", pdc.hasSecurityCharacteristics(1));
+        pdc.setFlags(false, ReadingMethod.UNKNOWN, VerificationMethod.UNKNOWN,
+                POSEnvironment.UNKNOWN, SecurityCharacteristic.UNKNOWN);
+        for (int i = 0x80000000; i != 0; i>>>=1) {
+            assertFalse("No reading method should be set", pdc.hasReadingMethods(i));
+            assertFalse("No verification method should be set", pdc.hasVerificationMethods(i));
+            assertFalse("No pos environment should be set", pdc.hasPosEnvironments(i));
+            assertFalse("No security characteristic should be set", pdc.hasSecurityCharacteristics(i));
+        }
+        pdc.setFlags(true,
+                CONTACTLESS, BARCODE,
+                ONLINE_PIN, OFFLINE_PIN_IN_CLEAR,
+                M_COMMERCE, RECURRING,
+                PRIVATE_ALG_ENCRYPTION, PKI_ENCRYPTION);
+        assertTrue("Reding methods missing",
+                pdc.hasReadingMethods(CONTACTLESS.intValue() | BARCODE.intValue()));
+        assertTrue("Verification methods missing",
+                pdc.hasVerificationMethods(ONLINE_PIN.intValue() | OFFLINE_PIN_IN_CLEAR.intValue()));
+        assertTrue("POS enironments missing",
+                pdc.hasPosEnvironments(M_COMMERCE.intValue() | RECURRING.intValue()));
+        assertTrue("Security characteristics  missing",
+                pdc.hasSecurityCharacteristics(PRIVATE_ALG_ENCRYPTION.intValue() | PKI_ENCRYPTION.intValue()));
+    }
+
+    @Test
+    public void setReadingMethods() {
+        pdc.setReadingMethods(CONTACTLESS, PHYSICAL, BARCODE);
+        assertTrue("Reding methods missing",
+                pdc.hasReadingMethods(CONTACTLESS.intValue() | PHYSICAL.intValue() | BARCODE.intValue()));
+    }
+
+    @Test
+    public void unsetReadingMethods() {
+        pdc.setReadingMethods(CONTACTLESS, PHYSICAL, BARCODE);
+        pdc.unsetReadingMethods(BARCODE);
+        assertFalse("Reding method BARCODE should not be present",
+                pdc.hasReadingMethods(CONTACTLESS.intValue() | PHYSICAL.intValue() | BARCODE.intValue()));
+        assertTrue("Reding methods CONTACTLESS and PHYSICAL should be present",
+                pdc.hasReadingMethods(CONTACTLESS.intValue() | PHYSICAL.intValue()));
+    }
+
+
+    @Test
+    public void setVerificationMethods() {
+        pdc.setVerificationMethods(ONLINE_PIN, OFFLINE_PIN_IN_CLEAR);
+        assertTrue("Verification methods missing",
+                pdc.hasVerificationMethods(ONLINE_PIN.intValue() | OFFLINE_PIN_IN_CLEAR.intValue()));
+    }
+
+    @Test
+    public void unsetVerificationMethods() {
+        pdc.setVerificationMethods(ONLINE_PIN, OFFLINE_PIN_IN_CLEAR);
+        pdc.unsetVerificationMethods(OFFLINE_PIN_IN_CLEAR);
+        assertFalse("Reding methods OFFLINE_PIN_IN_CLEAR should not be present",
+                pdc.hasVerificationMethods(ONLINE_PIN.intValue() | OFFLINE_PIN_IN_CLEAR.intValue()));
+        assertTrue("Reding methods ONLINE_PIN should be present",
+                pdc.hasVerificationMethods(ONLINE_PIN.intValue()));
+    }
+
+
+    @Test
+    public void setPOSEnvironments() {
+        pdc.setPOSEnvironments(M_COMMERCE, RECURRING);
+        assertTrue("Missing POS environments",
+                pdc.hasPosEnvironments(M_COMMERCE.intValue() | RECURRING.intValue()));
+    }
+
+    @Test
+    public void unsetPOSEnvironments() {
+        pdc.setPOSEnvironments(M_COMMERCE, RECURRING);
+        pdc.unsetPOSEnvironments(M_COMMERCE);
+        assertFalse("POS environment M_COMMERCE should not be present",
+                pdc.hasPosEnvironments(M_COMMERCE.intValue() | RECURRING.intValue()));
+        assertTrue("RECURRING POS environment should be present",
+                pdc.hasPosEnvironments(RECURRING.intValue()));
+    }
+
+
+    @Test
+    public void setSecurityCharacteristics() {
+        pdc.setSecurityCharacteristics(PRIVATE_ALG_ENCRYPTION, PKI_ENCRYPTION);
+        assertTrue("Missing Security Characteristics",
+                pdc.hasSecurityCharacteristics(PRIVATE_ALG_ENCRYPTION.intValue() | PKI_ENCRYPTION.intValue()));
+    }
+
+    @Test
+    public void unsetSecurityCharacteristics() {
+        pdc.setSecurityCharacteristics(PRIVATE_ALG_ENCRYPTION, PKI_ENCRYPTION);
+        pdc.unsetSecurityCharacteristics(PKI_ENCRYPTION);
+        assertFalse("PKI_ENCRYPTION Security Characteristics should not be present",
+                pdc.hasSecurityCharacteristics(PRIVATE_ALG_ENCRYPTION.intValue() | PKI_ENCRYPTION.intValue()));
+        assertTrue("PRIVATE_ALG_ENCRYPTION should be present",
+                pdc.hasSecurityCharacteristics(PRIVATE_ALG_ENCRYPTION.intValue()));
+   }
+
+}


### PR DESCRIPTION
- Add functionality to set/unset individual flags
- Bug fix: hasXXX methods failed when most significant bit of one byte was on, since conversion to integer preserved sign.
- Added Test cases for new functionality

New functionality is backward compatible since old code was not touched, except for the bugfix