### PR TITLE
Set of small fixes for QMUX, SimpleMsg and SecurePrivateKey

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/iso/QMUX.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QMUX.java
@@ -308,15 +308,14 @@ public class QMUX
     public String[] getReadyIndicatorNames() {
         return ready;
     }
-    private void addListeners () 
-        throws ConfigurationException
-    {
+
+    private void addListeners() throws ConfigurationException {
+        List<Element> rlisten = getPersist().getChildren("request-listener");
+        if (rlisten.isEmpty())
+            return;
+
         QFactory factory = getFactory ();
-        Iterator iter = getPersist().getChildren (
-            "request-listener"
-        ).iterator();
-        while (iter.hasNext()) {
-            Element l = (Element) iter.next();
+        for (Element l : rlisten) {
             ISORequestListener listener = (ISORequestListener) 
                 factory.newInstance (QFactory.getAttributeValue (l, "class"));
             factory.setLogger        (listener, l);

--- a/jpos/src/main/java/org/jpos/q2/iso/QMUX.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QMUX.java
@@ -197,12 +197,28 @@ public class QMUX
             sp.out (out, m);
         synchronized (this) { tx++; rxPending++; }
     }
+
+    protected boolean isNotifyEligible(ISOMsg msg) {
+        if (returnRejects)
+            return true;
+
+        try {
+            return msg.isResponse();
+        } catch (RuntimeException | ISOException ex) {
+            // * ArrayIndexOutOfBoundsException - It may occur for messages where
+            // MTI is not standard 4 characters (eg. FSDISOMsg), then notification is expected.
+            // * ISOException: When there is no field 0, the error should be logged
+            return true;
+        }
+    }
+
+    @Override
     public void notify (Object k, Object value) {
         Object obj = sp.inp (k);
         if (obj instanceof ISOMsg) {
             ISOMsg m = (ISOMsg) obj;
             try {
-                if (returnRejects || m.isResponse()) {
+                if (isNotifyEligible(m)) {
                     String key = getKey (m);
                     String req = key + ".req";
                     Object r = isp.inp (req);

--- a/jpos/src/main/java/org/jpos/security/SecurePrivateKey.java
+++ b/jpos/src/main/java/org/jpos/security/SecurePrivateKey.java
@@ -50,15 +50,6 @@ public class SecurePrivateKey extends SecureVariantKey implements Serializable{
     }
 
     @Override
-    public void setKeyLength(short keyLength) {}
-
-    @Override
-    public short getKeyLength() {
-        throw new UnsupportedOperationException("Operation getKeyLength() not"
-                + " allowed for " + SecurePrivateKey.class.getName());
-    }
-
-    @Override
     public void setVariant(byte variant) {}
 
     @Override

--- a/jpos/src/main/java/org/jpos/util/SimpleMsg.java
+++ b/jpos/src/main/java/org/jpos/util/SimpleMsg.java
@@ -18,6 +18,9 @@
 
 package  org.jpos.util;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import org.jpos.iso.ISOUtil;
 
 import java.io.PrintStream;
@@ -31,8 +34,12 @@ import java.util.Collection;
  * @author Hani S. Kirollos
  * @version $Revision$ $Date$
  */
-    public class SimpleMsg
-            implements Loggeable {
+    public class SimpleMsg implements Loggeable {
+
+        static final String STACKTRACE_EXTRA_INDENT = "    ";
+
+        static final String STACKTRACE_TAB_REPLACE  = STACKTRACE_EXTRA_INDENT + STACKTRACE_EXTRA_INDENT;
+
         String tagName;
         String msgName;
         Object msgContent;
@@ -70,6 +77,8 @@ import java.util.Collection;
                 cl = (Collection) msgContent;
             else if (msgContent instanceof Loggeable)
                 cl = Arrays.asList(msgContent);
+            else if (msgContent instanceof Throwable)
+                cl = Arrays.asList(msgContent);
             else if (msgName != null && msgContent == null){
                 p.println("/>");
                 return;
@@ -87,6 +96,8 @@ import java.util.Collection;
                 for (Object o : cl) {
                     if (o instanceof Loggeable)
                         ((Loggeable) o).dump(p, inner);
+                    else if (o instanceof Throwable)
+                        p.print(formatThrowable(indent, (Throwable) o));
                     else
                         p.println(inner + o);
                 }
@@ -95,4 +106,24 @@ import java.util.Collection;
 
             p.println("</" + tagName + ">");
         }
+
+        private String formatThrowable(String indent, Throwable t) {
+            String inde = indent + STACKTRACE_EXTRA_INDENT;
+            try (
+                    OutputStream os = new ByteArrayOutputStream();
+                    PrintStream ps = new PrintStream(os);
+                ) {
+                    // indent stack trace first line
+                    ps.print(inde);
+                    t.printStackTrace(ps);
+
+                    String res = os.toString();
+                    res = res.replace("\n\t", "\n" + inde + STACKTRACE_TAB_REPLACE);
+                    res = res.replace("\nCaused by:", "\n" + inde + "Caused by:");
+                    return res;
+            } catch (IOException ex) {
+                return ""; // it should never occur for ByteArrayOutputStream
+            }
+        }
+
     }

--- a/jpos/src/test/java/org/jpos/q2/iso/QMUXTest.java
+++ b/jpos/src/test/java/org/jpos/q2/iso/QMUXTest.java
@@ -18,13 +18,19 @@
 
 package org.jpos.q2.iso;
 
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.jdom2.Element;
+import org.jpos.core.Configuration;
+import org.jpos.core.SimpleConfiguration;
 import org.jpos.iso.Connector;
 import org.jpos.iso.ISOMsg;
 import org.jpos.iso.ISORequestListener;
@@ -83,6 +89,31 @@ public class QMUXTest {
     public void testGetUnhandledQueue() throws Throwable {
         String result = new QMUX().getUnhandledQueue();
         assertNull("result", result);
+    }
+
+    @Test
+    public void testInitServiceWithoutListeners() throws Throwable {
+        QMUX mux = new QMUX();
+        Configuration cfg = new SimpleConfiguration();
+        mux.setConfiguration(cfg);
+        Element persist = new Element("testQMUXName");
+        persist.addContent(new Element("in").addContent("queue-in"));
+        persist.addContent(new Element("out").addContent("queue-out"));
+        persist.addContent(new Element("unhandled").addContent("queue-unhandled"));
+        persist.addContent(new Element("ready").addContent("test-ready"));
+        persist.addContent(new Element("unhandled").addContent("queue-unhandled"));
+        mux.setPersist(persist);
+        mux.initService();
+
+        assertEquals("queue-unhandled", mux.unhandled);
+        assertEquals("queue-out", mux.out);
+        assertEquals("queue-in", mux.in);
+        assertNull(mux.ignorerc);
+        assertNotNull(mux.sp);
+        assertFalse(mux.isModified());
+        assertArrayEquals(new String[]{"test-ready"}, mux.ready);
+        assertArrayEquals(new String[]{"41", "11"}, mux.key);
+        assertEquals(0, mux.listeners.size());
     }
 
     @Test(expected = NullPointerException.class)

--- a/jpos/src/test/java/org/jpos/util/SimpleMsgTest.java
+++ b/jpos/src/test/java/org/jpos/util/SimpleMsgTest.java
@@ -19,9 +19,11 @@
 package org.jpos.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import org.hamcrest.Matchers;
 import org.jpos.iso.ISOUtil;
 import org.junit.Before;
 
@@ -266,6 +268,24 @@ public class SimpleMsgTest {
                       "--||--  null" + NL +
                       "--||--</tag>" +  NL
                       ,os.toString());
+    }
+
+    @Test
+    public void testDumpExceptionStackTrace() {
+        Exception ex = new IllegalArgumentException("This value is illegal"
+                , new IllegalStateException("Some illegal state")
+        );
+        Loggeable msg = new SimpleMsg("unexpected-exception", ex);
+
+        msg.dump(p, "--||--");
+        String res = os.toString();
+
+        assertThat(res, Matchers.startsWith("--||--<unexpected-exception>" + NL));
+        assertThat(res, Matchers.endsWith("--||--</unexpected-exception>" + NL));
+
+        assertThat(res, Matchers.containsString(NL + "--||--    java.lang.IllegalArgumentException: This value is illegal" + NL));
+        assertThat(res, Matchers.containsString(NL + "--||--    Caused by: java.lang.IllegalStateException: Some illegal state" + NL));
+        assertThat(res, Matchers.containsString(NL + "--||--            at org.jpos.util.SimpleMsgTest.test"));
     }
 
     @Test


### PR DESCRIPTION
All fixes are described in the relevant commit messages.

Additional explanations may be necessary for a608768:
When we use:
``` java
    evt.addMessage("message-tag", "Some message");
or
    evt.addMessage(new SimpleMsg("message-tag", "Some message"));
...
    Logger.log(evt);
```
then we expect in log:
``` xml
    <message-tag>Some message</message-tag>
```
similarly:
``` java
    evt.addMessage("exception-tag", ex.getMessage());
or
    evt.addMessage(new SimpleMsg("exception-tag", ex.getMessage()));
...
    Logger.log(evt);
```
then we expect in log:
``` xml
    <exception-tag>Some exception message</exception-tag>
```
And accordingly when:
``` java
    evt.addMessage(new SimpleMsg("message-tag", "Explanatory name", "Some long message"));
...
    Logger.log(evt);
```
we get:
``` xml
    <message-tag name="Explanatory name">
        Some long message
    </message-tag>
```
**All It works great.**

But when we use:
``` java
    evt.addMessage(new SimpleMsg("unexpected-exception-tag", ex));
...
    Logger.log(evt);
```
we get:
``` xml
    <unexpected-exception-tag>
        java.lang.IllegalArgumentException: This value is illegal
    </unexpected-exception-tag>
```
It is too simple and _**It is not enough to solve an problem.**_
 
but then we expect _(an stacktrace)_ like this:
``` xml
    <unexpected-exception-tag>
        java.lang.IllegalArgumentException: This value is illegal
                at org.jpos.util.SimpleMsgTest.testDumpExceptionStackTrace(SimpleMsgTest.java:275)
                at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
                at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
                at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                at java.lang.reflect.Method.invoke(Method.java:498)
                at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
                at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
                at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
                at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
                at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
                at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
                at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
                at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
                at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
                at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
                at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
                at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
                at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
                at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
                at java.lang.Thread.run(Thread.java:748)
        Caused by: java.lang.IllegalStateException: Some illegal state
                ... 46 more
    </unexpected-exception-tag>
```