### PR TITLE
Made generateClearKeyComponent public.

### DIFF
--- a/jpos/src/main/java/org/jpos/security/SMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/SMAdapter.java
@@ -1334,4 +1334,13 @@ public interface SMAdapter {
      * @throws SMException
      */
     SecureDESKey formKEYfromClearComponents (short keyLength, String keyType, String... clearComponent) throws SMException;
+    /**
+     * Generates a random clear key component.
+     * @param keyLength
+     * @return clear key componenet
+     * @throws SMException
+     */
+    default String generateClearKeyComponent (short keyLength) throws SMException{
+        throw new SMException("Operation not supported in: " + this.getClass().getName());
+    }
 }

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1197,7 +1197,7 @@ public class JCESecurityModule extends BaseSMAdapter {
      * @return clear key componenet
      * @throws SMException
      */
-    String generateClearKeyComponent (short keyLength) throws SMException {
+    public String generateClearKeyComponent (short keyLength) throws SMException {
         String clearKeyComponenetHexString;
         SimpleMsg[] cmdParameters =  {
             new SimpleMsg("parameter", "Key Length", keyLength)

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1191,8 +1191,7 @@ public class JCESecurityModule extends BaseSMAdapter {
     }
 
     /**
-     * Generates a random clear key component.<br>
-     * Used by Console, that's why it is package protected.
+     * Generates a random clear key component.
      * @param keyLength
      * @return clear key componenet
      * @throws SMException


### PR DESCRIPTION
It's key to an hsm implementation the ability to generate clear keys, so this "simulator" should be able to do it too.