### PR TITLE
Update com.sleepycat:je to 18.3.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ subprojects {
     repositories {
         mavenCentral()
         maven { url 'http://jpos.org/maven' }
-        maven { url 'http://download.oracle.com/maven' }
         mavenLocal()
     }
     if (project.hasProperty("lint")) {

--- a/jpos/libraries.gradle
+++ b/jpos/libraries.gradle
@@ -2,7 +2,7 @@ ext {
     libraries = [
         jdom: 'org.jdom:jdom2:2.0.6',
         jdbm: 'jdbm:jdbm:1.0',
-        sleepycat_je: 'com.sleepycat:je:7.0.6',
+        sleepycat_je: 'com.sleepycat:je:18.3.12',
         commons_cli: 'commons-cli:commons-cli:1.4',
         jline: 'org.jline:jline:3.9.0',
         beanshell: 'org.apache-extras.beanshell:bsh:2.0b6',


### PR DESCRIPTION
This artifact is available again in maven central (from version 18.1.11 of Jun 13, 2018)
so refference to repository http://download.oracle.com/maven was removed.

ps.
I wonder what is dependent in `jpos/jPOS` on artifacts from http://jpos.org/maven. I can not find anything like that. After removing that reference, the compilation and tests pass.