### PR TITLE
Add TLVList builder pattern

### DIFF
--- a/jpos/src/main/java/org/jpos/tlv/TLVList.java
+++ b/jpos/src/main/java/org/jpos/tlv/TLVList.java
@@ -18,7 +18,6 @@
 
 package org.jpos.tlv;
 
-import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOUtil;
 import org.jpos.util.Loggeable;
 
@@ -68,10 +67,9 @@ public class TLVList implements Serializable, Loggeable {
      * Unpack a message.
      *
      * @param buf raw message
-     * @throws ISOException
      * @throws IllegalArgumentException
      */
-    public void unpack(byte[] buf) throws ISOException, IllegalArgumentException {
+    public void unpack(byte[] buf) throws IllegalArgumentException {
         unpack(buf, 0);
     }
 
@@ -94,11 +92,10 @@ public class TLVList implements Serializable, Loggeable {
      *
      * @param buf raw message
      * @param offset the offset
-     * @throws ISOException
      * @throws IndexOutOfBoundsException if {@code offset} exceeds {code buf.length}
      * @throws IllegalArgumentException
      */
-    public void unpack(byte[] buf, int offset) throws ISOException, IllegalArgumentException
+    public void unpack(byte[] buf, int offset) throws IllegalArgumentException
             , IndexOutOfBoundsException {
         ByteBuffer buffer = ByteBuffer.wrap(buf, offset, buf.length - offset);
         TLVMsg currentNode;
@@ -247,22 +244,21 @@ public class TLVList implements Serializable, Loggeable {
      *
      * @param buffer the buffer
      * @return TLVMsg
-     * @throws ISOException
      * @throws IllegalArgumentException
      */
-    private TLVMsg getTLVMsg(ByteBuffer buffer) throws ISOException, IllegalArgumentException {
+    private TLVMsg getTLVMsg(ByteBuffer buffer) throws IllegalArgumentException {
         int tag = getTAG(buffer);  // tag id 0x00 if tag not found
         if (tag == SKIP_BYTE1)
             return null;
 
         // Get Length if buffer remains!
         if (!buffer.hasRemaining())
-            throw new ISOException(String.format("BAD TLV FORMAT - tag (%x)"
+            throw new IllegalArgumentException(String.format("BAD TLV FORMAT: tag (%x)"
                     + " without length or value",tag)
             );
         int length = getValueLength(buffer);
         if (length > buffer.remaining())
-            throw new ISOException(String.format("BAD TLV FORMAT - tag (%x)"
+            throw new IllegalArgumentException(String.format("BAD TLV FORMAT: tag (%x)"
                     + " length (%d) exceeds available data", tag, length)
             );
         byte[] arrValue = new byte[length];

--- a/jpos/src/main/java/org/jpos/tlv/TLVList.java
+++ b/jpos/src/main/java/org/jpos/tlv/TLVList.java
@@ -124,8 +124,9 @@ public class TLVList implements Serializable, Loggeable {
      *
      * @param tag tag id
      * @param value tag value
+     * @throws IllegalArgumentException when contains tag with illegal id
      */
-    public void append(int tag, byte[] value) {
+    public void append(int tag, byte[] value) throws IllegalArgumentException {
         append(createTLVMsg(tag, value));
     }
 
@@ -134,8 +135,9 @@ public class TLVList implements Serializable, Loggeable {
      *
      * @param tag id
      * @param value in hexadecimal character representation
+     * @throws IllegalArgumentException when contains tag with illegal id
      */
-    public void append(int tag, String value) {
+    public void append(int tag, String value) throws IllegalArgumentException {
         append(createTLVMsg(tag, ISOUtil.hex2byte(value)));
     }
 
@@ -286,9 +288,10 @@ public class TLVList implements Serializable, Loggeable {
      * @param tag tag identifier
      * @param value the value of tag
      * @return TLV message instance
+     * @throws IllegalArgumentException when contains tag with illegal id
      */
     @SuppressWarnings("deprecation")
-    protected TLVMsg createTLVMsg(int tag, byte[] value) {
+    protected TLVMsg createTLVMsg(int tag, byte[] value) throws IllegalArgumentException {
         return new TLVMsg(tag, value);
     }
 

--- a/jpos/src/main/java/org/jpos/tlv/TLVList.java
+++ b/jpos/src/main/java/org/jpos/tlv/TLVList.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author bharavi
@@ -107,9 +108,14 @@ public class TLVList implements Serializable, Loggeable {
     }
 
     /**
-     * Append TLVMsg to the TLVList.
+     * Append TLVMsg to the TLV list.
+     *
+     * @param tlv the TLV message
+     * @throws NullPointerException if {@code tlv} is {@code null}
      */
-    public void append(TLVMsg tlv) {
+    public void append(TLVMsg tlv) throws NullPointerException {
+        Objects.requireNonNull(tlv, "TLV message cannot be null");
+
         tags.add(tlv);
     }
 

--- a/jpos/src/main/java/org/jpos/tlv/TLVList.java
+++ b/jpos/src/main/java/org/jpos/tlv/TLVList.java
@@ -126,7 +126,7 @@ public class TLVList implements Serializable, Loggeable {
      * @param value tag value
      */
     public void append(int tag, byte[] value) {
-        append(getTLVMsg(tag, value));
+        append(createTLVMsg(tag, value));
     }
 
     /**
@@ -136,7 +136,7 @@ public class TLVList implements Serializable, Loggeable {
      * @param value in hexadecimal character representation
      */
     public void append(int tag, String value) {
-        append(getTLVMsg(tag, ISOUtil.hex2byte(value)));
+        append(createTLVMsg(tag, ISOUtil.hex2byte(value)));
     }
 
     /**
@@ -274,10 +274,21 @@ public class TLVList implements Serializable, Loggeable {
         byte[] arrValue = new byte[length];
         buffer.get(arrValue);
 
-        return getTLVMsg(tag, arrValue);
+        return createTLVMsg(tag, arrValue);
     }
 
-    protected TLVMsg getTLVMsg(int tag, byte[] value) {
+    /**
+     * Create TLV message instance.
+     *
+     * @apiNote The protected scope is intended to not promote the use of TLVMsg
+     * outside.
+     *
+     * @param tag tag identifier
+     * @param value the value of tag
+     * @return TLV message instance
+     */
+    @SuppressWarnings("deprecation")
+    protected TLVMsg createTLVMsg(int tag, byte[] value) {
         return new TLVMsg(tag, value);
     }
 

--- a/jpos/src/main/java/org/jpos/tlv/TLVList.java
+++ b/jpos/src/main/java/org/jpos/tlv/TLVList.java
@@ -57,7 +57,7 @@ public class TLVList implements Serializable, Loggeable {
 
     private final List<TLVMsg> tags = new ArrayList<>();
 
-    private int tagToFind = 0;
+    private int tagToFind = -1;
     private int indexLastOccurrence = -1;
 
     public TLVList() {
@@ -201,9 +201,13 @@ public class TLVList implements Serializable, Loggeable {
      * Return the next TLVMsg of same TAG value.
      *
      * @return TLV message or {@code null} if not found.
+     * @throws IllegalStateException when the search has not been initiated
      */
-    public TLVMsg findNextTLV() {
-
+    public TLVMsg findNextTLV() throws IllegalStateException {
+        if (tagToFind < 0)
+            throw new IllegalStateException(
+                    "The initialization of the searched tag is required"
+            );
         for ( int i=indexLastOccurrence + 1 ; i < tags.size(); i++) {
             if (tags.get(i).getTag() == tagToFind) {
                 indexLastOccurrence = i;

--- a/jpos/src/main/java/org/jpos/tlv/TLVMsg.java
+++ b/jpos/src/main/java/org/jpos/tlv/TLVMsg.java
@@ -43,7 +43,22 @@ public class TLVMsg implements Loggeable {
      *
      * @param tag id
      * @param value tag value
+     * @deprecated In most cases, a message is created to attach it to the list.
+     * <br>
+     * It can be done by:
+     * <pre>{@code
+     *   TLVList tl = ...;
+     *   tl.append(tag, value);
+     * }</pre>
+     * If for some reason this is not possible then a message can be created:
+     * <pre>{@code
+     *   TLVList tl = new TLVList();
+     *   tl.append(tag, value);
+     *   TLVMsg tm = tl.find(tag);
+     * }</pre>
+     * The intention is to not promote the use of TLVMsg outside
      */
+    @Deprecated
     public TLVMsg(int tag, byte[] value) {
         this.tag = tag;
         this.value = value;

--- a/jpos/src/main/java/org/jpos/tlv/TLVMsg.java
+++ b/jpos/src/main/java/org/jpos/tlv/TLVMsg.java
@@ -27,19 +27,20 @@ import org.jpos.util.Loggeable;
  * @author bharavi
  */
 public class TLVMsg implements Loggeable {
+
     private int tag;
     protected byte[] value;
 
     /**
-     * empty constructor
+     * Empty constructor.
      */
     public TLVMsg() {
         super();
     }
 
     /**
-     * constructs a TLV Message from tag and value
-     * 
+     * Constructs a TLV message from tag and value.
+     *
      * @param tag id
      * @param value tag value
      */
@@ -97,14 +98,13 @@ public class TLVMsg implements Loggeable {
             System.arraycopy(bTag, 0, out, 0, bTag.length);
             System.arraycopy(bLen, 0, out, bTag.length, bLen.length);
             return out;
-
         }
     }
 
     /**
      * Value up to 127 can be encoded in single byte and multiple bytes are
      * required for length bigger than 127
-     * 
+     *
      * @return encoded length
      */
     public byte[] getL() {
@@ -124,20 +124,20 @@ public class TLVMsg implements Loggeable {
         byte[] rBytes = bi.toByteArray();
         /* If value can be encoded on one byte */
         if (value.length < 0x80)
-          return rBytes;
+            return rBytes;
 
         //we need 1 byte to indicate the length
         //for that is used sign byte (first 8-bits equals 0),
         //if it is not present it is added
-        if ( rBytes[0] > 0 )
-          rBytes = ISOUtil.concat(new byte[1], rBytes);
-        rBytes[0] = (byte) (0x80 | rBytes.length-1);
+        if (rBytes[0] > 0)
+            rBytes = ISOUtil.concat(new byte[1], rBytes);
+        rBytes[0] = (byte) (0x80 | rBytes.length - 1);
 
         return rBytes;
     }
-    
+
     /**
-     * @return value 
+     * @return value
      */
     public String getStringValue() {
         return ISOUtil.hexString(value);
@@ -147,18 +147,20 @@ public class TLVMsg implements Loggeable {
     public String toString(){
         String t = Integer.toHexString(tag);
         if (t.length() % 2 > 0)
-          t = "0"+t;
+            t = "0" + t;
         return String.format("[tag: 0x%s, %s]", t
-                ,value==null?null:getStringValue());
+                ,value == null ? null : getStringValue()
+        );
     }
 
     @Override
     public void dump(PrintStream p, String indent) {
-        p.print (indent);
-        p.print ("<tag id='");
-        p.print (Integer.toHexString(getTag()));
-        p.print ("' value='");
-        p.print (ISOUtil.hexString(getValue()));
-        p.println ("' />");
+        p.print(indent);
+        p.print("<tag id='");
+        p.print(Integer.toHexString(getTag()));
+        p.print("' value='");
+        p.print(ISOUtil.hexString(getValue()));
+        p.println("' />");
     }
+
 }

--- a/jpos/src/main/java/org/jpos/tlv/TLVMsg.java
+++ b/jpos/src/main/java/org/jpos/tlv/TLVMsg.java
@@ -28,15 +28,8 @@ import org.jpos.util.Loggeable;
  */
 public class TLVMsg implements Loggeable {
 
-    private int tag;
-    protected byte[] value;
-
-    /**
-     * Empty constructor.
-     */
-    public TLVMsg() {
-        super();
-    }
+    private final int tag;
+    private final byte[] value;
 
     /**
      * Constructs a TLV message from tag and value.
@@ -76,20 +69,6 @@ public class TLVMsg implements Loggeable {
      */
     public byte[] getValue() {
         return value;
-    }
-
-    /**
-     * @param tag of TLV Message
-     */
-    public void setTag(int tag) {
-        this.tag = tag;
-    }
-
-    /**
-     * @param value of TLV Message
-     */
-    public void setValue(byte[] value) {
-        this.value = value;
     }
 
     /**

--- a/jpos/src/main/java/org/jpos/tlv/TLVMsg.java
+++ b/jpos/src/main/java/org/jpos/tlv/TLVMsg.java
@@ -81,24 +81,22 @@ public class TLVMsg implements Loggeable {
      * @return tag + length + value of the TLV Message
      */
     public byte[] getTLV() {
-        String hexVal = Integer.toHexString(tag);
-        byte[] bTag = ISOUtil.hex2byte(hexVal);
+        String hexTag = Integer.toHexString(tag);
+        byte[] bTag = ISOUtil.hex2byte(hexTag);
         byte[] bLen = getL();
-        if (value != null) {
-            int tLength = bTag.length + bLen.length + value.length;
-            byte[] out = new byte[tLength];
-            System.arraycopy(bTag, 0, out, 0, bTag.length);
-            System.arraycopy(bLen, 0, out, bTag.length, bLen.length);
-            System.arraycopy(value, 0, out, bTag.length + bLen.length,
-                    value.length);
-            return out;
-        } else {//Length can be 0
-            int tLength = bTag.length + bLen.length;
-            byte[] out = new byte[tLength];
-            System.arraycopy(bTag, 0, out, 0, bTag.length);
-            System.arraycopy(bLen, 0, out, bTag.length, bLen.length);
-            return out;
-        }
+        byte[] bVal = getValue();
+        if (bVal == null)
+            //Value can be null
+            bVal = new byte[0];
+
+        int tLength = bTag.length + bLen.length + bVal.length;
+        byte[] out = new byte[tLength];
+        System.arraycopy(bTag, 0, out, 0, bTag.length);
+        System.arraycopy(bLen, 0, out, bTag.length, bLen.length);
+        System.arraycopy(bVal, 0, out, bTag.length + bLen.length,
+                bVal.length
+        );
+        return out;
     }
 
     /**

--- a/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
@@ -60,6 +60,17 @@ public class TLVListTest {
         assertFalse(instance.getTags().isEmpty());
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testAppendThrowsNPE() {
+        instance.append(TEST_TAG1, new byte[2]);
+        try {
+            instance.append(null);
+        } catch (RuntimeException ex) {
+            assertFalse(instance.getTags().isEmpty());
+            throw ex;
+        }
+    }
+
     @Test
     public void testConstructor() {
         assertTrue(instance.getTags().isEmpty());
@@ -103,43 +114,6 @@ public class TLVListTest {
         instance.append(TEST_TAG2, new byte[0]);
         instance.deleteByTag(TEST_TAG2);
         assertTrue(instance.getTags().isEmpty());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testDeleteByTagThrowsNullPointerException() {
-        instance.append(TEST_TAG1, new byte[1]);
-        instance.append(null);
-        try {
-            instance.deleteByTag(TEST_TAG3);
-        } catch (RuntimeException ex) {
-            assertFalse(instance.getTags().isEmpty());
-            throw ex;
-        }
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testDeleteByTagThrowsNullPointerException2() {
-        instance.append(new TLVMsg());
-        instance.append(TEST_TAG1, new byte[2]);
-        instance.append(null);
-        try {
-            instance.deleteByTag(TEST_TAG1);
-        } catch (RuntimeException ex) {
-            assertFalse(instance.getTags().isEmpty());
-            throw ex;
-        }
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testDeleteByTagThrowsNullPointerException3() {
-        instance.append(TEST_TAG1, new byte[1]);
-        instance.append(null);
-        try {
-            instance.deleteByTag(TEST_TAG1);
-        } catch (RuntimeException ex) {
-            assertFalse(instance.getTags().isEmpty());
-            throw ex;
-        }
     }
 
     @Test
@@ -200,19 +174,6 @@ public class TLVListTest {
         assertEquals(0, result);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testFindIndexThrowsNullPointerException() {
-        instance.append(new TLVMsg());
-        instance.append(null);
-        instance.findIndex(TEST_TAG1);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testFindIndexThrowsNullPointerException1() {
-        instance.append(null);
-        instance.findIndex(TEST_TAG1);
-    }
-
     @Test
     public void testFindNextTLV() {
         instance.findIndex(TEST_TAG1);
@@ -243,33 +204,6 @@ public class TLVListTest {
         assertNull(result);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testFindNextTLVThrowsNullPointerException() {
-        instance.append(null);
-        instance.findNextTLV();
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testFindNextTLVThrowsNullPointerException1() {
-        instance.findIndex(TEST_TAG1);
-        instance.append(new TLVMsg());
-        instance.append(null);
-        instance.findNextTLV();
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testFindThrowsNullPointerException() {
-        instance.append(null);
-        instance.find(TEST_TAG1);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testFindThrowsNullPointerException1() {
-        instance.append(new TLVMsg());
-        instance.append(null);
-        instance.find(TEST_TAG1);
-    }
-
     @Test
     public void testIndex() {
         TLVMsg expected = new TLVMsg(TEST_TAG1, null);
@@ -289,14 +223,12 @@ public class TLVListTest {
         instance.deleteByIndex(0);
         instance.append(new TLVMsg());
         instance.append(1, new byte[3]);
-        instance.append(null);
         instance.append(0x0a, new byte[0]);
         instance.append(new TLVMsg());
         instance.append(0x2710, new byte[2]);
         instance.append(0x0186a0, new byte[1]);
-        instance.append(null);
-        TLVMsg result = instance.index(12);
-        assertNull(result);
+        TLVMsg result = instance.index(10);
+        assertEquals(0x0186a0, result.getTag());
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -308,12 +240,6 @@ public class TLVListTest {
     public void testPack() {
         byte[] result = instance.pack();
         assertEquals(0, result.length);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testPackThrowsNullPointerException() {
-        instance.append(null);
-        instance.pack();
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
@@ -185,23 +185,34 @@ public class TLVListTest {
     @Test
     public void testFindNextTLV1() {
         instance.append(TEST_TAG1, new byte[2]);
-        TLVMsg expected = new TLVMsg();
+        instance.append(TEST_TAG2, new byte[2]);
+        TLVMsg expected = instance.getTLVMsg(TEST_TAG1, null);
         instance.append(expected);
+        assertEquals(0, instance.findIndex(TEST_TAG1));
         TLVMsg result = instance.findNextTLV();
         assertSame(expected, result);
     }
 
     @Test
     public void testFindNextTLV2() {
-        instance.append(0x00, new byte[3]);
+        instance.append(TEST_TAG1, new byte[2]);
+        instance.append(TEST_TAG2, new byte[2]);
+        TLVMsg expected = instance.getTLVMsg(TEST_TAG1, null);
+        instance.append(expected);
+        instance.find(TEST_TAG1);
         TLVMsg result = instance.findNextTLV();
-        assertEquals(0x00, result.getTag());
+        assertSame(expected, result);
     }
 
-    @Test
-    public void testFindNextTLV3() {
-        TLVMsg result = instance.findNextTLV();
-        assertNull(result);
+    @Test(expected = IllegalStateException.class)
+    public void testFindNextTLVThrowsIllegalStateExeption1() {
+        instance.append(TEST_TAG1, new byte[3]);
+        instance.findNextTLV();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testFindNextTLVThrowsIllegalStateExeption2() {
+        instance.findNextTLV();
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import java.nio.BufferUnderflowException;
 import java.util.List;
 
 import org.jpos.iso.ISOException;
@@ -441,23 +440,23 @@ public class TLVListTest {
         assertFalse(instance.getTags().isEmpty());
     }
 
-    @Test(expected = BufferUnderflowException.class)
-    public void testUnpackInvalidLengthThrowsBufferUnderflowException() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackInvalidLengthThrowsIllegalArgumentException() throws Throwable {
         byte[] buf = ISOUtil.hex2byte("14830000");
         try {
             instance.unpack(buf);
-        } catch (RuntimeException ex) {
+        } catch (IllegalArgumentException ex) {
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = BufferUnderflowException.class)
-    public void testUnpackInvalidTagThrowsBufferUnderflowException() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackInvalidTagThrowsIllegalArgumentException() throws Throwable {
         byte[] buf = ISOUtil.hex2byte("007f");
         try {
             instance.unpack(buf);
-        } catch (BufferUnderflowException ex) {
+        } catch (IllegalArgumentException ex) {
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }

--- a/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
@@ -37,7 +37,7 @@ import org.junit.rules.ExpectedException;
 
 public class TLVListTest {
 
-    static final String ISO_EXCEPT_EXCEEDS_AVAL = "BAD TLV FORMAT - tag (%x) length (%d) exceeds available data.";
+    static final String ISO_EXCEPT_EXCEEDS_AVAL = "BAD TLV FORMAT - tag (%x) length (%d) exceeds available data";
 
     static final String ISO_EXCEPT_WITHOUT_LEN  = "BAD TLV FORMAT - tag (%x) without length or value";
 
@@ -446,8 +446,19 @@ public class TLVListTest {
         assertTrue("tLVList.elements().hasMoreElements()", tLVList.elements().hasMoreElements());
     }
 
+    @Test(expected = BufferUnderflowException.class)
+    public void testUnpackInvalidLengthThrowsBufferUnderflowException() throws Throwable {
+        byte[] buf = ISOUtil.hex2byte("14830000");
+        try {
+            tLVList.unpack(buf);
+        } catch (RuntimeException ex) {
+            assertTrue(tLVList.getTags().isEmpty());
+            throw ex;
+        }
+    }
+
     @Test
-    public void testUnpackThrowsBufferUnderflowException3() throws Throwable {
+    public void testUnpackInvalidTagThrowsBufferUnderflowException() throws Throwable {
         byte[] buf = ISOUtil.hex2byte("007f");
         exception.expect(BufferUnderflowException.class);
         try {
@@ -679,7 +690,7 @@ public class TLVListTest {
             assertFalse("tLVList.elements().hasMoreElements()", tLVList.elements().hasMoreElements());
             throw ex;
         }
-    } 
+    }
 
     @Test
     public void testUnpackThrowsISOException6() throws Throwable {
@@ -746,4 +757,5 @@ public class TLVListTest {
     public void testUnpackThrowsNullPointerException1() throws Throwable {
         tLVList.unpack(null);
     }
+
 }

--- a/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
@@ -133,9 +133,9 @@ public class TLVListTest {
 
     @Test
     public void testFind1() {
-        TLVMsg expected = new TLVMsg();
+        TLVMsg expected = instance.createTLVMsg(TEST_TAG1, null);
         instance.append(expected);
-        TLVMsg result = instance.find(0x00);
+        TLVMsg result = instance.find(TEST_TAG1);
         assertSame(expected, result);
     }
 
@@ -169,8 +169,8 @@ public class TLVListTest {
 
     @Test
     public void testFindIndex2() {
-        instance.append(new TLVMsg());
-        int result = instance.findIndex(0);
+        instance.append(instance.createTLVMsg(TEST_TAG1, null));
+        int result = instance.findIndex(TEST_TAG1);
         assertEquals(0, result);
     }
 
@@ -227,15 +227,15 @@ public class TLVListTest {
     public void testIndex1() {
         instance.append(instance.createTLVMsg(TEST_TAG1, "testString".getBytes()));
         instance.append(TEST_TAG1, new byte[1]);
-        instance.append(new TLVMsg());
+        instance.append(instance.createTLVMsg(0x0b, null));
         instance.append(TEST_TAG3, new byte[3]);
         instance.append(TEST_TAG2, new byte[1]);
         instance.append(-1, new byte[0]);
         instance.deleteByIndex(0);
-        instance.append(new TLVMsg());
+        instance.append(instance.createTLVMsg(0x0c, null));
         instance.append(1, new byte[3]);
         instance.append(0x0a, new byte[0]);
-        instance.append(new TLVMsg());
+        instance.append(instance.createTLVMsg(0x0d, null));
         instance.append(0x2710, new byte[2]);
         instance.append(0x0186a0, new byte[1]);
         TLVMsg result = instance.index(10);

--- a/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
@@ -56,7 +56,7 @@ public class TLVListTest {
 
     @Test
     public void testAppend1() {
-        instance.append(new TLVMsg(TEST_TAG1, new byte[0]));
+        instance.append(instance.createTLVMsg(TEST_TAG1, new byte[0]));
         assertFalse(instance.getTags().isEmpty());
     }
 
@@ -125,7 +125,7 @@ public class TLVListTest {
     @Test
     public void testFind() {
         instance.append(TEST_TAG1, new byte[1]);
-        TLVMsg expected = new TLVMsg(0x07, null);
+        TLVMsg expected = instance.createTLVMsg(0x07, null);
         instance.append(expected);
         TLVMsg result = instance.find(0x07);
         assertSame(expected, result);
@@ -186,7 +186,7 @@ public class TLVListTest {
     public void testFindNextTLV1() {
         instance.append(TEST_TAG1, new byte[2]);
         instance.append(TEST_TAG2, new byte[2]);
-        TLVMsg expected = instance.getTLVMsg(TEST_TAG1, null);
+        TLVMsg expected = instance.createTLVMsg(TEST_TAG1, null);
         instance.append(expected);
         assertEquals(0, instance.findIndex(TEST_TAG1));
         TLVMsg result = instance.findNextTLV();
@@ -197,7 +197,7 @@ public class TLVListTest {
     public void testFindNextTLV2() {
         instance.append(TEST_TAG1, new byte[2]);
         instance.append(TEST_TAG2, new byte[2]);
-        TLVMsg expected = instance.getTLVMsg(TEST_TAG1, null);
+        TLVMsg expected = instance.createTLVMsg(TEST_TAG1, null);
         instance.append(expected);
         instance.find(TEST_TAG1);
         TLVMsg result = instance.findNextTLV();
@@ -217,7 +217,7 @@ public class TLVListTest {
 
     @Test
     public void testIndex() {
-        TLVMsg expected = new TLVMsg(TEST_TAG1, null);
+        TLVMsg expected = instance.createTLVMsg(TEST_TAG1, null);
         instance.append(expected);
         TLVMsg result = instance.index(0);
         assertSame(expected, result);
@@ -225,7 +225,7 @@ public class TLVListTest {
 
     @Test
     public void testIndex1() {
-        instance.append(new TLVMsg(TEST_TAG1, "testString".getBytes()));
+        instance.append(instance.createTLVMsg(TEST_TAG1, "testString".getBytes()));
         instance.append(TEST_TAG1, new byte[1]);
         instance.append(new TLVMsg());
         instance.append(TEST_TAG3, new byte[3]);

--- a/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
@@ -27,16 +27,15 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOUtil;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TLVListTest {
 
-    static final String ISO_EXCEPT_EXCEEDS_AVAL = "BAD TLV FORMAT - tag (%x) length (%d) exceeds available data";
+    static final String EXCEPT_MSG_EXCEEDS_AVAL = "BAD TLV FORMAT: tag (%x) length (%d) exceeds available data";
 
-    static final String ISO_EXCEPT_WITHOUT_LEN  = "BAD TLV FORMAT - tag (%x) without length or value";
+    static final String EXCEPT_MSG_WITHOUT_LEN  = "BAD TLV FORMAT: tag (%x) without length or value";
 
     static final int TEST_TAG1      = 0x64;
     static final int TEST_TAG2      = 0x46;
@@ -318,7 +317,7 @@ public class TLVListTest {
     }
 
     @Test
-    public void testUnpack() throws Throwable {
+    public void testUnpack() {
         byte[] buf = ISOUtil.hex2byte("030100");
         instance.unpack(buf, 0);
         assertFalse(instance.getTags().isEmpty());
@@ -328,7 +327,7 @@ public class TLVListTest {
     }
 
     @Test
-    public void testUnpack1() throws Throwable {
+    public void testUnpack1() {
         byte[] buf = ISOUtil.hex2byte("000100");
         instance.unpack(buf, 0);
         assertFalse(instance.getTags().isEmpty());
@@ -338,7 +337,7 @@ public class TLVListTest {
     }
 
     @Test
-    public void testUnpack10() throws Throwable {
+    public void testUnpack10() {
         byte[] buf = ISOUtil.hex2byte("2080");
         instance.unpack(buf);
         assertFalse(instance.getTags().isEmpty());
@@ -348,7 +347,7 @@ public class TLVListTest {
     }
 
     @Test
-    public void testUnpack11() throws Throwable {
+    public void testUnpack11() {
         byte[] buf = ISOUtil.hex2byte("030100");
         instance.unpack(buf);
         assertFalse(instance.getTags().isEmpty());
@@ -358,14 +357,14 @@ public class TLVListTest {
     }
 
     @Test
-    public void testUnpack12() throws Throwable {
+    public void testUnpack12() {
         byte[] buf = ISOUtil.hex2byte("ff00");
         instance.unpack(buf);
         assertTrue(instance.getTags().isEmpty());
     }
 
     @Test
-    public void testUnpack2() throws Throwable {
+    public void testUnpack2() {
         byte[] buf = ISOUtil.hex2byte("000100");
         instance.unpack(buf);
         assertFalse(instance.getTags().isEmpty());
@@ -375,7 +374,7 @@ public class TLVListTest {
     }
 
     @Test
-    public void testUnpack3() throws Throwable {
+    public void testUnpack3() {
         byte[] buf = ISOUtil.hex2byte("0100");
         instance.unpack(buf);
         assertFalse(instance.getTags().isEmpty());
@@ -385,63 +384,63 @@ public class TLVListTest {
     }
 
     @Test
-    public void testUnpack4() throws Throwable {
+    public void testUnpack4() {
         byte[] buf = new byte[0];
         instance.unpack(buf);
         assertTrue(instance.getTags().isEmpty());
     }
 
     @Test
-    public void testUnpack5() throws Throwable {
+    public void testUnpack5() {
         byte[] buf = new byte[0];
         instance.unpack(buf, 0);
         assertTrue(instance.getTags().isEmpty());
     }
 
     @Test
-    public void testUnpack6() throws Throwable {
+    public void testUnpack6() {
         byte[] buf = ISOUtil.hex2byte("6000");
         instance.unpack(buf);
         assertFalse(instance.getTags().isEmpty());
     }
 
     @Test
-    public void testUnpack7() throws Throwable {
+    public void testUnpack7() {
         byte[] buf = new byte[2];
         instance.unpack(buf);
         assertTrue(instance.getTags().isEmpty());
     }
 
     @Test
-    public void testUnpack8() throws Throwable {
+    public void testUnpack8() {
         byte[] buf = new byte[3];
         instance.unpack(buf);
         assertTrue(instance.getTags().isEmpty());
     }
 
     @Test
-    public void testUnpack9() throws Throwable {
+    public void testUnpack9() {
         byte[] buf = ISOUtil.hex2byte("1e00");
         instance.unpack(buf);
         assertFalse(instance.getTags().isEmpty());
     }
 
     @Test
-    public void testUnpackWith0x00Padding() throws Throwable {
+    public void testUnpackWith0x00Padding() {
         byte[] buf = ISOUtil.hex2byte("fe0000");
         instance.unpack(buf, 0);
         assertFalse(instance.getTags().isEmpty());
     }
 
     @Test
-    public void testUnpackWith0x00Padding1() throws Throwable {
+    public void testUnpackWith0x00Padding1() {
         byte[] buf = ISOUtil.hex2byte("878000");
         instance.unpack(buf);
         assertFalse(instance.getTags().isEmpty());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testUnpackInvalidLengthThrowsIllegalArgumentException() throws Throwable {
+    public void testUnpackInvalidLengthThrowsIllegalArgumentException() {
         byte[] buf = ISOUtil.hex2byte("14830000");
         try {
             instance.unpack(buf);
@@ -452,7 +451,7 @@ public class TLVListTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testUnpackInvalidTagThrowsIllegalArgumentException() throws Throwable {
+    public void testUnpackInvalidTagThrowsIllegalArgumentException() {
         byte[] buf = ISOUtil.hex2byte("007f");
         try {
             instance.unpack(buf);
@@ -463,7 +462,7 @@ public class TLVListTest {
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
-    public void testUnpackThrowsIndexOutOfBounds() throws Throwable {
+    public void testUnpackThrowsIndexOutOfBounds() {
         byte[] buf = new byte[3];
         try {
             instance.unpack(buf, 100);
@@ -474,241 +473,241 @@ public class TLVListTest {
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException() {
         byte[] buf = ISOUtil.hex2byte("00ff80");
         try {
             instance.unpack(buf, 0);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x80), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x80), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException1() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException1() {
         byte[] buf = ISOUtil.hex2byte("001e");
         try {
             instance.unpack(buf, 0);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x1e), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x1e), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException10() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException10() {
         byte[] buf = ISOUtil.hex2byte("7f0007");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_EXCEEDS_AVAL, 0x7f00, 0x07), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_EXCEEDS_AVAL, 0x7f00, 0x07), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException11() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException11() {
         byte[] buf = ISOUtil.hex2byte("ff1e");
         try {
             instance.unpack(buf, 0);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x1e), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x1e), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException12() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException12() {
         byte[] buf = ISOUtil.hex2byte("fe2000");
         try {
             instance.unpack(buf, 0);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_EXCEEDS_AVAL, 0xfe, 0x20), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_EXCEEDS_AVAL, 0xfe, 0x20), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException13() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException13() {
         byte[] buf = ISOUtil.hex2byte("000008");
         try {
             instance.unpack(buf, 0);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x08), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x08), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException14() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException14() {
         byte[] buf = ISOUtil.hex2byte("7f00");
         try {
             instance.unpack(buf, 0);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x7f00), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x7f00), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException15() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException15() {
         byte[] buf = ISOUtil.hex2byte("f8");
         try {
             instance.unpack(buf, 0);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0xf8), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0xf8), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException16() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException16() {
         byte[] buf = ISOUtil.hex2byte("fe81ed");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_EXCEEDS_AVAL, 0xfe, 0xed), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_EXCEEDS_AVAL, 0xfe, 0xed), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException17() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException17() {
         byte[] buf = ISOUtil.hex2byte("000001");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x01), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x01), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException18() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException18() {
         byte[] buf = ISOUtil.hex2byte("878009");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x09), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x09), ex.getMessage());
             assertFalse(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException2() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException2() {
         byte[] buf = ISOUtil.hex2byte("0001");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x01), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x01), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException3() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException3() {
         byte[] buf = ISOUtil.hex2byte("fe00ed");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0xed), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0xed), ex.getMessage());
             assertFalse(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException4() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException4() {
         byte[] buf = ISOUtil.hex2byte("00fe");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0xfe), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0xfe), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException5() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsISOException5() {
         byte[] buf = ISOUtil.hex2byte("fe7600");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_EXCEEDS_AVAL, 0xfe, 0x76), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_EXCEEDS_AVAL, 0xfe, 0x76), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException6() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException6() {
         byte[] buf = ISOUtil.hex2byte("ff1e");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x1e), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x1e), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException7() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException7() {
         byte[] buf = ISOUtil.hex2byte("01");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x01), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x01), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException8() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException8() {
         byte[] buf = ISOUtil.hex2byte("7f00");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_WITHOUT_LEN, 0x7f00), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_WITHOUT_LEN, 0x7f00), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
-    @Test(expected = ISOException.class)
-    public void testUnpackThrowsISOException9() throws Throwable {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnpackThrowsIllegalArgumentException9() {
         byte[] buf = ISOUtil.hex2byte("00f801");
         try {
             instance.unpack(buf);
-        } catch (ISOException ex) {
-            assertEquals(String.format(ISO_EXCEPT_EXCEEDS_AVAL, 0xf8, 0x01), ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            assertEquals(String.format(EXCEPT_MSG_EXCEEDS_AVAL, 0xf8, 0x01), ex.getMessage());
             assertTrue(instance.getTags().isEmpty());
             throw ex;
         }
     }
 
     @Test(expected = NullPointerException.class)
-    public void testUnpackThrowsNullPointerException() throws Throwable {
+    public void testUnpackThrowsNullPointerException() {
         instance.unpack(null, 100);
     }
 
     @Test(expected = NullPointerException.class)
-    public void testUnpackThrowsNullPointerException1() throws Throwable {
+    public void testUnpackThrowsNullPointerException1() {
         instance.unpack(null);
     }
 

--- a/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
@@ -20,6 +20,7 @@ package org.jpos.tlv;
 
 import org.jpos.iso.ISOUtil;
 import static org.junit.Assert.*;
+import org.junit.Before;
 import org.junit.Test;
 
 public class TLVMsgTest {
@@ -28,13 +29,11 @@ public class TLVMsgTest {
     static final int TEST_TAG3      = 0x03e8;
 
     TLVMsg msg;
+    TLVList tl;
 
-    @Test
-    public void testConstructor() {
-        byte[] value = new byte[2];
-        msg = new TLVMsg(TEST_TAG1, value);
-        assertSame(value, msg.getValue());
-        assertEquals(TEST_TAG1, msg.getTag());
+    @Before
+    public void setUp() {
+        tl = new TLVList();
     }
 
     @Test
@@ -46,82 +45,82 @@ public class TLVMsgTest {
     @Test
     public void testGetL() {
         byte[] value = new byte[3];
-        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        byte[] result = tl.createTLVMsg(TEST_TAG1, value).getL();
         assertArrayEquals(ISOUtil.hex2byte("03"), result);
     }
 
     @Test
     public void testGetL1() {
         byte[] value = new byte[1];
-        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        byte[] result = tl.createTLVMsg(TEST_TAG1, value).getL();
         assertArrayEquals(ISOUtil.hex2byte("01"), result);
     }
 
     @Test
     public void testGetL2() {
-        byte[] result = new TLVMsg(TEST_TAG1, null).getL();
+        byte[] result = tl.createTLVMsg(TEST_TAG1, null).getL();
         assertArrayEquals(ISOUtil.hex2byte("00"), result);
     }
 
     @Test
     public void testGetL3() {
         byte[] value = new byte[200];
-        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        byte[] result = tl.createTLVMsg(TEST_TAG1, value).getL();
         assertArrayEquals(ISOUtil.hex2byte("81C8"), result);
     }
 
     @Test
     public void testGetL4() {
         byte[] value = new byte[0x7ff7];
-        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        byte[] result = tl.createTLVMsg(TEST_TAG1, value).getL();
         assertArrayEquals(ISOUtil.hex2byte("827FF7"), result);
     }
 
     @Test
     public void testGetL5() {
         byte[] value = new byte[0x8ff8];
-        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        byte[] result = tl.createTLVMsg(TEST_TAG1, value).getL();
         assertArrayEquals(ISOUtil.hex2byte("828FF8"), result);
     }
 
     @Test
     public void testGetL6() {
         byte[] value = new byte[0];
-        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        byte[] result = tl.createTLVMsg(TEST_TAG1, value).getL();
         assertArrayEquals(ISOUtil.hex2byte("00"), result);
     }
 
     @Test
     public void testGetTLV() {
         byte[] value = new byte[1];
-        byte[] result = new TLVMsg(TEST_TAG1, value).getTLV();
+        byte[] result = tl.createTLVMsg(TEST_TAG1, value).getTLV();
         assertArrayEquals(ISOUtil.hex2byte("640100"), result);
     }
 
     @Test
     public void testGetTLV1() {
-        byte[] result = new TLVMsg(TEST_TAG1, null).getTLV();
+        byte[] result = tl.createTLVMsg(TEST_TAG1, null).getTLV();
         assertArrayEquals(ISOUtil.hex2byte("6400"), result);
     }
 
     @Test
     public void testGetTLVEmptyValue1() {
         byte[] value = new byte[0];
-        byte[] result = new TLVMsg(TEST_TAG1, value).getTLV();
+        byte[] result = tl.createTLVMsg(TEST_TAG1, value).getTLV();
         assertArrayEquals(ISOUtil.hex2byte("6400"), result);
     }
 
     @Test
     public void testGetTLVEmptyValue2() {
         byte[] value = new byte[0];
-        byte[] result = new TLVMsg(TEST_TAG3, value).getTLV();
+        byte[] result = tl.createTLVMsg(TEST_TAG3, value).getTLV();
         assertArrayEquals(ISOUtil.hex2byte("03E800"), result);
     }
 
     @Test
     public void testSetTag() {
         byte[] value = new byte[0];
-        msg = new TLVMsg(TEST_TAG1, value);
+        msg = tl.createTLVMsg(TEST_TAG1, value);
         msg.setTag(TEST_TAG3);
         assertEquals(TEST_TAG3, msg.getTag());
     }
@@ -136,14 +135,14 @@ public class TLVMsgTest {
 
     @Test
     public void testGetStringValue() {
-        msg = new TLVMsg(23, "987612".getBytes());
+        msg = tl.createTLVMsg(23, "987612".getBytes());
         String result = msg.getStringValue();
         assertEquals("393837363132", result);
     }
 
     @Test
     public void testLowTagID() {
-        msg = new TLVMsg(8, "987612".getBytes());
+        msg = tl.createTLVMsg(8, "987612".getBytes());
         String result = msg.getStringValue();
         assertEquals("393837363132", result);
         byte[] b = msg.getTLV();

--- a/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
@@ -18,7 +18,6 @@
 
 package org.jpos.tlv;
 
-import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
@@ -148,20 +147,22 @@ public class TLVMsgTest {
         tLVMsg.setValue(newValue);
         assertSame("tLVMsg.getValue()", newValue, tLVMsg.getValue());
     }
-    
+
     @Test
     public void testGetStringValue() {
         TLVMsg tLVMsg = new TLVMsg(23, "987612".getBytes());
         String result = tLVMsg.getStringValue();
-        assertThat(result,is("393837363132"));
+        assertEquals("393837363132", result);
     }
+
     @Test
     public void testLowTagID() {
         TLVMsg tlvMsg = new TLVMsg(8, "987612".getBytes());
         String result = tlvMsg.getStringValue();
-        assertThat(result,is("393837363132"));
+        assertEquals("393837363132", result);
         byte[] b = tlvMsg.getTLV();
         assertEquals("b.length", 8, b.length);
         assertEquals("b[0]", (byte) 8, b[0]);
     }
+
 }

--- a/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class TLVMsgTest {
 
     static final int TEST_TAG1      = 0x64;
-    static final int TEST_TAG3      = 0x03e8;
+    static final int TEST_TAG3      = 0x1fe8;
 
     TLVMsg msg;
     TLVList tl;
@@ -108,7 +108,7 @@ public class TLVMsgTest {
     public void testGetTLVEmptyValue2() {
         byte[] value = new byte[0];
         byte[] result = tl.createTLVMsg(TEST_TAG3, value).getTLV();
-        assertArrayEquals(ISOUtil.hex2byte("03E800"), result);
+        assertArrayEquals(ISOUtil.hex2byte("1FE800"), result);
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
@@ -18,151 +18,136 @@
 
 package org.jpos.tlv;
 
+import org.jpos.iso.ISOUtil;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
 public class TLVMsgTest {
 
+    static final int TEST_TAG1      = 0x64;
+    static final int TEST_TAG3      = 0x03e8;
+
+    TLVMsg msg;
+
     @Test
-    public void testConstructor() throws Throwable {
+    public void testConstructor() {
         byte[] value = new byte[2];
-        TLVMsg tLVMsg = new TLVMsg(100, value);
-        assertSame("tLVMsg.getValue()", value, tLVMsg.getValue());
-        assertEquals("tLVMsg.getTag()", 100, tLVMsg.getTag());
+        msg = new TLVMsg(TEST_TAG1, value);
+        assertSame(value, msg.getValue());
+        assertEquals(TEST_TAG1, msg.getTag());
     }
 
     @Test
-    public void testConstructor1() throws Throwable {
-        TLVMsg tLVMsg = new TLVMsg();
-        assertEquals("tLVMsg.getTag()", 0, tLVMsg.getTag());
+    public void testConstructor1() {
+        msg = new TLVMsg();
+        assertEquals(0, msg.getTag());
     }
 
     @Test
-    public void testGetL() throws Throwable {
+    public void testGetL() {
         byte[] value = new byte[3];
-        byte[] result = new TLVMsg(100, value).getL();
-        assertEquals("result.length", 1, result.length);
-        assertEquals("result[0]", (byte) 3, result[0]);
+        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        assertArrayEquals(ISOUtil.hex2byte("03"), result);
     }
 
     @Test
-    public void testGetL1() throws Throwable {
+    public void testGetL1() {
         byte[] value = new byte[1];
-        byte[] result = new TLVMsg(100, value).getL();
-        assertEquals("result.length", 1, result.length);
-        assertEquals("result[0]", (byte) 1, result[0]);
+        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        assertArrayEquals(ISOUtil.hex2byte("01"), result);
     }
 
     @Test
-    public void testGetL2() throws Throwable {
-        byte[] result = new TLVMsg(100, null).getL();
-        assertEquals("result.length", 1, result.length);
-        assertEquals("result[0]", (byte) 0, result[0]);
+    public void testGetL2() {
+        byte[] result = new TLVMsg(TEST_TAG1, null).getL();
+        assertArrayEquals(ISOUtil.hex2byte("00"), result);
     }
 
     @Test
-    public void testGetL3() throws Throwable {
+    public void testGetL3() {
         byte[] value = new byte[200];
-        byte[] result = new TLVMsg(100, value).getL();
-        assertEquals("result.length", 2, result.length);
-        assertEquals("result[0]", (byte) 0x81, result[0]);
-        assertEquals("result[1]", (byte) 0xc8, result[1]);
+        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        assertArrayEquals(ISOUtil.hex2byte("81C8"), result);
     }
 
     @Test
-    public void testGetL4() throws Throwable {
+    public void testGetL4() {
         byte[] value = new byte[0x7ff7];
-        byte[] result = new TLVMsg(100, value).getL();
-        assertEquals("result.length", 3, result.length);
-        assertEquals("result[0]", (byte) 0x82, result[0]);
-        assertEquals("result[1]", (byte) 0x7f, result[1]);
-        assertEquals("result[2]", (byte) 0xf7, result[2]);
+        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        assertArrayEquals(ISOUtil.hex2byte("827FF7"), result);
     }
 
     @Test
-    public void testGetL5() throws Throwable {
+    public void testGetL5() {
         byte[] value = new byte[0x8ff8];
-        byte[] result = new TLVMsg(100, value).getL();
-        assertEquals("result.length", 3, result.length);
-        assertEquals("result[0]", (byte) 0x82, result[0]);
-        assertEquals("result[1]", (byte) 0x8f, result[1]);
-        assertEquals("result[2]", (byte) 0xf8, result[2]);
+        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        assertArrayEquals(ISOUtil.hex2byte("828FF8"), result);
     }
 
     @Test
-    public void testGetL6() throws Throwable {
+    public void testGetL6() {
         byte[] value = new byte[0];
-        byte[] result = new TLVMsg(100, value).getL();
-        assertEquals("result.length", 1, result.length);
-        assertEquals("result[0]", (byte) 0x00, result[0]);
+        byte[] result = new TLVMsg(TEST_TAG1, value).getL();
+        assertArrayEquals(ISOUtil.hex2byte("00"), result);
     }
 
     @Test
-    public void testGetTLV() throws Throwable {
+    public void testGetTLV() {
         byte[] value = new byte[1];
-        byte[] result = new TLVMsg(100, value).getTLV();
-        assertEquals("result.length", 3, result.length);
-        assertEquals("result[0]", (byte) 100, result[0]);
+        byte[] result = new TLVMsg(TEST_TAG1, value).getTLV();
+        assertArrayEquals(ISOUtil.hex2byte("640100"), result);
     }
 
     @Test
-    public void testGetTLV1() throws Throwable {
-        byte[] result = new TLVMsg(100, null).getTLV();
-        assertEquals("result.length", 2, result.length);
-        assertEquals("result[0]", (byte) 100, result[0]);
-        assertEquals("result[1]", (byte) 0,   result[1]);
+    public void testGetTLV1() {
+        byte[] result = new TLVMsg(TEST_TAG1, null).getTLV();
+        assertArrayEquals(ISOUtil.hex2byte("6400"), result);
     }
 
     @Test
-    public void testGetTLVEmptyValue1() throws Throwable {
+    public void testGetTLVEmptyValue1() {
         byte[] value = new byte[0];
-        byte[] result = new TLVMsg(100, value).getTLV();
-        assertEquals("result.length", 2, result.length);
-        assertEquals("result[0]", (byte) 100, result[0]);
-        assertEquals("result[1]", (byte) 0,   result[1]);
+        byte[] result = new TLVMsg(TEST_TAG1, value).getTLV();
+        assertArrayEquals(ISOUtil.hex2byte("6400"), result);
     }
 
     @Test
-    public void testGetTLVEmptyValue2() throws Throwable {
+    public void testGetTLVEmptyValue2() {
         byte[] value = new byte[0];
-        byte[] result = new TLVMsg(1000, value).getTLV();
-        assertEquals("result.length", 3, result.length);
-        assertEquals("result[0]", (byte) 0x03, result[0]);
-        assertEquals("result[1]", (byte) 0xe8, result[1]);
-        assertEquals("result[2]", (byte) 0,    result[2]);
+        byte[] result = new TLVMsg(TEST_TAG3, value).getTLV();
+        assertArrayEquals(ISOUtil.hex2byte("03E800"), result);
     }
 
     @Test
-    public void testSetTag() throws Throwable {
+    public void testSetTag() {
         byte[] value = new byte[0];
-        TLVMsg tLVMsg = new TLVMsg(100, value);
-        tLVMsg.setTag(1000);
-        assertEquals("tLVMsg.getTag()", 1000, tLVMsg.getTag());
+        msg = new TLVMsg(TEST_TAG1, value);
+        msg.setTag(TEST_TAG3);
+        assertEquals(TEST_TAG3, msg.getTag());
     }
 
     @Test
-    public void testSetValue() throws Throwable {
-        TLVMsg tLVMsg = new TLVMsg();
-        byte[] newValue = new byte[1];
-        tLVMsg.setValue(newValue);
-        assertSame("tLVMsg.getValue()", newValue, tLVMsg.getValue());
+    public void testSetValue() {
+        msg = new TLVMsg();
+        byte[] expected = new byte[1];
+        msg.setValue(expected);
+        assertSame(expected, msg.getValue());
     }
 
     @Test
     public void testGetStringValue() {
-        TLVMsg tLVMsg = new TLVMsg(23, "987612".getBytes());
-        String result = tLVMsg.getStringValue();
+        msg = new TLVMsg(23, "987612".getBytes());
+        String result = msg.getStringValue();
         assertEquals("393837363132", result);
     }
 
     @Test
     public void testLowTagID() {
-        TLVMsg tlvMsg = new TLVMsg(8, "987612".getBytes());
-        String result = tlvMsg.getStringValue();
+        msg = new TLVMsg(8, "987612".getBytes());
+        String result = msg.getStringValue();
         assertEquals("393837363132", result);
-        byte[] b = tlvMsg.getTLV();
-        assertEquals("b.length", 8, b.length);
-        assertEquals("b[0]", (byte) 8, b[0]);
+        byte[] b = msg.getTLV();
+        assertArrayEquals(ISOUtil.hex2byte("0806393837363132"), b);
     }
 
 }

--- a/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
@@ -37,12 +37,6 @@ public class TLVMsgTest {
     }
 
     @Test
-    public void testConstructor1() {
-        msg = new TLVMsg();
-        assertEquals(0, msg.getTag());
-    }
-
-    @Test
     public void testGetL() {
         byte[] value = new byte[3];
         byte[] result = tl.createTLVMsg(TEST_TAG1, value).getL();
@@ -115,22 +109,6 @@ public class TLVMsgTest {
         byte[] value = new byte[0];
         byte[] result = tl.createTLVMsg(TEST_TAG3, value).getTLV();
         assertArrayEquals(ISOUtil.hex2byte("03E800"), result);
-    }
-
-    @Test
-    public void testSetTag() {
-        byte[] value = new byte[0];
-        msg = tl.createTLVMsg(TEST_TAG1, value);
-        msg.setTag(TEST_TAG3);
-        assertEquals(TEST_TAG3, msg.getTag());
-    }
-
-    @Test
-    public void testSetValue() {
-        msg = new TLVMsg();
-        byte[] expected = new byte[1];
-        msg.setValue(expected);
-        assertSame(expected, msg.getValue());
     }
 
     @Test


### PR DESCRIPTION
Last commit implements builder pattern for `TLVList`. So is possible parse/unpack TLV byte sequences that are not compliant with ISO/IEC 7816-4 BER-TLV rules. e.g: Visa Base1 Datasets _(which are fixed 2 bytes long)_
```java
    TLVList tl = TLVList.createInstance()
                        .fixedLengthSize(2)
                        .build()
```
After that using `tl` is as usual: unpack, append, pack, etc.
It is also possible to create `TLVList` with a fixed tag size:
```java
    TLVList tl = TLVList.createInstance()
                        .fixedTagSize(2)
                        .build()
```
and even mixing them together.

e.g: when fixed length size 1 is used then length is encoded i 1 byte _(0..255)_ unlike at ISO/IEC 7816-4 only _(0..127)_

The changes affected only `TLVList` and `TLVMsg` _(and corresponding jUnit test)_. They are never used in jPOS itself.
 
#### API changes:
* remove `TLVMsg()`
* remove `TLVMsg.setTag(int)`
* remove `TLVMsg.setValue(byte[] value)`

At problems use just TLVList.append(tag, bytes)

* change `TLVList.unpack` to throws only one unchecked `IllegalArgumentException` instead `ISOException` and extra undocumented  `BufferUnderflowException`
* deprecate `TLVMsg(int, byte)` - use TLVList.append(int, byte) instead.

Most of these changes were necessary to ensure consistency in the situation of the availability of various types of `TLVList` _(which was previously not necessary)_

In addition 2427a9f introduces verification of created tag identifiers.
So now it is not possible to create an illegal _(in ISO/IEC 7816-4 BER-TLV mode)_ `FF`, `00`, '3F', etc. tags. Using them resulted in the creation of an unparsable byte sequence.