### PR TITLE
Add LLLTTvvvvv Ebcdic encoded header and value, length left zero padded.

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/IFELPE_LLLCHAR.java
+++ b/jpos/src/main/java/org/jpos/iso/IFELPE_LLLCHAR.java
@@ -1,0 +1,94 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * ISOFieldPackager ASCII variable len CHAR 
+ * suitable for GICC subfield 60<br>
+ * <code>
+ * Format LLLTT....
+ * Where LLL is the 3 digit field length
+ *       TT is the 2 digit field number (Tag)
+ *       is the field content   
+ * </code>
+ */
+public class IFELPE_LLLCHAR extends ISOFieldPackager {
+    private static final int TAG_BYTE_LENGTH = 2;
+    private static final int LENGTH_BYTE_LENGTH = 3;
+    private static final int TAG_HEADER_LENGTH = TAG_BYTE_LENGTH + LENGTH_BYTE_LENGTH;
+
+    public IFELPE_LLLCHAR() {
+        super();
+    }
+    /**
+     * @param len - field len
+     * @param description symbolic descrption
+     */
+    public IFELPE_LLLCHAR(int len, String description) {
+        super(len, description);
+    }
+    /**
+     * @param c - a component
+     * @return packed component
+     * @exception ISOException
+     */
+    @Override
+    public byte[] pack(final ISOComponent c) throws ISOException {
+        final String s = (String) c.getValue();
+        final int len = s.length();
+        final byte[] payload = new byte[len + TAG_HEADER_LENGTH];
+        final String tagHeader = ISOUtil.zeropad(Integer.toString(len + TAG_BYTE_LENGTH), LENGTH_BYTE_LENGTH)
+                + ISOUtil.zeropad(c.getKey().toString(), TAG_BYTE_LENGTH);
+        System.arraycopy(ISOUtil.asciiToEbcdic(tagHeader), 0, payload, 0, TAG_HEADER_LENGTH);
+        System.arraycopy(ISOUtil.asciiToEbcdic(s), 0, payload, TAG_HEADER_LENGTH, len);
+        return payload;
+    }
+
+    @Override
+    public int unpack(final ISOComponent c, final byte[] b, final int offset) throws ISOException {
+        final String asciiResult = ISOUtil.ebcdicToAscii(b, offset, LENGTH_BYTE_LENGTH);
+        final int len = Integer.parseInt(asciiResult) - TAG_BYTE_LENGTH;
+        if (!(c instanceof ISOField)) throw new ISOException(c.getClass()
+                .getName()
+                + " is not an ISOField");
+        c.setFieldNumber(Integer.parseInt(ISOUtil.ebcdicToAscii(b, offset + LENGTH_BYTE_LENGTH, TAG_BYTE_LENGTH)));
+        c.setValue(ISOUtil.ebcdicToAscii(b, offset + TAG_HEADER_LENGTH, len));
+        return len + 5;
+    }
+
+    @Override
+    public void unpack(final ISOComponent c, final InputStream in) throws IOException,
+            ISOException {
+        if (!(c instanceof ISOField)) throw new ISOException(c.getClass()
+                .getName()
+                + " is not an ISOField");
+
+        final int len = Integer.parseInt(ISOUtil.ebcdicToAscii(readBytes(in, LENGTH_BYTE_LENGTH))) - TAG_BYTE_LENGTH;
+        final int fieldNumber = Integer.parseInt(ISOUtil.ebcdicToAscii(readBytes(in, TAG_BYTE_LENGTH)));
+        c.setFieldNumber(fieldNumber);
+        c.setValue(new String(readBytes(in, len)));
+    }
+
+    @Override
+    public int getMaxPackedLength() {
+        return getLength() + TAG_BYTE_LENGTH;
+    }
+}

--- a/jpos/src/test/java/org/jpos/iso/IFELPE_LLLCHARTest.java
+++ b/jpos/src/test/java/org/jpos/iso/IFELPE_LLLCHARTest.java
@@ -1,0 +1,70 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import junit.framework.TestCase;
+
+public class IFELPE_LLLCHARTest extends TestCase
+{
+    public void testPack() throws Exception
+    {
+        ISOField field = new ISOField(92, "123");
+        IFELPE_LLLCHAR packager = new IFELPE_LLLCHAR(92, "Should be F0F0F5F9F2F1F2F3");
+        TestUtils.assertEquals(new byte[] {(byte)0xF0, (byte)0xF0,(byte)0xf5, (byte)0xF9, (byte)0xF2,  (byte)0xF1, (byte)0xF2, (byte)0xF3},
+                            packager.pack(field));
+    }
+
+    public void testUnpack() throws Exception
+    {
+        byte[] raw = new byte[] {(byte)0xF0, (byte)0xF0,(byte)0xf5, (byte)0xF9, (byte)0xF2,  (byte)0xF1, (byte)0xF2, (byte)0xF3};
+        IFELPE_LLLCHAR packager = new IFELPE_LLLCHAR(10, "Should be F0F0F5F9F2F1F2F3");
+        ISOField field = new ISOField();
+        int len = packager.unpack(field, raw, 0);
+        assertEquals(raw.length, len);
+        assertEquals("123", (String) field.getValue());
+        assertEquals(92, field.fieldNumber);    // Derived from TAG!
+    }
+
+    public void testReversability() throws Exception
+    {
+        String origin = "Abc123:.-";
+        ISOField f = new ISOField(92, origin);
+        IFELPE_LLLCHAR packager = new IFELPE_LLLCHAR(92, "Should be Abc123:.-");
+
+        ISOField unpack = new ISOField();
+        int len = packager.unpack(unpack, packager.pack(f), 0);
+        assertEquals(origin.length()+2+3, len);
+        assertEquals(origin, (String) unpack.getValue());
+        assertEquals(92,unpack.fieldNumber);    // Derived from TAG!
+    }
+    
+    public void testReversability2() throws Exception
+    {
+        String origin = "Packager";
+        ISOField f = new ISOField(87, origin);
+        IFELPE_LLLCHAR packager = new IFELPE_LLLCHAR(87, "Should be Packager");
+
+        ISOField unpack = new ISOField();
+        byte[] packed = packager.pack(f);
+        int len = packager.unpack(unpack, packed , 0);
+        assertEquals(origin.length()+2+3, len);
+        assertEquals(origin, unpack.getValue());
+        assertEquals(87,unpack.fieldNumber);    // Derived from TAG!
+    }
+}


### PR DESCRIPTION
Due to some discussions over more generic solution in #203 this change will add another option of a LLLTTvvvvv field packager that I finally wanted to create.