### PR TITLE
SMAdapter keyblock handling extension

### DIFF
--- a/jpos/src/main/java/org/jpos/security/Algorithm.java
+++ b/jpos/src/main/java/org/jpos/security/Algorithm.java
@@ -1,0 +1,122 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Defines the cryptographic algorithm with which the key contained in the key
+ * block will be used.
+ * <p>
+ * Each value repesents byte 7 of the Keyblok Header.
+ */
+public enum Algorithm {
+
+    /**
+     * AES - Advanced Encryption Standard.
+     */
+    AES         ('A', "AES - Advanced Encryption Standard"),
+
+    /**
+     * DES - Data Encryption Standard.
+     */
+    DES         ('D', "DES - Data Encryption Standard"),
+
+    /**
+     * Elliptic curve.
+     */
+    EC          ('E', "Elliptic curve"),
+
+    /**
+     * HMAC - Hash Message Authentication Code.
+     */
+    HMAC        ('H', "HMAC - Hash Message Authentication Code"),
+
+    /**
+     * RSA - Rivest–Shamir–Adleman.
+     */
+    RSA         ('R', "RSA - Rivest Shamir Adleman"),
+
+    /**
+     * DSA - Digital Signature Algorithm.
+     */
+    DSA         ('S', "DSA - Digital Signature Algorithm"),
+
+    /**
+     * TDES - Triple Data Encryption Standard.
+     * <p>
+     * Also known as TDSA <i>(official Triple Data Encryption Algorithm)</i>.
+     */
+    TDES        ('T', "Triple DES - Triple Data Encryption Standard");
+
+
+    private static final Map<Character, Algorithm> MAP = new HashMap<>();
+
+    static {
+        for (Algorithm alg : Algorithm.values())
+            MAP.put(alg.getCode(), alg);
+    }
+
+    private final char code;
+    private final String name;
+
+    Algorithm(char code, String name) {
+        Objects.requireNonNull(name, "The name of algorithm is required");
+        this.code = code;
+        this.name = name;
+    }
+
+    /**
+     * Get algorithm code.
+     *
+     * @return character algorithm code
+     */
+    public char getCode() {
+        return code;
+    }
+
+    /**
+     * Get algorithm name.
+     *
+     * @return the algorithm name
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Algorithm[code: %s, name: %s]", code, name);
+    }
+
+    /**
+     * Returns the enum constant of this type with the specified {@code code}.
+     *
+     * @param code the string must match exactly with identifier specified by
+     *        <i>ISO 8583-1:2003(E) Table A.22 — Transaction type codes</i>
+     * @return the enum constant with the specified processing code or
+     *         {@code null} if unknown.
+     */
+    public static Algorithm valueOfByCode(char code) {
+        return MAP.get(code);
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -50,8 +50,8 @@ import java.util.Map;
  * @author Hani S. Kirollos
  * @version $Revision$ $Date$
  */
-public class BaseSMAdapter
-        implements SMAdapter, Configurable, LogSource {
+public class BaseSMAdapter<T>
+        implements SMAdapter<T>, Configurable, LogSource {
     protected Logger logger = null;
     protected String realm = null;
     protected Configuration cfg;
@@ -137,7 +137,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public byte[] generateKeyCheckValue (SecureDESKey kd) throws SMException {
+    public byte[] generateKeyCheckValue(T kd) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "Key with untrusted check value", kd));
         LogEvent evt = new LogEvent(this, "s-m-operation");
@@ -156,7 +156,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public SecureDESKey translateKeyScheme (SecureDESKey key, KeyScheme destKeyScheme)
+    public SecureDESKey translateKeyScheme(SecureDESKey key, KeyScheme destKeyScheme)
             throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "Key", key));
@@ -265,7 +265,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public EncryptedPIN importPIN (EncryptedPIN pinUnderKd1, SecureDESKey kd1) throws SMException {
+    public EncryptedPIN importPIN(EncryptedPIN pinUnderKd1, T kd1) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "PIN under Data Key 1", pinUnderKd1));
         cmdParameters.add(new SimpleMsg("parameter", "Data Key 1", kd1));
@@ -285,8 +285,8 @@ public class BaseSMAdapter
     }
 
     @Override
-    public EncryptedPIN translatePIN (EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-            SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
+    public EncryptedPIN translatePIN(EncryptedPIN pinUnderKd1, T kd1,
+            T kd2, byte destinationPINBlockFormat) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "PIN under Data Key 1", pinUnderKd1));
         cmdParameters.add(new SimpleMsg("parameter", "Data Key 1", kd1));
@@ -309,14 +309,14 @@ public class BaseSMAdapter
     }
 
     @Override
-    public EncryptedPIN importPIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk) throws SMException {
+    public EncryptedPIN importPIN(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            T bdk) throws SMException {
         return importPIN(pinUnderDuk,ksn,bdk,false);
     }
 
     @Override
-    public EncryptedPIN importPIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk, boolean tdes) throws SMException {
+    public EncryptedPIN importPIN(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            T bdk, boolean tdes) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "PIN under Derived Unique Key", pinUnderDuk));
         cmdParameters.add(new SimpleMsg("parameter", "Key Serial Number", ksn));
@@ -337,14 +337,14 @@ public class BaseSMAdapter
     }
 
     @Override
-    public EncryptedPIN translatePIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
+    public EncryptedPIN translatePIN(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            T bdk, T kd2, byte destinationPINBlockFormat) throws SMException {
         return translatePIN(pinUnderDuk,ksn,bdk,kd2,destinationPINBlockFormat,false);
     }
 
     @Override
-    public EncryptedPIN translatePIN (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat,boolean tdes) throws SMException {
+    public EncryptedPIN translatePIN(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            T bdk, T kd2, byte destinationPINBlockFormat, boolean tdes) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "PIN under Derived Unique Key", pinUnderDuk));
         cmdParameters.add(new SimpleMsg("parameter", "Key Serial Number", ksn));
@@ -367,7 +367,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public EncryptedPIN exportPIN (EncryptedPIN pinUnderLmk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
+    public EncryptedPIN exportPIN(EncryptedPIN pinUnderLmk, T kd2, byte destinationPINBlockFormat) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "PIN under LMK", pinUnderLmk));
         cmdParameters.add(new SimpleMsg("parameter", "Data Key 2", kd2));
@@ -418,7 +418,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public void printPIN (String accountNo, EncryptedPIN pinUnderKd1, SecureDESKey kd1
+    public void printPIN(String accountNo, EncryptedPIN pinUnderKd1, T kd1
                          ,String template, Map<String, String> fields) throws SMException {
       List<Loggeable> cmdParameters = new ArrayList<>();
       cmdParameters.add(new SimpleMsg("parameter", "account number", accountNo == null ? "" : accountNo));
@@ -442,15 +442,15 @@ public class BaseSMAdapter
     }
 
     @Override
-    public String calculatePVV(EncryptedPIN pinUnderLMK, SecureDESKey pvkA,
-                               SecureDESKey pvkB, int pvkIdx) throws SMException {
+    public String calculatePVV(EncryptedPIN pinUnderLMK, T pvkA,
+                               T pvkB, int pvkIdx) throws SMException {
       return calculatePVV(pinUnderLMK, pvkA, pvkB, pvkIdx, null);
     }
 
     @Override
-    public String calculatePVV(EncryptedPIN pinUnderLMK, SecureDESKey pvkA,
-                               SecureDESKey pvkB, int pvkIdx,
-                               List<String> excludes) throws SMException {
+    public String calculatePVV(EncryptedPIN pinUnderLMK, T pvkA,
+                               T pvkB, int pvkIdx, List<String> excludes)
+            throws SMException {
       List<Loggeable> cmdParameters = new ArrayList<>();
       cmdParameters.add(new SimpleMsg("parameter", "account number", pinUnderLMK.getAccountNumber()));
       cmdParameters.add(new SimpleMsg("parameter", "PIN under LMK", pinUnderLMK));
@@ -475,15 +475,15 @@ public class BaseSMAdapter
     }
 
     @Override
-    public String calculatePVV(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                               SecureDESKey pvkA, SecureDESKey pvkB, int pvkIdx)
+    public String calculatePVV(EncryptedPIN pinUnderKd1, T kd1,
+                               T pvkA, T pvkB, int pvkIdx)
             throws SMException {
       return calculatePVV(pinUnderKd1, kd1, pvkA, pvkB, pvkIdx, null);
     }
 
     @Override
-    public String calculatePVV(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                               SecureDESKey pvkA, SecureDESKey pvkB, int pvkIdx,
+    public String calculatePVV(EncryptedPIN pinUnderKd1, T kd1,
+                               T pvkA, T pvkB, int pvkIdx,
                                List<String> excludes) throws SMException {
       List<Loggeable> cmdParameters = new ArrayList<>();
       cmdParameters.add(new SimpleMsg("parameter", "account number", pinUnderKd1.getAccountNumber()));
@@ -510,8 +510,8 @@ public class BaseSMAdapter
     }
 
     @Override
-    public boolean verifyPVV(EncryptedPIN pinUnderKd1, SecureDESKey kd1, SecureDESKey pvkA,
-                          SecureDESKey pvkB, int pvki, String pvv) throws SMException {
+    public boolean verifyPVV(EncryptedPIN pinUnderKd1, T kd1, T pvkA,
+                          T pvkB, int pvki, String pvv) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "account number", pinUnderKd1.getAccountNumber()));
         cmdParameters.add(new SimpleMsg("parameter", "PIN under Data Key 1", pinUnderKd1));
@@ -536,14 +536,14 @@ public class BaseSMAdapter
     }
 
     @Override
-    public String calculateIBMPINOffset(EncryptedPIN pinUnderLmk, SecureDESKey pvk,
+    public String calculateIBMPINOffset(EncryptedPIN pinUnderLmk, T pvk,
                            String decTab, String pinValData, int minPinLen)
             throws SMException {
       return calculateIBMPINOffset(pinUnderLmk, pvk, decTab, pinValData, minPinLen, null);
     }
 
     @Override
-    public String calculateIBMPINOffset(EncryptedPIN pinUnderLmk, SecureDESKey pvk,
+    public String calculateIBMPINOffset(EncryptedPIN pinUnderLmk, T pvk,
                            String decTab, String pinValData, int minPinLen,
                            List<String> excludes) throws SMException {
       List<Loggeable> cmdParameters = new ArrayList<>();
@@ -572,16 +572,16 @@ public class BaseSMAdapter
     }
 
     @Override
-    public String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                           SecureDESKey pvk, String decTab, String pinValData, int minPinLen)
+    public String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, T kd1,
+                           T pvk, String decTab, String pinValData, int minPinLen)
             throws SMException {
       return calculateIBMPINOffset(pinUnderKd1, kd1, pvk, decTab,
               pinValData, minPinLen, null);
     }
 
     @Override
-    public String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                           SecureDESKey pvk, String decTab, String pinValData, int minPinLen,
+    public String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, T kd1,
+                           T pvk, String decTab, String pinValData, int minPinLen,
                            List<String> excludes) throws SMException {
       List<Loggeable> cmdParameters = new ArrayList<>();
       cmdParameters.add(new SimpleMsg("parameter", "account number", pinUnderKd1.getAccountNumber()));
@@ -610,7 +610,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public boolean verifyIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1, SecureDESKey pvk,
+    public boolean verifyIBMPINOffset(EncryptedPIN pinUnderKd1, T kd1, T pvk,
                                       String offset, String decTab, String pinValData,
                                       int minPinLen) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
@@ -640,7 +640,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public EncryptedPIN deriveIBMPIN(String accountNo, SecureDESKey pvk,
+    public EncryptedPIN deriveIBMPIN(String accountNo, T pvk,
                                      String decTab, String pinValData,
                                      int minPinLen, String offset) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
@@ -666,7 +666,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public String calculateCVV(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    public String calculateCVV(String accountNo, T cvkA, T cvkB,
                                Date expDate, String serviceCode) throws SMException {
 
         List<Loggeable> cmdParameters = new ArrayList<>();
@@ -691,7 +691,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public String calculateCVV(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    public String calculateCVV(String accountNo, T cvkA, T cvkB,
                                String expDate, String serviceCode) throws SMException {
 
         List<Loggeable> cmdParameters = new ArrayList<>();
@@ -716,7 +716,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public String calculateCAVV(String accountNo, SecureDESKey cvk, String upn,
+    public String calculateCAVV(String accountNo, T cvk, String upn,
                                 String authrc, String sfarc) throws SMException {
 
       List<Loggeable> cmdParameters = new ArrayList<>();
@@ -741,7 +741,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public boolean verifyCVV(String accountNo , SecureDESKey cvkA, SecureDESKey cvkB,
+    public boolean verifyCVV(String accountNo , T cvkA, T cvkB,
                             String cvv, Date expDate, String serviceCode) throws SMException {
 
         List<Loggeable> cmdParameters = new ArrayList<>();
@@ -766,7 +766,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public boolean verifyCVV(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    public boolean verifyCVV(String accountNo, T cvkA, T cvkB,
                             String cvv, String expDate, String serviceCode) throws SMException {
 
         List<Loggeable> cmdParameters = new ArrayList<>();
@@ -791,7 +791,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public boolean verifyCAVV(String accountNo, SecureDESKey cvk, String cavv,
+    public boolean verifyCAVV(String accountNo, T cvk, String cavv,
                               String upn, String authrc, String sfarc) throws SMException {
 
       List<Loggeable> cmdParameters = new ArrayList<>();
@@ -817,7 +817,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public boolean verifydCVV(String accountNo, SecureDESKey imkac, String dcvv,
+    public boolean verifydCVV(String accountNo, T imkac, String dcvv,
                      Date expDate, String serviceCode, byte[] atc, MKDMethod mkdm)
                      throws SMException {
 
@@ -859,7 +859,7 @@ public class BaseSMAdapter
      * @throws SMException
      */
     @Override
-    public boolean verifyCVC3(SecureDESKey imkcvc3, String accountNo, String acctSeqNo,
+    public boolean verifyCVC3(T imkcvc3, String accountNo, String acctSeqNo,
                      byte[] atc, byte[] upn, byte[] data, MKDMethod mkdm, String cvc3)
                      throws SMException {
 
@@ -887,9 +887,9 @@ public class BaseSMAdapter
     }
 
     @Override
-    public boolean verifyARQC(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
+    public boolean verifyARQC(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc
-            ,byte[] upn, byte[] transData) throws SMException {
+            ,byte[] upn, byte[] txnData) throws SMException {
 
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "mkd method", mkdm));
@@ -900,11 +900,11 @@ public class BaseSMAdapter
         cmdParameters.add(new SimpleMsg("parameter", "arqc", arqc == null ? "" : ISOUtil.hexString(arqc)));
         cmdParameters.add(new SimpleMsg("parameter", "atc", atc == null ? "" : ISOUtil.hexString(atc)));
         cmdParameters.add(new SimpleMsg("parameter", "upn", upn == null ? "" : ISOUtil.hexString(upn)));
-        cmdParameters.add(new SimpleMsg("parameter", "txn data", transData == null ? "" : ISOUtil.hexString(transData)));
+        cmdParameters.add(new SimpleMsg("parameter", "txn data", txnData == null ? "" : ISOUtil.hexString(txnData)));
       LogEvent evt = new LogEvent(this, "s-m-operation");
       evt.addMessage(new SimpleMsg("command", "Verify ARQC/TC/AAC", cmdParameters));
       try {
-        boolean r = verifyARQCImpl(mkdm, skdm, imkac, accoutNo, acctSeqNo, arqc, atc, upn, transData);
+        boolean r = verifyARQCImpl(mkdm, skdm, imkac, accoutNo, acctSeqNo, arqc, atc, upn, txnData);
         evt.addMessage(new SimpleMsg("result", "Verification status", r ? "valid" : "invalid"));
         return r;
       } catch (Exception e) {
@@ -916,7 +916,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public byte[] generateARPC(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
+    public byte[] generateARPC(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
             throws SMException {
@@ -951,9 +951,9 @@ public class BaseSMAdapter
     }
 
     @Override
-    public byte[] verifyARQCGenerateARPC(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
+    public byte[] verifyARQCGenerateARPC(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
-            ,byte[] transData, ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
+            ,byte[] txnData, ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
             throws SMException {
 
         List<Loggeable> cmdParameters = new ArrayList<>();
@@ -965,7 +965,7 @@ public class BaseSMAdapter
         cmdParameters.add(new SimpleMsg("parameter", "arqc", arqc == null ? "" : ISOUtil.hexString(arqc)));
         cmdParameters.add(new SimpleMsg("parameter", "atc", atc == null ? "" : ISOUtil.hexString(atc)));
         cmdParameters.add(new SimpleMsg("parameter", "upn", upn == null ? "" : ISOUtil.hexString(upn)));
-        cmdParameters.add(new SimpleMsg("parameter", "txn data", transData == null ? "" : ISOUtil.hexString(transData)));
+        cmdParameters.add(new SimpleMsg("parameter", "txn data", txnData == null ? "" : ISOUtil.hexString(txnData)));
         cmdParameters.add(new SimpleMsg("parameter", "arpc gen. method", arpcMethod));
         cmdParameters.add(new SimpleMsg("parameter", "auth. rc", arc == null ? "" : ISOUtil.hexString(arc)));
         cmdParameters.add(new SimpleMsg("parameter", "prop auth. data",
@@ -974,8 +974,10 @@ public class BaseSMAdapter
       LogEvent evt = new LogEvent(this, "s-m-operation");
       evt.addMessage(new SimpleMsg("command", "Genarate ARPC", cmdParameters));
       try {
-        byte[] result = verifyARQCGenerateARPCImpl(mkdm, skdm, imkac, accoutNo,
-                                                   acctSeqNo, arqc, atc, upn, transData, arpcMethod, arc, propAuthData);
+            byte[] result = verifyARQCGenerateARPCImpl(
+                      mkdm, skdm, imkac, accoutNo, acctSeqNo, arqc, atc, upn
+                    , txnData, arpcMethod, arc, propAuthData
+            );
         evt.addMessage(new SimpleMsg("result", "ARPC", result == null ? "" : ISOUtil.hexString(result)));
         return result;
       } catch (Exception e) {
@@ -988,7 +990,7 @@ public class BaseSMAdapter
 
     @Override
     public byte[] generateSM_MAC(MKDMethod mkdm, SKDMethod skdm
-            ,SecureDESKey imksmi, String accountNo, String acctSeqNo
+            ,T imksmi, String accountNo, String acctSeqNo
             ,byte[] atc, byte[] arqc, byte[] data) throws SMException {
 
         List<Loggeable> cmdParameters = new ArrayList<>();
@@ -1016,10 +1018,10 @@ public class BaseSMAdapter
 
     @Override
     public Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MAC(MKDMethod mkdm
-           ,SKDMethod skdm, PaddingMethod padm, SecureDESKey imksmi
+           ,SKDMethod skdm, PaddingMethod padm, T imksmi
            ,String accountNo, String acctSeqNo, byte[] atc, byte[] arqc
            ,byte[] data, EncryptedPIN currentPIN, EncryptedPIN newPIN
-           ,SecureDESKey kd1, SecureDESKey imksmc, SecureDESKey imkac
+           ,T kd1, T imksmc, T imkac
            ,byte destinationPINBlockFormat) throws SMException {
 
       List<Loggeable> cmdParameters = new ArrayList<>();
@@ -1147,7 +1149,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public byte[] generateCBC_MAC (byte[] data, SecureDESKey kd) throws SMException {
+    public byte[] generateCBC_MAC(byte[] data, T kd) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "data", data));
         cmdParameters.add(new SimpleMsg("parameter", "data key", kd));
@@ -1167,7 +1169,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public byte[] generateEDE_MAC (byte[] data, SecureDESKey kd) throws SMException {
+    public byte[] generateEDE_MAC(byte[] data, T kd) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "data", data));
         cmdParameters.add(new SimpleMsg("parameter", "data key", kd));
@@ -1187,7 +1189,7 @@ public class BaseSMAdapter
     }
 
     @Override
-    public SecureDESKey translateKeyFromOldLMK (SecureDESKey kd) throws SMException {
+    public SecureDESKey translateKeyFromOldLMK(SecureDESKey kd) throws SMException {
         List<Loggeable> cmdParameters = new ArrayList<>();
         cmdParameters.add(new SimpleMsg("parameter", "Key under old LMK", kd));
         LogEvent evt = new LogEvent(this, "s-m-operation");
@@ -1348,7 +1350,7 @@ public class BaseSMAdapter
      * @return generated Key Check Value
      * @throws SMException
      */
-    protected byte[] generateKeyCheckValueImpl (SecureDESKey kd) throws SMException {
+    protected byte[] generateKeyCheckValueImpl(T kd) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1359,7 +1361,7 @@ public class BaseSMAdapter
      * @return translated key with {@code destKeyScheme} scheme
      * @throws SMException
      */
-    protected SecureDESKey translateKeySchemeImpl (SecureDESKey key, KeyScheme destKeyScheme)
+    protected SecureDESKey translateKeySchemeImpl(SecureDESKey key, KeyScheme destKeyScheme)
             throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1374,7 +1376,7 @@ public class BaseSMAdapter
      * @return imported key
      * @throws SMException
      */
-    protected SecureDESKey importKeyImpl (short keyLength, String keyType, byte[] encryptedKey,
+    protected SecureDESKey importKeyImpl(short keyLength, String keyType, byte[] encryptedKey,
             SecureDESKey kek, boolean checkParity) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1386,7 +1388,7 @@ public class BaseSMAdapter
      * @return exported key
      * @throws SMException
      */
-    protected byte[] exportKeyImpl (SecureDESKey key, SecureDESKey kek) throws SMException {
+    protected byte[] exportKeyImpl(SecureDESKey key, SecureDESKey kek) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1418,7 +1420,7 @@ public class BaseSMAdapter
      * @return imported pin
      * @throws SMException
      */
-    protected EncryptedPIN importPINImpl (EncryptedPIN pinUnderKd1, SecureDESKey kd1) throws SMException {
+    protected EncryptedPIN importPINImpl(EncryptedPIN pinUnderKd1, T kd1) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1431,8 +1433,8 @@ public class BaseSMAdapter
      * @return translated pin
      * @throws SMException
      */
-    protected EncryptedPIN translatePINImpl (EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-            SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
+    protected EncryptedPIN translatePINImpl(EncryptedPIN pinUnderKd1, T kd1,
+            T kd2, byte destinationPINBlockFormat) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1445,8 +1447,8 @@ public class BaseSMAdapter
      * @return imported pin
      * @throws SMException
      */
-    protected EncryptedPIN importPINImpl (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk) throws SMException {
+    protected EncryptedPIN importPINImpl(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            T bdk) throws SMException {
         return importPINImpl(pinUnderDuk,ksn,bdk,false);
     }
 
@@ -1459,8 +1461,8 @@ public class BaseSMAdapter
      * @return imported pin
      * @throws SMException
      */
-    protected EncryptedPIN importPINImpl (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk, boolean tdes) throws SMException {
+    protected EncryptedPIN importPINImpl(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            T bdk, boolean tdes) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1475,8 +1477,8 @@ public class BaseSMAdapter
      * @return translated pin
      * @throws SMException
      */
-    protected EncryptedPIN translatePINImpl (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException {
+    protected EncryptedPIN translatePINImpl(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            T bdk, T kd2, byte destinationPINBlockFormat) throws SMException {
         return translatePINImpl(pinUnderDuk,ksn,bdk,kd2,destinationPINBlockFormat,false);
     }
 
@@ -1491,8 +1493,8 @@ public class BaseSMAdapter
      * @return translated pin
      * @throws SMException
      */
-    protected EncryptedPIN translatePINImpl (EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-            SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat,
+    protected EncryptedPIN translatePINImpl(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
+            T bdk, T kd2, byte destinationPINBlockFormat,
             boolean tdes) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1505,7 +1507,7 @@ public class BaseSMAdapter
      * @return exported pin
      * @throws SMException
      */
-    protected EncryptedPIN exportPINImpl (EncryptedPIN pinUnderLmk, SecureDESKey kd2,
+    protected EncryptedPIN exportPINImpl(EncryptedPIN pinUnderLmk, T kd2,
             byte destinationPINBlockFormat) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1532,7 +1534,7 @@ public class BaseSMAdapter
      * @param fields
      * @throws SMException
      */
-    public void printPINImpl (String accountNo, EncryptedPIN pinUnderKd1, SecureDESKey kd1
+    public void printPINImpl(String accountNo, EncryptedPIN pinUnderKd1, T kd1
                              ,String template, Map<String, String> fields) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1548,8 +1550,8 @@ public class BaseSMAdapter
      * @throws SMException
      */
     protected String calculatePVVImpl(EncryptedPIN pinUnderLMK,
-                       SecureDESKey pvkA, SecureDESKey pvkB, int pvkIdx,
-                       List<String> excludes) throws SMException {
+                       T pvkA, T pvkB, int pvkIdx, List<String> excludes)
+            throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1564,8 +1566,8 @@ public class BaseSMAdapter
      * @return PVV (VISA PIN Verification Value)
      * @throws SMException
      */
-    protected String calculatePVVImpl(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                       SecureDESKey pvkA, SecureDESKey pvkB, int pvkIdx,
+    protected String calculatePVVImpl(EncryptedPIN pinUnderKd1, T kd1,
+                       T pvkA, T pvkB, int pvkIdx,
                        List<String> excludes) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1581,8 +1583,8 @@ public class BaseSMAdapter
      * @return true if pin is valid false if not
      * @throws SMException
      */
-    protected boolean verifyPVVImpl(EncryptedPIN pinUnderKd, SecureDESKey kd, SecureDESKey pvkA,
-                        SecureDESKey pvkB, int pvki, String pvv) throws SMException {
+    protected boolean verifyPVVImpl(EncryptedPIN pinUnderKd, T kd, T pvkA,
+                        T pvkB, int pvki, String pvv) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1597,7 +1599,7 @@ public class BaseSMAdapter
      * @return IBM PIN Offset
      * @throws SMException
      */
-    protected String calculateIBMPINOffsetImpl(EncryptedPIN pinUnderLmk, SecureDESKey pvk,
+    protected String calculateIBMPINOffsetImpl(EncryptedPIN pinUnderLmk, T pvk,
                               String decTab, String pinValData, int minPinLen,
                               List<String> excludes) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
@@ -1615,8 +1617,8 @@ public class BaseSMAdapter
      * @return IBM PIN Offset
      * @throws SMException
      */
-    protected String calculateIBMPINOffsetImpl(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                              SecureDESKey pvk, String decTab, String pinValData,
+    protected String calculateIBMPINOffsetImpl(EncryptedPIN pinUnderKd1, T kd1,
+                              T pvk, String decTab, String pinValData,
                               int minPinLen, List<String> excludes)
             throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
@@ -1634,8 +1636,8 @@ public class BaseSMAdapter
      * @return true if pin is valid false if not
      * @throws SMException
      */
-    protected boolean verifyIBMPINOffsetImpl(EncryptedPIN pinUnderKd, SecureDESKey kd
-                            ,SecureDESKey pvk, String offset, String decTab
+    protected boolean verifyIBMPINOffsetImpl(EncryptedPIN pinUnderKd, T kd
+                            ,T pvk, String offset, String decTab
                             ,String pinValData, int minPinLen) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1651,9 +1653,9 @@ public class BaseSMAdapter
      * @return derived PIN under LMK
      * @throws SMException
      */
-    protected EncryptedPIN deriveIBMPINImpl(String accountNo, SecureDESKey pvk
-                              ,String decTab, String pinValData, int minPinLen
-                              ,String offset) throws SMException {
+    protected EncryptedPIN deriveIBMPINImpl(String accountNo, T pvk, String decTab
+                                , String pinValData, int minPinLen, String offset)
+            throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1667,7 +1669,7 @@ public class BaseSMAdapter
      * @return Card Verification Code/Value
      * @throws SMException
      */
-    protected String calculateCVVImpl(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    protected String calculateCVVImpl(String accountNo, T cvkA, T cvkB,
                                    Date expDate, String serviceCode) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1683,7 +1685,7 @@ public class BaseSMAdapter
      * @return Card Verification Code/Value
      * @throws SMException
      */
-    protected String calculateCVVImpl(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    protected String calculateCVVImpl(String accountNo, T cvkA, T cvkB,
                                    String expDate, String serviceCode) throws SMException {
         throw new UnsupportedOperationException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1699,7 +1701,7 @@ public class BaseSMAdapter
      * @return Cardholder Authentication Verification Value
      * @throws SMException
      */
-    protected String calculateCAVVImpl(String accountNo, SecureDESKey cvk, String upn,
+    protected String calculateCAVVImpl(String accountNo, T cvk, String upn,
                                     String authrc, String sfarc) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1715,7 +1717,7 @@ public class BaseSMAdapter
      * @return true if CVV/CVC is falid or false if not
      * @throws SMException
      */
-    protected boolean verifyCVVImpl(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    protected boolean verifyCVVImpl(String accountNo, T cvkA, T cvkB,
                         String cvv, Date expDate, String serviceCode) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1731,7 +1733,7 @@ public class BaseSMAdapter
      * @return {@code true} if CVV/CVC is valid or {@code false} otherwise
      * @throws SMException
      */
-    protected boolean verifyCVVImpl(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    protected boolean verifyCVVImpl(String accountNo, T cvkA, T cvkB,
                         String cvv, String expDate, String serviceCode) throws SMException {
         throw new UnsupportedOperationException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1747,7 +1749,7 @@ public class BaseSMAdapter
      * @return Cardholder Authentication Verification Value
      * @throws SMException
      */
-    protected boolean verifyCAVVImpl(String accountNo, SecureDESKey cvk, String cavv,
+    protected boolean verifyCAVVImpl(String accountNo, T cvk, String cavv,
                                      String upn, String authrc, String sfarc) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1764,7 +1766,7 @@ public class BaseSMAdapter
      * @return true if dcvv is valid false if not
      * @throws SMException
      */
-    protected boolean verifydCVVImpl(String accountNo, SecureDESKey imkac, String dcvv,
+    protected boolean verifydCVVImpl(String accountNo, T imkac, String dcvv,
                      Date expDate, String serviceCode, byte[] atc, MKDMethod mkdm)
                      throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
@@ -1783,7 +1785,7 @@ public class BaseSMAdapter
      * @return true if cvc3 is valid false if not
      * @throws SMException
      */
-    protected boolean verifyCVC3Impl(SecureDESKey imkcvc3, String accountNo, String acctSeqNo,
+    protected boolean verifyCVC3Impl(T imkcvc3, String accountNo, String acctSeqNo,
                      byte[] atc, byte[] upn, byte[] data, MKDMethod mkdm, String cvc3)
                      throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
@@ -1799,13 +1801,13 @@ public class BaseSMAdapter
      * @param arqc
      * @param atc
      * @param upn
-     * @param transData
+     * @param txnData
      * @return true if ARQC/TC/AAC is falid or false if not
      * @throws SMException
      */
-    protected boolean verifyARQCImpl(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
+    protected boolean verifyARQCImpl(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accountNo, String acctSeqNo, byte[] arqc, byte[] atc
-            ,byte[] upn, byte[] transData) throws SMException {
+            ,byte[] upn, byte[] txnData) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1825,7 +1827,7 @@ public class BaseSMAdapter
      * @return calculated ARPC
      * @throws SMException
      */
-    protected byte[] generateARPCImpl(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
+    protected byte[] generateARPCImpl(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accountNo, String acctSeqNo, byte[] arqc, byte[] atc
             ,byte[] upn, ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
             throws SMException {
@@ -1849,7 +1851,7 @@ public class BaseSMAdapter
      * @return calculated ARPC
      * @throws SMException
      */
-    protected byte[] verifyARQCGenerateARPCImpl(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
+    protected byte[] verifyARQCGenerateARPCImpl(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accountNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,byte[] transData, ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
             throws SMException {
@@ -1872,7 +1874,7 @@ public class BaseSMAdapter
      * @throws SMException
      */
     protected byte[] generateSM_MACImpl(MKDMethod mkdm, SKDMethod skdm
-            ,SecureDESKey imksmi, String accountNo, String acctSeqNo
+            ,T imksmi, String accountNo, String acctSeqNo
             ,byte[] atc, byte[] arqc, byte[] data) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1898,10 +1900,10 @@ public class BaseSMAdapter
      * @throws SMException
      */
     protected Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MACImpl(MKDMethod mkdm
-           ,SKDMethod skdm, PaddingMethod padm, SecureDESKey imksmi
+           ,SKDMethod skdm, PaddingMethod padm, T imksmi
            ,String accountNo, String acctSeqNo, byte[] atc, byte[] arqc
            ,byte[] data, EncryptedPIN currentPIN, EncryptedPIN newPIN
-           ,SecureDESKey kd1, SecureDESKey imksmc, SecureDESKey imkac
+           ,T kd1, T imksmc, T imkac
            ,byte destinationPINBlockFormat) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
@@ -1941,7 +1943,7 @@ public class BaseSMAdapter
      * @return generated CBC-MAC
      * @throws SMException
      */
-    protected byte[] generateCBC_MACImpl (byte[] data, SecureDESKey kd) throws SMException {
+    protected byte[] generateCBC_MACImpl(byte[] data, T kd) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1952,7 +1954,7 @@ public class BaseSMAdapter
      * @return generated EDE-MAC
      * @throws SMException
      */
-    protected byte[] generateEDE_MACImpl (byte[] data, SecureDESKey kd) throws SMException {
+    protected byte[] generateEDE_MACImpl(byte[] data, T kd) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1964,7 +1966,7 @@ public class BaseSMAdapter
      * @return key encrypted under the new LMK
      * @throws SMException if the parity of the imported key is not adjusted AND checkParity = true
      */
-    protected SecureDESKey translateKeyFromOldLMKImpl (SecureDESKey kd) throws SMException {
+    protected SecureDESKey translateKeyFromOldLMKImpl(SecureDESKey kd) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -1976,7 +1978,7 @@ public class BaseSMAdapter
      */
     protected Pair<PublicKey, SecurePrivateKey> generateKeyPairImpl(AlgorithmParameterSpec spec)
             throws SMException {
-        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+        throw new UnsupportedOperationException("Operation not supported in: " + this.getClass().getName());
     }
 
     /**
@@ -2037,12 +2039,12 @@ public class BaseSMAdapter
     }
 
     @Override
-    public byte[] dataEncrypt (SecureDESKey bdk, byte[] clearText) throws SMException {
+    public byte[] dataEncrypt(T bdk, byte[] clearText) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
     @Override
-    public byte[] dataDecrypt (SecureDESKey bdk, byte[] clearText) throws SMException {
+    public byte[] dataDecrypt(T bdk, byte[] clearText) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 
@@ -2050,4 +2052,5 @@ public class BaseSMAdapter
     public SecureDESKey formKEYfromClearComponents(short keyLength, String keyType, String... clearComponents) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
+
 }

--- a/jpos/src/main/java/org/jpos/security/Exportability.java
+++ b/jpos/src/main/java/org/jpos/security/Exportability.java
@@ -1,0 +1,107 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Defines the conditions under which the key contained in the key block can be
+ * exported outside the cryptographic domain in which the key is found.
+ * <p>
+ * Each value repesents byte 11 of the Keyblok Header.
+ * <p>
+ */
+public enum Exportability {
+
+    /**
+     * May only be exported in a trusted key block, provided the wrapping key
+     * itself is in a trusted format.
+     */
+    ANY         ('E', "Exportable only in a trusted key block"),
+
+    /**
+     * No export permitted.
+     */
+    NONE        ('N', "No export permitted"),
+
+    /**
+     * May only be exported in a trusted key block, provided the wrapping key
+     * itself is in a trusted format <b>only if allowed</b>.
+     * <p>
+     * Sensitive; all other export possibilities are permitted, provided such
+     * export has been enabled <i>(existing Authorized State requirements
+     * remain)</i>.
+     */
+    TRUSTED     ('S', "Exportable only in a trusted key block if allowed");
+
+
+    private static final Map<Character, Exportability> MAP = new HashMap<>();
+
+    static {
+        for (Exportability exp : Exportability.values())
+            MAP.put(exp.getCode(), exp);
+    }
+
+    private final char code;
+    private final String name;
+
+    Exportability(char code, String name) {
+        Objects.requireNonNull(name, "The name of key exportability is required");
+        this.code = code;
+        this.name = name;
+    }
+
+    /**
+     * Get exportability code.
+     *
+     * @return the character exportability code
+     */
+    public char getCode() {
+        return code;
+    }
+
+    /**
+     * Get exportability name.
+     *
+     * @return the exportability name
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Exportability[code: %s, name: %s]", code, name);
+    }
+
+    /**
+     * Returns the enum constant of this type with the specified {@code code}.
+     *
+     * @param code the string must match exactly with identifier specified by
+     *        <i>ISO 8583-1:2003(E) Table A.22 — Transaction type codes</i>
+     * @return the enum constant with the specified processing code or
+     *         {@code null} if unknown.
+     */
+    public static Exportability valueOfByCode(char code) {
+        return MAP.get(code);
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/security/ExtKeyUsage.java
+++ b/jpos/src/main/java/org/jpos/security/ExtKeyUsage.java
@@ -1,0 +1,274 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Defines the primary usage of the key contained in the key block.
+ * <p>
+ * Each value repesents bytes 5-6 of the Keyblok Header.
+ * <p>
+ * This class defines proprietary specific key usages. In the great majority of
+ * cases, the ones defined by TR-31 {@link KeyUsage} will be sufficient. There
+ * are no strong reasons for separating e.g. KEK keys to ZMK and TMK, or PINENC
+ * keys to ZPK and TPK. KEK and PINENC should be enough.
+ * <p>
+ * However, when it is necessary to use, for example: private/public RSA keys
+ * or HMAC keys, the only option is to use the proprietary key usages.
+ * <p>
+ * The proprietary key usages for {@code ExtKeyUsage} are optional and can be
+ * defined in your resources at {@value ExtKeyUsage#EXTERNAL_KEY_USAGES}. A file
+ * with the same name in the jPOS test resources can be used as an example.
+ */
+public class ExtKeyUsage extends KeyUsage {
+
+    /**
+     * Key usages by code key.
+     * <p>
+     * This field has to be first
+     */
+    private static final Map<String, KeyUsage> MAP = new LinkedHashMap<>();
+
+    private static final String EXTERNAL_KEY_USAGES = "META-INF/org/jpos/security/proprietary-hsm.properties";
+
+    private static final String KEY_USAGE_PREFIX    = "ku.";
+
+    /**
+     * Key usages by entry key.
+     * <p>
+     * This field has to be after {@link MAP} and before key usages;
+     */
+    private static final Map<String, KeyUsage> EXT_DEF = loadKeyUsagesFromClasspath(EXTERNAL_KEY_USAGES);
+
+    /**
+     * DEK - Data Encryption Key.
+     *
+     * @apiNote It is proprietary specific version of {@link KeyUsage#ENC}
+     */
+    public final static KeyUsage DEK        = getKeyUsage("DEK");
+
+    /**
+     * ZEK - Zone Encryption Key.
+     *
+     * @apiNote It is proprietary specific version of {@link KeyUsage#ENC}
+     */
+    public final static KeyUsage ZEK        = getKeyUsage("ZEK");
+
+    /**
+     * TEK - Terminal Encryption Key.
+     *
+     * @apiNote It is proprietary specific version of {@link KeyUsage#ENC}
+     */
+    public final static KeyUsage TEK        = getKeyUsage("TEK");
+
+    /**
+     * RSA Public Key.
+     *
+     * @apiNote It is proprietary specific, there is no equivalent in TR-31.
+     */
+    public final static KeyUsage RSAPK      = getKeyUsage("RSAPK");
+
+    /**
+     * RSA Private Key for signing or key management.
+     *
+     * @apiNote It is proprietary specific, there is no equivalent in TR-31.
+     */
+    public final static KeyUsage RSASK      = getKeyUsage("RSASK");
+
+    /**
+     * RSA Private Key for ICC personalization.
+     *
+     * @apiNote It is proprietary specific, there is no equivalent in TR-31.
+     */
+    public final static KeyUsage RSASKICC   = getKeyUsage("RSASKICC");
+
+    /**
+     * RSA Private Key for PIN translation.
+     *
+     * @apiNote It is proprietary specific, there is no equivalent in TR-31.
+     */
+    public final static KeyUsage RSASKPIN   = getKeyUsage("RSASKPIN");
+
+    /**
+     * RSA Private Key for TLS.
+     *
+     * @apiNote It is proprietary specific, there is no equivalent in TR-31.
+     */
+    public final static KeyUsage RSASKTLS   = getKeyUsage("RSASKTLS");
+
+    /**
+     * TMK - Terminal Master Key.
+     *
+     * @apiNote It is proprietary specific version of {@link KeyUsage#KEK}
+     */
+    public final static KeyUsage TMK        = getKeyUsage("TMK");
+
+    /**
+     * ZMK - Zone Master Key.
+     *
+     * @apiNote It is proprietary specific version of {@link KeyUsage#KEK}
+     */
+    public final static KeyUsage ZMK        = getKeyUsage("ZMK");
+
+    /**
+     * HMAC key using SHA-1.
+     *
+     * @apiNote It is proprietary specific, there is no equivalent in TR-31.
+     */
+    public final static KeyUsage HMACSHA1   = getKeyUsage("HMACSHA1");
+
+    /**
+     * HMAC key using SHA-224.
+     *
+     * @apiNote It is proprietary specific, there is no equivalent in TR-31.
+     */
+    public final static KeyUsage HMACSHA224 = getKeyUsage("HMACSHA224");
+
+    /**
+     * HMAC key using SHA-256.
+     *
+     * @apiNote It is proprietary specific, there is no equivalent in TR-31.
+     */
+    public final static KeyUsage HMACSHA256 = getKeyUsage("HMACSHA256");
+
+    /**
+     * HMAC key using SHA-384.
+     *
+     * @apiNote It is proprietary specific, there is no equivalent in TR-31.
+     */
+    public final static KeyUsage HMACSHA384 = getKeyUsage("HMACSHA384");
+
+    /**
+     * HMAC key using SHA-512.
+     *
+     * @apiNote It is proprietary specific, there is no equivalent in TR-31.
+     */
+    public final static KeyUsage HMACSHA512 = getKeyUsage("HMACSHA512");
+
+    /**
+     * TPK - Terminal PIN Encryption Key.
+     *
+     * @apiNote It is proprietary specific version of {@link KeyUsage#PINENC}
+     */
+    public final static KeyUsage TPK        = getKeyUsage("TPK");
+
+    /**
+     * ZPK - Zone PIN Encryption Key.
+     *
+     * @apiNote It is proprietary specific version of {@link KeyUsage#PINENC}
+     */
+    public final static KeyUsage ZPK        = getKeyUsage("ZPK");
+
+
+    /**
+     * Internal constructor.
+     * <p>
+     * The constructor is protected to guarantee only one instance of the key
+     * usage in the entire JVM. This makes it possible to use the operator
+     * {@code ==} or {@code !=} as it does for enums.
+     *
+     * @param code the key usage code
+     * @param name the usage name
+     */
+    protected ExtKeyUsage(String code, String name) {
+        super(code, name);
+    }
+
+    private static KeyUsage getKeyUsage(String entry) {
+        if (EXT_DEF == null)
+            return null;
+
+        return EXT_DEF.get(entry);
+    }
+
+    /**
+     * Returns the enum constant of this type with the specified {@code code}.
+     *
+     * @param code
+     * @return the enum constant with the specified processing code or
+     *         {@code null} if unknown.
+     */
+    public static KeyUsage valueOfByCode(String code) {
+        KeyUsage ku = MAP.get(code);
+        if (ku != null)
+            return ku;
+
+        return TR31MAP.get(code);
+    }
+
+    public static Map<String, KeyUsage> entries() {
+        Map ret = new LinkedHashMap(TR31MAP);
+        ret.putAll(MAP);
+        return Collections.unmodifiableMap(ret);
+    }
+
+    private static InputStream loadResourceAsStream(String name) {
+        InputStream in = null;
+
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        if (contextClassLoader != null)
+            in = contextClassLoader.getResourceAsStream(name);
+
+        if (in == null)
+            in = ExtKeyUsage.class.getClassLoader().getResourceAsStream(name);
+
+        return in;
+    }
+
+    static Map<String, KeyUsage> loadKeyUsagesFromClasspath(String resource) {
+        Properties props = new Properties();
+        try (InputStream in = loadResourceAsStream(resource)) {
+            props.load(in);
+            return registerKeyUsages(props);
+        } catch (IOException | NullPointerException ex) {
+            return null;
+        }
+    }
+
+    private static Map<String, KeyUsage> registerKeyUsages(Properties props) {
+        Map<String, KeyUsage> ret = new LinkedHashMap<>();
+        for (String key : props.stringPropertyNames()) {
+            if (!key.startsWith(KEY_USAGE_PREFIX))
+                continue;
+
+            String value = props.getProperty(key);
+            if (value == null || value.isEmpty())
+                continue;
+
+            String k = key.substring(KEY_USAGE_PREFIX.length());
+            String[] entry = value.split(",");
+            KeyUsage ku = new KeyUsage(entry[0], entry[1]);
+            // Override is disabled
+            if (MAP.containsKey(ku.getCode()))
+                continue;
+
+            ret.put(k, ku);
+            MAP.put(ku.getCode(), ku);
+        }
+
+        return ret;
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/security/KeyScheme.java
+++ b/jpos/src/main/java/org/jpos/security/KeyScheme.java
@@ -54,6 +54,29 @@ public enum KeyScheme {
      * <p>
      * Used for encryption of keys under a variant LMK.
      */
-    T
+    T,
+
+    /**
+     * Encryption of single/double/triple-length DES & AES keys using the ANSI
+     * X9 TR-31 Key Block methods.
+     * <p>
+     * Only used for exporting keys <i>(e.g. under a KEK)</i>.
+     * <p>
+     * The ANSI X9 Committee published Technical Report 31 (TR-31) on
+     * <i>Interoperable Secure Key ExcKey Block Specification for Symmetric
+     * Algorithms</i> in 2010 to describe a method for secure key exchange which
+     * meets the needs of X9.24.
+     */
+    R,
+
+    /**
+     * Encryption of all DES, AES, HMAC & RSA keys using proprietary Key Block
+     * methods.
+     * <p>
+     * Used for encrypting keys for local use <i>(under a Key Block LMK)</i> or
+     * for importing/exporting keys <i>(e.g. under a KEK or ZMK)</i>.
+     */
+    S
+
 }
 

--- a/jpos/src/main/java/org/jpos/security/KeyUsage.java
+++ b/jpos/src/main/java/org/jpos/security/KeyUsage.java
@@ -1,0 +1,239 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.jpos.iso.ISOUtil;
+
+/**
+ * Defines the primary usage of the key contained in the key block.
+ * <p>
+ * Each value repesents bytes 5-6 of the Keyblok Header.
+ */
+public class KeyUsage {
+
+    protected static final Map<String, KeyUsage> TR31MAP =  new LinkedHashMap<>();
+
+    /**
+     * TR-31 BDK Base Derivation Key.
+     */
+    public final static KeyUsage BDK       = create("B0", "BDK - Base Derivation Key");
+
+    /**
+     * TR-31 DUKPT Initial Key (IKEY aka IPEK).
+     */
+    public final static KeyUsage IKEY      = create("B1", "IKEY - DUKPT Initial Key");
+
+    /**
+     * TR-31 CVK Card Verification Key.
+     */
+    public final static KeyUsage CVK       = create("C0", "CVK - Card Verification Key");
+
+    /**
+     * TR-31 Data Encryption Key.
+     */
+    public final static KeyUsage ENC       = create("D0", "Data Encryption Key");
+
+    /**
+     * TR-31 Initialization Value.
+     * <p>
+     * Used for protect eg. Initalization Vector or Decimalization Table.
+     */
+    public final static KeyUsage INIT      = create("I0", "Initialization Value");
+
+    /**
+     * TR-31 Generic Key Encryption / Wrapping Key.
+     */
+    public final static KeyUsage KEK       = create("K0", "Key Encryption / Wrapping Key");
+
+    /**
+     * TR-31 Key Block Protection Key.
+     */
+    public final static KeyUsage KEKWRAP   = create("K1", "Key Block Protection Key");
+
+    /**
+     * TR-31 ISO 16609 MAC algorithm 1 Key <i>(using 3-DES)</i>.
+     */
+    public final static KeyUsage ISOMAC0   = create("M0", "ISO 16609 MAC algorithm 1 Key");
+
+    /**
+     * TR-31 ISO 9797-1 MAC algorithm 1 Key.
+     */
+    public final static KeyUsage ISOMAC1   = create("M1", "ISO 9797-1 MAC algorithm 1 Key");
+
+    /**
+     * TR-31 ISO 9797-1 MAC algorithm 2 Key.
+     */
+    public final static KeyUsage ISOMAC2   = create("M2", "ISO 9797-1 MAC algorithm 2 Key");
+
+    /**
+     * TR-31 ISO 9797-1 MAC algorithm 3 Key.
+     */
+    public final static KeyUsage ISOMAC3   = create("M3", "ISO 9797-1 MAC algorithm 3 Key");
+
+    /**
+     * TR-31 ISO 9797-1 MAC algorithm 4 Key.
+     */
+    public final static KeyUsage ISOMAC4   = create("M4", "ISO 9797-1 MAC algorithm 4 Key");
+
+    /**
+     * TR-31 ISO 9797-1 MAC algorithm 5 Key.
+     */
+    public final static KeyUsage ISOMAC5   = create("M5", "ISO 9797-1 MAC algorithm 5 Key");
+
+    /**
+     * TR-31 Generic PIN Encription Key.
+     */
+    public final static KeyUsage PINENC    = create("P0", "PIN encryption key");
+
+    /**
+     * TR-31 Generic PIN Verification Key.
+     */
+    public final static KeyUsage PINVER    = create("V0", "PIN verification key or other algorithm");
+
+    /**
+     * TR-31 PIN Verification Key (IBM 3624 algorithm).
+     */
+    public final static KeyUsage PINV3624  = create("V1", "PIN verification key, IBM 3624 algorithm");
+
+    /**
+     * TR-31 PIN Verification Key (Visa PVV algorithm).
+     */
+    public final static KeyUsage VISAPVV   = create("V2", "PIN verification key, VISA PVV algorithm");
+
+    /**
+     * TR-31 Application Cryptograms Key.
+     */
+    public final static KeyUsage EMVACMK   = create("E0", "EMV/Chip card Master Key, MKAC - Application Cryptogram");
+
+    /**
+     * TR-31 Secure Messaging for Confidentiality Key.
+     */
+    public final static KeyUsage EMVSCMK   = create("E1", "EMV/Chip card Master Key, MKSMC - Secure Messaging for Confidentiality");
+
+    /**
+     * TR-31 Secure Messaging for Integrity.
+     */
+    public final static KeyUsage EMVSIMK   = create("E2", "EMV/Chip card Master Key, MKSMI - Secure Messaging for Integrity");
+
+    /**
+     * TR-31 Data Authentication Code Key.
+     */
+    public final static KeyUsage EMVDAMK   = create("E3", "EMV/Chip card Master Key, MKDAC - Data Authentication Code");
+
+    /**
+     * TR-31 Dynamic Numbers Key.
+     */
+    public final static KeyUsage EMVDNMK   = create("E4", "EMV/Chip card Master Key, MKDN - Dynamic Numbers");
+
+    /**
+     * TR-31 Card Personalization Key.
+     */
+    public final static KeyUsage EMVCPMK   = create("E5", "EMV/Chip card Master Key, Card Personalization");
+
+    /**
+     * TR-31 Chip card Master Key.
+     */
+    public final static KeyUsage EMVOTMK   = create("E6", "EMV/Chip card Master Key, Other");
+
+    /**
+     * TR-31 Master Personalization Key.
+     */
+    public final static KeyUsage EMVMPMK   = create("E7", "EMV/Master Personalization Key");
+
+
+    private final String code;
+    private final String name;
+
+    /**
+     * Internal constructor.
+     * <p>
+     * The constructor is protected to guarantee only one instance of the key
+     * usage in the entire JVM. This makes it possible to use the operator
+     * {@code ==} or {@code !=} as it does for enums.
+     *
+     * @param code the key usage code
+     * @param name the usage name
+     */
+    protected KeyUsage(String code, String name) {
+        Objects.requireNonNull(code, "The code of key usage is required");
+        Objects.requireNonNull(name, "The name of key usage is required");
+        if (code.length() != 2)  //The length of the code must be 2
+            throw new IllegalArgumentException("The length of the key block Key Usage code must be 2");
+
+        this.code = code;
+        this.name = name;
+    }
+
+    private static KeyUsage create(String code, String name) {
+        KeyUsage ku = new KeyUsage(code, name);
+        if (ISOUtil.isNumeric(code, 10))
+            throw new IllegalArgumentException(
+                "The TR-31 Key Usage code can not consist of digits only"
+            );
+        if (TR31MAP.containsKey(ku.getCode()))
+            throw new IllegalArgumentException(
+                "The TR-31 Key Usage code can by registered only once"
+            );
+        TR31MAP.put(ku.getCode(), ku);
+        return ku;
+    }
+
+    /**
+     * Get key usage code.
+     *
+     * @return two characters which represents key usage code
+     */
+    public String getCode() {
+        return code;
+    }
+
+    /**
+     * Get key usage name.
+     *
+     * @return the key usage name
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("KeyUsage[code: %s, name: %s]", code, name);
+    }
+
+    /**
+     * Returns the enum constant of this type with the specified {@code code}.
+     *
+     * @param code
+     * @return the enum constant with the specified processing code or
+     *         {@code null} if unknown.
+     */
+    public static KeyUsage valueOfByCode(String code) {
+        return TR31MAP.get(code);
+    }
+
+    public static Map<String, KeyUsage> entries() {
+        return Collections.unmodifiableMap(TR31MAP);
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/security/ModeOfUse.java
+++ b/jpos/src/main/java/org/jpos/security/ModeOfUse.java
@@ -1,0 +1,143 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Defines the operation that the key contained in the key block can perform.
+ * <p>
+ * Each value represents byte 8 of the Keyblok Header.
+ */
+public enum ModeOfUse {
+
+    /**
+     * The key may be used to perform both encrypt and decrypt operations.
+     */
+    ENCDEC          ('B', "Encryption and Decryption"),
+
+    /**
+     * The key may be used to perform MAC calculation <i>(both generate &
+     * verify)</i> operations.
+     */
+    GENVER          ('C', "Verification and Generation of MAC, CVD"),
+
+    /**
+     * The key may only be used to perform decrypt operations.
+     */
+    DECONLY         ('D', "Data Decryption"),
+
+    /**
+     * The key may only be used to perform encrypt operations.
+     */
+    ENCONLY         ('E', "Data Encryption"),
+
+    /**
+     * The key may only be used to perform MAC generate operations.
+     */
+    GENONLY         ('G', "Generaction of MAC, CVD"),
+
+    /**
+     * No special restrictions apply.
+     */
+    ANY             ('N', "Without restrictions"),
+
+    /**
+     * The key may only be used to perform digital signature generation
+     * operations.
+     */
+    GENSIGN         ('S', "Digital Signature Generation"),
+
+    /**
+     * The key may be used to perform both digital signature generation and
+     * verification operations.
+     */
+    SIGNVER         ('T', "Digital Signature Generation and Verification"),
+
+    /**
+     * The key may only be used to perform digital signature verification
+     * operations.
+     */
+    VERONLY         ('V', "Digital Signature Verification"),
+
+    /**
+     * The key may only be used to derive other keys.
+     */
+    DERIVE          ('X', "Derive Keys"),
+
+    /**
+     * The key may be used to create key variants.
+     */
+    KEYVAR          ('Y', "Key used to create key variants");
+
+
+    private static final Map<Character, ModeOfUse> MAP = new HashMap<>();
+
+    static {
+        for (ModeOfUse tr : ModeOfUse.values())
+            MAP.put(tr.getCode(), tr);
+    }
+
+    private final char code;
+    private final String name;
+
+    ModeOfUse(char code, String name) {
+        Objects.requireNonNull(name, "The name of key use mode is required");
+        this.code = code;
+        this.name = name;
+    }
+
+    /**
+     * Get code of key use mode.
+     *
+     * @return the character which represents code of key use mode
+     */
+    public char getCode() {
+        return code;
+    }
+
+    /**
+     * Get name of key use mode.
+     *
+     * @return the name of key use mode.
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ModeOfUse[code: %s, name: %s]", code, name);
+    }
+
+    /**
+     * Returns the enum constant of this type with the specified {@code code}.
+     *
+     * @param code the string must match exactly with identifier specified by
+     *        <i>ISO 8583-1:2003(E) Table A.22 — Transaction type codes</i>
+     * @return the enum constant with the specified processing code or
+     *         {@code null} if unknown.
+     */
+    public static ModeOfUse valueOfByCode(char code) {
+        return MAP.get(code);
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/security/SMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/SMAdapter.java
@@ -275,6 +275,16 @@ public interface SMAdapter<T> {
      */
     SecureDESKey generateKey(short keyLength, String keyType) throws SMException;
 
+    /**
+     * Generates a random Key.
+     *
+     * @param keySpec the specification of the key to be generated
+     *               (length, type, usage, algorithm, etc)
+     * @return the random key secured by the security module
+     * @throws SMException
+     * @see SecureKeySpec
+     */
+    SecureKey generateKey(SecureKeySpec keySpec) throws SMException;
 
 
     /**
@@ -319,6 +329,22 @@ public interface SMAdapter<T> {
     SecureDESKey importKey(short keyLength, String keyType, byte[] encryptedKey,
                            SecureDESKey kek, boolean checkParity) throws SMException;
 
+    /**
+     * Imports a key from encryption under a KEK (Key-Encrypting Key)
+     * to protection under the security module.
+     *
+     * @param kek the key-encrypting key
+     * @param key key to be imported and encrypted under KEK
+     * @param keySpec the specification of the key to be imported. It allows
+     *        passing or change key block attributes.
+     * @param checkParity if {@code true}, the key is not imported unless it has
+     *        adjusted parity
+     * @return imported key secured by the security module
+     * @throws SMException e.g: if the parity of the imported key is not adjusted
+     *         and {@code checkParity} is {@code true}
+     */
+    SecureKey importKey(SecureKey kek, SecureKey key, SecureKeySpec keySpec, boolean checkParity)
+            throws SMException;
 
 
     /**
@@ -329,6 +355,19 @@ public interface SMAdapter<T> {
      * @throws SMException
      */
     byte[] exportKey(SecureDESKey key, SecureDESKey kek) throws SMException;
+
+    /**
+     * Exports secure key to encryption under a KEK (Key-Encrypting Key).
+     *
+     * @param kek the key-encrypting key
+     * @param key the secure key to be exported
+     * @param keySpec the specification of the key to be exported. It allows
+     *        passing or change key block attributes.
+     * @return the exported key (key encrypted under kek)
+     * @throws SMException
+     */
+    SecureKey exportKey(SecureKey kek, SecureKey key, SecureKeySpec keySpec)
+            throws SMException;
 
     /**
      * Encrypts a clear pin under LMK.
@@ -1319,9 +1358,22 @@ public interface SMAdapter<T> {
      *
      * @param kd the key encrypted under old LMK
      * @return key encrypted under the new LMK
-     * @throws SMException if the parity of the imported key is not adjusted AND checkParity = true
+     * @throws SMException
      */
     SecureDESKey translateKeyFromOldLMK(SecureDESKey kd) throws SMException;
+
+
+    /**
+     * Translate key from encryption under the LMK held in key change storage
+     * to encryption under a new LMK.
+     *
+     * @param key the key encrypted under old LMK
+     * @param keySpec the specification of the key to be translated. It allows
+     *        passing new key block attributes.
+     * @return key encrypted under the new LMK
+     * @throws SMException
+     */
+    SecureKey translateKeyFromOldLMK(SecureKey key, SecureKeySpec keySpec) throws SMException;
 
 
     /**
@@ -1336,6 +1388,18 @@ public interface SMAdapter<T> {
       throws SMException;
 
 
+    /**
+     * Generate a public/private key pair.
+     *
+     * @param keySpec the specification of the key to be generated. It allows
+     *        passing key algorithm type, size and key block attributes.
+     *        NOTE: For pass an extra key usage of the RSA key, possible is use
+     *        e.g. {@code keySpec.setVariant()} or {@code keySpec.setReserved()}
+     * @return key pair generated according to passed parameters
+     * @throws SMException
+     */
+    Pair<PublicKey, SecureKey> generateKeyPair(SecureKeySpec keySpec) throws SMException;
+
 
     /**
      * Calculate signature of Data Block.
@@ -1346,7 +1410,7 @@ public interface SMAdapter<T> {
      * @return signature of passed data.
      * @throws SMException
      */
-    byte[] calculateSignature(MessageDigest hash, SecurePrivateKey privateKey
+    byte[] calculateSignature(MessageDigest hash, SecureKey privateKey
             ,byte[] data) throws SMException;
 
 
@@ -1354,7 +1418,7 @@ public interface SMAdapter<T> {
      * Encrypts clear Data Block with specified cipher.
      * <p>
      * NOTE: This is a more general version of the
-     * {@link #encryptData(CipherMode, SecureDESKey, Object, byte[], byte[])}
+     * {@link #encryptData(CipherMode, SecureDESKey, byte[], byte[])}
      *
      * @param encKey the data encryption key e.g:
      *        <ul>
@@ -1380,7 +1444,7 @@ public interface SMAdapter<T> {
      * Decrypts encrypted Data Block with specified cipher.
      * <p>
      * NOTE: This is a more general version of the
-     * {@link #decryptData(CipherMode, SecureDESKey, Object, byte[], byte[])}
+     * {@link #decryptData(CipherMode, SecureDESKey, byte[], byte[])}
      *
      * @param decKey the data decryption key e.g:
      *        <ul>

--- a/jpos/src/main/java/org/jpos/security/SMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/SMAdapter.java
@@ -42,7 +42,7 @@ import java.util.Map;
  * @author Robert Demski
  * @version $Revision$ $Date$
  */
-public interface SMAdapter {
+public interface SMAdapter<T> {
     /**
      * DES Key Length <code>LENGTH_DES</code> = 64.
      */
@@ -280,11 +280,11 @@ public interface SMAdapter {
     /**
      * Generates key check value.
      *
-     * @param kd SecureDESKey with untrusted or fake Key Check Value
+     * @param kd the key with untrusted or fake Key Check Value
      * @return key check value bytes
      * @throws SMException
      */
-    byte[] generateKeyCheckValue(SecureDESKey kd) throws SMException;
+    byte[] generateKeyCheckValue(T kd) throws SMException;
 
 
 
@@ -372,7 +372,7 @@ public interface SMAdapter {
      * @return pin encrypted under LMK
      * @throws SMException
      */
-    EncryptedPIN importPIN(EncryptedPIN pinUnderKd1, SecureDESKey kd1) throws SMException;
+    EncryptedPIN importPIN(EncryptedPIN pinUnderKd1, T kd1) throws SMException;
 
 
 
@@ -386,8 +386,8 @@ public interface SMAdapter {
      * @return pin encrypted under KD2
      * @throws SMException
      */
-    EncryptedPIN translatePIN(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                              SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException;
+    EncryptedPIN translatePIN(EncryptedPIN pinUnderKd1, T kd1,
+                              T kd2, byte destinationPINBlockFormat) throws SMException;
 
 
 
@@ -403,8 +403,8 @@ public interface SMAdapter {
      * @return pin encrypted under LMK
      * @throws SMException
      */
-    EncryptedPIN importPIN(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-                           SecureDESKey bdk) throws SMException;
+    EncryptedPIN importPIN(EncryptedPIN pinUnderDuk, KeySerialNumber ksn, T bdk)
+            throws SMException;
 
     /**
      * Imports a PIN from encryption under a transaction key to encryption
@@ -419,7 +419,7 @@ public interface SMAdapter {
      * @throws SMException
      */
     EncryptedPIN importPIN(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-                           SecureDESKey bdk, boolean tdes) throws SMException;
+                           T bdk, boolean tdes) throws SMException;
 
 
 
@@ -438,7 +438,7 @@ public interface SMAdapter {
      * @throws SMException
      */
     EncryptedPIN translatePIN(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-                              SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException;
+                              T bdk, T kd2, byte destinationPINBlockFormat) throws SMException;
 
 
     /**
@@ -456,7 +456,7 @@ public interface SMAdapter {
      * @throws SMException
      */
     EncryptedPIN translatePIN(EncryptedPIN pinUnderDuk, KeySerialNumber ksn,
-                              SecureDESKey bdk, SecureDESKey kd2, byte destinationPINBlockFormat, boolean tdes) throws SMException;
+                              T bdk, T kd2, byte destinationPINBlockFormat, boolean tdes) throws SMException;
 
 
 
@@ -470,7 +470,7 @@ public interface SMAdapter {
      * @return pin encrypted under kd2
      * @throws SMException
      */
-    EncryptedPIN exportPIN(EncryptedPIN pinUnderLmk, SecureDESKey kd2, byte destinationPINBlockFormat) throws SMException;
+    EncryptedPIN exportPIN(EncryptedPIN pinUnderLmk, T kd2, byte destinationPINBlockFormat) throws SMException;
 
 
 
@@ -522,8 +522,9 @@ public interface SMAdapter {
      *               in template. null if no solicitation data are passed
      * @throws SMException
      */
-    void printPIN(String accountNo, EncryptedPIN pinUnderKd1, SecureDESKey kd1
+    void printPIN(String accountNo, EncryptedPIN pinUnderKd1, T kd1
       , String template, Map<String, String> fields) throws SMException;
+
 
     /**
      * Calculate PVV (VISA PIN Verification Value of PIN under LMK)
@@ -539,9 +540,8 @@ public interface SMAdapter {
      * @return PVV (VISA PIN Verification Value)
      * @throws SMException if PIN is on exclude list {@link WeakPINException} is thrown
      */
-    String calculatePVV(EncryptedPIN pinUnderLmk, SecureDESKey pvkA,
-                        SecureDESKey pvkB, int pvkIdx) throws SMException;
-
+    String calculatePVV(EncryptedPIN pinUnderLmk, T pvkA, T pvkB, int pvkIdx)
+            throws SMException;
 
 
     /**
@@ -559,10 +559,8 @@ public interface SMAdapter {
      * @return PVV (VISA PIN Verification Value)
      * @throws SMException
      */
-    String calculatePVV(EncryptedPIN pinUnderLmk, SecureDESKey pvkA,
-                        SecureDESKey pvkB, int pvkIdx,
+    String calculatePVV(EncryptedPIN pinUnderLmk, T pvkA, T pvkB, int pvkIdx,
                         List<String> excludes) throws SMException;
-
 
 
     /**
@@ -579,10 +577,8 @@ public interface SMAdapter {
      * @return PVV (VISA PIN Verification Value)
      * @throws SMException
      */
-    String calculatePVV(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                        SecureDESKey pvkA, SecureDESKey pvkB, int pvkIdx)
+    String calculatePVV(EncryptedPIN pinUnderKd1, T kd1, T pvkA, T pvkB, int pvkIdx)
             throws SMException;
-
 
 
     /**
@@ -602,10 +598,8 @@ public interface SMAdapter {
      * @throws WeakPINException if passed PIN is on {@code excludes} list
      * @throws SMException
      */
-    String calculatePVV(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                        SecureDESKey pvkA, SecureDESKey pvkB, int pvkIdx,
+    String calculatePVV(EncryptedPIN pinUnderKd1, T kd1, T pvkA, T pvkB, int pvkIdx,
                         List<String> excludes) throws SMException;
-
 
 
     /**
@@ -623,9 +617,8 @@ public interface SMAdapter {
      * @return true if pin is valid false if not
      * @throws SMException
      */
-    boolean verifyPVV(EncryptedPIN pinUnderKd1, SecureDESKey kd1, SecureDESKey pvkA,
-                      SecureDESKey pvkB, int pvki, String pvv) throws SMException;
-
+    boolean verifyPVV(EncryptedPIN pinUnderKd1, T kd1, T pvkA,
+                      T pvkB, int pvki, String pvv) throws SMException;
 
 
     /**
@@ -646,7 +639,7 @@ public interface SMAdapter {
      * @return IBM PIN Offset
      * @throws SMException
      */
-    String calculateIBMPINOffset(EncryptedPIN pinUnderLmk, SecureDESKey pvk,
+    String calculateIBMPINOffset(EncryptedPIN pinUnderLmk, T pvk,
                                  String decTab, String pinValData,
                                  int minPinLen) throws SMException;
 
@@ -673,7 +666,7 @@ public interface SMAdapter {
      * @throws WeakPINException if passed PIN is on {@code excludes} list
      * @throws SMException
      */
-    String calculateIBMPINOffset(EncryptedPIN pinUnderLmk, SecureDESKey pvk,
+    String calculateIBMPINOffset(EncryptedPIN pinUnderLmk, T pvk,
                                  String decTab, String pinValData, int minPinLen,
                                  List<String> excludes) throws SMException;
 
@@ -698,8 +691,8 @@ public interface SMAdapter {
      * @return IBM PIN Offset
      * @throws SMException
      */
-    String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                                 SecureDESKey pvk, String decTab, String pinValData,
+    String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, T kd1,
+                                 T pvk, String decTab, String pinValData,
                                  int minPinLen) throws SMException;
 
 
@@ -726,8 +719,8 @@ public interface SMAdapter {
      * @throws WeakPINException if passed PIN is on {@code excludes} list
      * @throws SMException
      */
-    String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1,
-                                 SecureDESKey pvk, String decTab, String pinValData,
+    String calculateIBMPINOffset(EncryptedPIN pinUnderKd1, T kd1,
+                                 T pvk, String decTab, String pinValData,
                                  int minPinLen, List<String> excludes) throws SMException;
 
 
@@ -750,7 +743,7 @@ public interface SMAdapter {
      * @return true if pin offset is valid false if not
      * @throws SMException
      */
-    boolean verifyIBMPINOffset(EncryptedPIN pinUnderKd1, SecureDESKey kd1, SecureDESKey pvk,
+    boolean verifyIBMPINOffset(EncryptedPIN pinUnderKd1, T kd1, T pvk,
                                String offset, String decTab, String pinValData,
                                int minPinLen) throws SMException;
 
@@ -778,7 +771,7 @@ public interface SMAdapter {
      * @return           PIN under LMK
      * @throws SMException
      */
-    EncryptedPIN deriveIBMPIN(String accountNo, SecureDESKey pvk
+    EncryptedPIN deriveIBMPIN(String accountNo, T pvk
       , String decTab, String pinValData, int minPinLen
       , String offset) throws SMException;
 
@@ -808,7 +801,7 @@ public interface SMAdapter {
      * solve problem. Use {@link #calculateCVV} with string version of {@code expDate}
      */
     @Deprecated
-    String calculateCVV(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    String calculateCVV(String accountNo, T cvkA, T cvkB,
                         Date expDate, String serviceCode) throws SMException;
 
 
@@ -833,7 +826,7 @@ public interface SMAdapter {
      * @return Card Verification Code/Value
      * @throws SMException
      */
-    String calculateCVV(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    String calculateCVV(String accountNo, T cvkA, T cvkB,
                         String expDate, String serviceCode) throws SMException;
 
 
@@ -858,13 +851,13 @@ public interface SMAdapter {
      *                    the Transaction Status (status) that will be used in
      *                    PARes. A 1 decimal digit value must be supplied.
      * @param sfarc       the Second Factor Authentication Results Code.
-     *                    A value based on the result of second factor authentication. 
+     *                    A value based on the result of second factor authentication.
      *                    A 2 decimal digits value must be suppiled.
      * @return Cardholder Authentication Verification Value/Accountholder
      *         Authentication Value
      * @throws SMException
      */
-    String calculateCAVV(String accountNo, SecureDESKey cvk, String upn,
+    String calculateCAVV(String accountNo, T cvk, String upn,
                          String authrc, String sfarc) throws SMException;
 
     /**
@@ -892,7 +885,7 @@ public interface SMAdapter {
      * solve problem. Use {@link #verifyCVV} with string version of {@code expDate}
      */
     @Deprecated
-    boolean verifyCVV(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    boolean verifyCVV(String accountNo, T cvkA, T cvkB,
                       String cvv, Date expDate, String serviceCode) throws SMException;
 
 
@@ -917,7 +910,7 @@ public interface SMAdapter {
      * @return {@code true} if CVV/CVC is valid or {@code false} otherwise
      * @throws SMException
      */
-    boolean verifyCVV(String accountNo, SecureDESKey cvkA, SecureDESKey cvkB,
+    boolean verifyCVV(String accountNo, T cvkA, T cvkB,
                       String cvv, String expDate, String serviceCode) throws SMException;
 
 
@@ -943,12 +936,12 @@ public interface SMAdapter {
      *                    the Transaction Status (status) that will be used in
      *                    PARes. A 1 decimal digit value must be supplied.
      * @param sfarc       the Second Factor Authentication Results Code.
-     *                    A value based on the result of second factor authentication. 
+     *                    A value based on the result of second factor authentication.
      *                    A 2 decimal digits value must be suppiled.
      * @return true if CAVV/AAV is valid or false if not
      * @throws SMException
      */
-    boolean verifyCAVV(String accountNo, SecureDESKey cvk, String cavv,
+    boolean verifyCAVV(String accountNo, T cvk, String cavv,
                        String upn, String authrc, String sfarc) throws SMException;
 
 
@@ -976,7 +969,7 @@ public interface SMAdapter {
      * @return true if dcvv is valid false if not
      * @throws SMException
      */
-    boolean verifydCVV(String accountNo, SecureDESKey imkac, String dcvv,
+    boolean verifydCVV(String accountNo, T imkac, String dcvv,
                        Date expDate, String serviceCode, byte[] atc, MKDMethod mkdm)
                      throws SMException;
 
@@ -1025,7 +1018,7 @@ public interface SMAdapter {
      * @return true if cvc3 is valid false if not
      * @throws SMException
      */
-    boolean verifyCVC3(SecureDESKey imkcvc3, String accountNo, String acctSeqNo,
+    boolean verifyCVC3(T imkcvc3, String accountNo, String acctSeqNo,
                        byte[] atc, byte[] upn, byte[] data, MKDMethod mkdm, String cvc3)
                      throws SMException;
 
@@ -1053,7 +1046,7 @@ public interface SMAdapter {
      * @param upn unpredictable number. This is used for Session Key Generation
      *        A 4 byte value must be supplied. For {@code skdm} equals
      *        {@link SKDMethod#VSDC} is not used.
-     * @param transData transaction data. Transaction data elements and them
+     * @param txnData transaction data. Transaction data elements and them
      *        order is dependend to proper cryptogram version. If the data
      *        supplied is a multiple of 8 bytes, no extra padding is added.
      *        If it is not a multiple of 8 bytes, additional zero padding is added.
@@ -1062,9 +1055,9 @@ public interface SMAdapter {
      * @return true if ARQC/TC/AAC is passed or false if not
      * @throws SMException
      */
-    boolean verifyARQC(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
+    boolean verifyARQC(MKDMethod mkdm, SKDMethod skdm, T imkac
       , String accountNo, String acctSeqNo, byte[] arqc, byte[] atc
-      , byte[] upn, byte[] transData) throws SMException;
+      , byte[] upn, byte[] txnData) throws SMException;
 
 
 
@@ -1100,7 +1093,7 @@ public interface SMAdapter {
      *        {@link ARPCMethod#METHOD_2} 4 bytes ARPC
      * @throws SMException
      */
-    byte[] generateARPC(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
+    byte[] generateARPC(MKDMethod mkdm, SKDMethod skdm, T imkac
       , String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
       , ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
             throws SMException;
@@ -1129,7 +1122,7 @@ public interface SMAdapter {
      * @param upn unpredictable number. This is used for Session Key Generation
      *        A 4 byte value must be supplied. For {@code skdm} equals
      *        {@link SKDMethod#VSDC} is not used.
-     * @param transData transaction data. Transaction data elements and them
+     * @param txnData transaction data. Transaction data elements and them
      *        order is dependend to proper cryptogram version. If the data
      *        supplied is a multiple of 8 bytes, no extra padding is added.
      *        If it is not a multiple of 8 bytes, additional zero padding is added.
@@ -1139,7 +1132,7 @@ public interface SMAdapter {
      *        {@link SKDMethod#VSDC}, {@link SKDMethod#MCHIP},
      *        {@link SKDMethod#AEPIS_V40} only {@link ARPCMethod#METHOD_1} is valid
      * @param arc the Authorisation Response Code. A 2 byte value must be supplied.
-     *        For {@code arpcMethod} equals {@link ARPCMethod#METHOD_2} it is 
+     *        For {@code arpcMethod} equals {@link ARPCMethod#METHOD_2} it is
      *        csu - Card Status Update. Then a 4 byte value must be supplied.
      * @param propAuthData Proprietary Authentication Data. Up to 8 bytes.
      *        Contains optional issuer data for transmission to the card in
@@ -1151,9 +1144,9 @@ public interface SMAdapter {
      *         4 bytes ARPC, null in other case
      * @throws SMException
      */
-    byte[] verifyARQCGenerateARPC(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
+    byte[] verifyARQCGenerateARPC(MKDMethod mkdm, SKDMethod skdm, T imkac
       , String accountNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
-      , byte[] transData, ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
+      , byte[] txnData, ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
             throws SMException;
 
 
@@ -1185,7 +1178,7 @@ public interface SMAdapter {
      * @throws SMException
      */
     byte[] generateSM_MAC(MKDMethod mkdm, SKDMethod skdm
-      , SecureDESKey imksmi, String accountNo, String acctSeqNo
+      , T imksmi, String accountNo, String acctSeqNo
       , byte[] atc, byte[] arqc, byte[] data) throws SMException;
 
 
@@ -1253,10 +1246,10 @@ public interface SMAdapter {
      * @throws SMException
      */
     Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MAC(MKDMethod mkdm
-      , SKDMethod skdm, PaddingMethod padm, SecureDESKey imksmi
+      , SKDMethod skdm, PaddingMethod padm, T imksmi
       , String accountNo, String acctSeqNo, byte[] atc, byte[] arqc
       , byte[] data, EncryptedPIN currentPIN, EncryptedPIN newPIN
-      , SecureDESKey kd1, SecureDESKey imksmc, SecureDESKey imkac
+      , T kd1, T imksmc, T imkac
       , byte destinationPINBlockFormat) throws SMException;
 
 
@@ -1307,7 +1300,7 @@ public interface SMAdapter {
      * @return the MAC
      * @throws SMException
      */
-    byte[] generateCBC_MAC(byte[] data, SecureDESKey kd) throws SMException;
+    byte[] generateCBC_MAC(byte[] data, T kd) throws SMException;
 
     /**
      * Generates EDE-MAC (Encrypt Decrypt Encrypt Message Message Authentication Code)
@@ -1318,7 +1311,7 @@ public interface SMAdapter {
      * @return the MAC
      * @throws SMException
      */
-    byte[] generateEDE_MAC(byte[] data, SecureDESKey kd) throws SMException;
+    byte[] generateEDE_MAC(byte[] data, T kd) throws SMException;
 
     /**
      * Translate key from encryption under the LMK held in key change storage
@@ -1425,7 +1418,7 @@ public interface SMAdapter {
      * @param clearText clear Text
      * @return cyphertext
      */
-    byte[] dataEncrypt (SecureDESKey bdk, byte[] clearText) throws SMException;
+    byte[] dataEncrypt(T bdk, byte[] clearText) throws SMException;
 
     /**
      * Decrypt Data
@@ -1433,7 +1426,7 @@ public interface SMAdapter {
      * @param cypherText clear Text
      * @return cleartext
      */
-    byte[] dataDecrypt (SecureDESKey bdk, byte[] cypherText) throws SMException;
+    byte[] dataDecrypt(T bdk, byte[] cypherText) throws SMException;
 
     /**
      * Forms a key from 3 clear components and returns it encrypted under its corresponding LMK
@@ -1444,14 +1437,16 @@ public interface SMAdapter {
      * @return forms an SecureDESKey from two clear components
      * @throws SMException
      */
-    SecureDESKey formKEYfromClearComponents (short keyLength, String keyType, String... clearComponent) throws SMException;
+    SecureDESKey formKEYfromClearComponents(short keyLength, String keyType, String... clearComponent) throws SMException;
+
     /**
      * Generates a random clear key component.
      * @param keyLength
      * @return clear key componenet
      * @throws SMException
      */
-    default String generateClearKeyComponent (short keyLength) throws SMException{
+    default String generateClearKeyComponent(short keyLength) throws SMException {
         throw new SMException("Operation not supported in: " + this.getClass().getName());
     }
+
 }

--- a/jpos/src/main/java/org/jpos/security/SecureKeyBlock.java
+++ b/jpos/src/main/java/org/jpos/security/SecureKeyBlock.java
@@ -1,0 +1,296 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.jpos.iso.ISOUtil;
+
+/**
+ * The class represents a secure key in key block form (TR-31 or derivatives).
+ * <p>
+ * In addition to standard Key Chcek Value and Key Schema, specifies the key
+ * block header, optional key block header, encrypted key and key block MAC.
+ * <p>
+ * The {@code SecureKeyBlock} instance can come from HSM <i>(generate, import,
+ * translate)</i> or from the key store. And this is an integral whole.
+ * Therefore, manipulation of key block values is not desirable. This is the
+ * reason why the key block setters methods are not available. Use the
+ * {@code SecureKeyBlockBuilder} to create the key block structure.
+ */
+public class SecureKeyBlock extends SecureKey {
+
+    /**
+     * Identifies the method by which the key block is cryptographically
+     * protected and the content layout of the block.
+     */
+    protected char keyBlockVersion = ' ';
+
+    /**
+     * Entire key block length after encoding (header, optional header,
+     * encrypted confidential data, and MAC).
+     */
+    protected int keyBlockLength;
+
+    /**
+     * The primary usage of the key contained in the key block.
+     */
+    protected KeyUsage keyUsage;
+
+    /**
+     * The cryptographic algorithm with which the key contained in key block
+     * will be used.
+     */
+    protected Algorithm algorithm = Algorithm.TDES;
+
+    /**
+     * The operation that the key contained in the key block can perform.
+     */
+    protected ModeOfUse modeOfUse = ModeOfUse.ANY;
+
+    /**
+     * Version number to optionally indicate that the contents of the key block
+     * is a component (key part), or to prevent re-injection of an old key.
+     */
+    protected String keyVersion = "  ";
+
+    /**
+     * The conditions under which the key can be exported outside the
+     * cryptographic domain.
+     */
+    protected Exportability exportability = Exportability.ANY;
+
+    /**
+     * This element is not specified by TR-31 (should contain two ASCII zeros).
+     * <p>
+     * In proprietary derivatives can be used as e.g: LMK identifier.
+     */
+    protected String reserved = "00";
+
+    /**
+     * The TR-31 Key Block format allows a key block to contain up to 99
+     * Optional Header Blocks which can be used to include additional (optional)
+     * data within the Key Block.
+     */
+    protected Map<String, String> optionalHeaders = new LinkedHashMap<>();
+
+    /**
+     * The key block MAC ensures the integrity of the key block, and is
+     * calculated over the Header, Optional Header Blocks and the encrypted Key
+     * Data.
+     */
+    protected byte[] keyBlockMAC;
+
+    /**
+     * Constructs an SecureKeyBlock.
+     * <p>
+     * It can be used internally by e.g: {@code SecureKeyBlockBuilder}.
+     */
+    protected SecureKeyBlock() {
+        super();
+    }
+
+    @Override
+    public void setKeyType(String keyType) {
+        throw new UnsupportedOperationException(
+            "Operation setKeyType() not allowed for " + SecureKeyBlock.class.getName()
+        );
+    }
+
+    @Override
+    public String getKeyType() {
+        throw new UnsupportedOperationException(
+            "Operation getKeyType() not allowed for " + SecureKeyBlock.class.getName()
+        );
+    }
+
+    @Override
+    public void setKeyLength(short keyLength) {
+        throw new UnsupportedOperationException(
+            "Operation setKeyLength() not allowed for " + SecureKeyBlock.class.getName()
+        );
+    }
+
+    @Override
+    public short getKeyLength() {
+        throw new UnsupportedOperationException(
+            "Operation getKeyLength() not allowed for " + SecureKeyBlock.class.getName()
+        );
+    }
+
+    @Override
+    public KeyScheme getScheme() {
+        return scheme;
+    }
+
+    /**
+     * Identifies the method by which the key block is cryptographically
+     * protected and the content layout of the block.
+     *
+     * @return The key block version that corresponds to byte 0 of the key block.
+     */
+    public char getKeyBlockVersion() {
+        return keyBlockVersion;
+    }
+
+    /**
+     * Entire key block length after encoding (header, optional header,
+     * encrypted confidential data, and MAC).
+     *
+     * @return The key block length that corresponds to bytes 1-4 of the key block.
+     */
+    public int getKeyBlockLength() {
+        return keyBlockLength;
+    }
+
+    /**
+     * The primary usage of the key contained in the key block.
+     *
+     * @return The key usage that corresponds to bytes 5-6 of the key block.
+     */
+    public KeyUsage getKeyUsage() {
+        return keyUsage;
+    }
+
+    /**
+     * The cryptographic algorithm with which the key contained in key block
+     * will be used.
+     *
+     * @return The key algorithm that corresponds to byte 7 of the key block.
+     */
+    public Algorithm getAlgorithm() {
+        return algorithm;
+    }
+
+    /**
+     * The operation that the key contained in the key block can perform.
+     *
+     * @return The mode of use that corresponds to byte 8 of the key block.
+     */
+    public ModeOfUse getModeOfUse() {
+        return modeOfUse;
+    }
+
+    /**
+     * Version number to optionally indicate that the contents of the key block
+     * is a component (key part), or to prevent re-injection of an old key.
+     *
+     * @return The key version that corresponds to bytes 9-10 of the key block.
+     */
+    public String getKeyVersion() {
+        return keyVersion;
+    }
+
+    /**
+     * The conditions under which the key can be exported outside the
+     * cryptographic domain.
+     *
+     * @return The key exportability that corresponds to byte 11 of the key block.
+     */
+    public Exportability getExportability() {
+        return exportability;
+    }
+
+    /**
+     * This element is not specified by TR-31 (should contain two ASCII zeros).
+     * <p>
+     * In proprietary derivatives can be used as e.g: LMK identifier.
+     *
+     * @return The reserved that corresponds to bytes 14-15 of the key block.
+     */
+    public String getReserved() {
+        return reserved;
+    }
+
+    /**
+     * The key blok Optional Header Blocks.
+     * <p>
+     * The number of optional heders corresponds to bytes 12-13 of the key block.
+     * <p>
+     * The order of the elements in the map is preserved by {@code LinkedHashMap}
+     *
+     * @return Read only map of Optional Key Blok Heders.
+     */
+    public Map<String, String> getOptionalHeaders() {
+        return Collections.unmodifiableMap(optionalHeaders);
+    }
+
+    /**
+     * The key block MAC ensures the integrity of the key block.
+     * <p>
+     * It is calculated over the Header, Optional Header Blocks and the
+     * encrypted Key Data.
+     * The length of the MAC depends on the type of LMK key:
+     * <ul>
+     *   <li>4 bytes for DES Key Block LMK
+     *   <li>8 bytes for AES Key Block LMK
+     * </ul>
+     *
+     * @return calculated key block MAC value.
+     */
+    public byte[] getKeyBlockMAC() {
+        return keyBlockMAC;
+    }
+
+    /**
+     * Dumps SecureKeyBlock basic information
+     *
+     * @param p a PrintStream usually supplied by Logger
+     * @param indent indention string, usually suppiled by Logger
+     * @see org.jpos.util.Loggeable
+     */
+    @Override
+    public void dump(PrintStream p, String indent) {
+        String inner = indent + "  ";
+        String inner2 = inner + "  ";
+        p.print(indent + "<secure-key-block");
+        p.print(" scheme=\"" + scheme + "\"");
+        if (keyName != null)
+            p.print(" name=\"" + keyName + "\"");
+
+        p.println(">");
+
+        p.println(inner + "<header>");
+        p.println(inner2 + "<version>" + keyBlockVersion + "</version>");
+        p.println(inner2 + "<key-usage>" + keyUsage.getCode() + "</key-usage>");
+        p.println(inner2 + "<algorithm>" + algorithm.getCode() + "</algorithm>");
+        p.println(inner2 + "<mode-of-use>" + modeOfUse.getCode() + "</mode-of-use>");
+        p.println(inner2 + "<key-version>" + keyVersion + "</key-version>");
+        p.println(inner2 + "<exportability>" + exportability.getCode() + "</exportability>");
+        if (reserved != null && !"00".equals(reserved))
+            p.println(inner2 + "<reserved>" + reserved + "</reserved>");
+        p.println(inner + "</header>");
+
+        if (!optionalHeaders.isEmpty()) {
+            p.println(inner + "<optional-header>");
+            for (Entry<String, String> ent : optionalHeaders.entrySet())
+                p.println(inner2 + "<entry id=\""+ ent.getKey() + "\" value=\""+ ent.getValue()+ "\"/>");
+            p.println(inner + "</optional-header>");
+        }
+
+        p.println(inner + "<data>" + ISOUtil.hexString(getKeyBytes()) + "</data>");
+        p.println(inner + "<mac>" + ISOUtil.hexString(getKeyBlockMAC()) + "</mac>");
+        p.println(inner + "<check-value>" + ISOUtil.hexString(getKeyCheckValue()) + "</check-value>");
+        p.println(indent + "</secure-key-block>");
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/security/SecureKeyBlockBuilder.java
+++ b/jpos/src/main/java/org/jpos/security/SecureKeyBlockBuilder.java
@@ -1,0 +1,219 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.function.ToIntFunction;
+import org.jpos.iso.ISOUtil;
+
+/**
+ * The builder class to create and parse key block structure.
+ */
+public class SecureKeyBlockBuilder {
+
+    protected static final int SIZE_KEYBLOCK_VERSION    = 1;
+
+    protected static final int SIZE_KEYBLOCK_LENGTH     = 4;
+
+    protected static final int SIZE_KEYUSAGE            = 2;
+
+    protected static final int SIZE_KEY_VERSION         = 2;
+
+    protected static final int SIZE_NUMOFOPTHDR         = 2;
+
+    protected static final int SIZE_RESERVED            = 2;
+
+    protected static final int SIZE_HEADER              = 16;
+
+    protected static final int SIZE_OPTHDR_ID           = 2;
+
+    protected static final int SIZE_OPTHDR_LENGTH       = 2;
+
+    protected static final int SIZE_HEADER_3DES         = 4;
+
+    protected static final int SIZE_HEADER_AES          = 8;
+
+    private final List<Character> versionsWith4CharacterMAC = Arrays.asList(
+         'A' // TR-31:2005 'A' Key block protected using the Key Variant Binding Method
+        ,'B' // TR-31:2010 'B' Key block protected using the Key Derivation Binding Method
+        ,'C' // TR-31:1010 'C' Key block protected using the Key Variant Binding Method
+        ,'0' // Proprietary '0' Key block protected using the 3-DES key
+    );
+
+    /**
+     * Don't let anyone instantiate this class.
+     */
+    private SecureKeyBlockBuilder() {
+    }
+
+    public static SecureKeyBlockBuilder newBuilder() {
+        return new SecureKeyBlockBuilder();
+    }
+
+    /**
+     * Configure key block versions with 4 digits key block MAC.
+     * <p>
+     * Default 4 digits key block MAC versions are:
+     * <ul>
+     *   <li>'A' TR-31:2005 Key block protected using the Key Variant Binding Method
+     *   <li>'B' TR-31:2010 Key block protected using the Key Derivation Binding Method
+     *   <li>'C' TR-31:2010 Key block protected using the Key Variant Binding Method
+     *   <li>'0' Proprietary Key block protected using the 3-DES key
+     * </ul>
+     * @param versions the string with versions characters
+     * @return This builder instance
+     */
+    public SecureKeyBlockBuilder with4characterMACVersions(String versions) {
+        Objects.requireNonNull(versions, "The versions with 4 digits MAC cannot be null");
+        versionsWith4CharacterMAC.clear();
+        for (Character ch : versions.toCharArray())
+            versionsWith4CharacterMAC.add(ch);
+
+        return this;
+    }
+
+    protected int getMACLength(SecureKeyBlock skb) {
+        if (versionsWith4CharacterMAC.contains(skb.getKeyBlockVersion()))
+            return SIZE_HEADER_3DES;
+
+        return SIZE_HEADER_AES;
+    }
+
+
+    protected static String readString(StringReader sr, int len) {
+        char[] chars = new char[len];
+        try {
+            sr.read(chars);
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Problem witch reading key block characters", ex);
+        }
+        return String.valueOf(chars);
+    }
+
+    protected static char readChar(StringReader sr) {
+        try {
+            return (char) sr.read();
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Problem witch reading key block character", ex);
+        }
+    }
+
+    protected static Map<String, String> parseOptionalHeader(StringReader sr, int numOfBlocks) {
+        Map<String, String> ret = new LinkedHashMap<>();
+        int cnt = numOfBlocks;
+        String hbi;
+        int len;
+        String hdata;
+        while (cnt-- > 0) {
+            hbi = readString(sr, SIZE_OPTHDR_ID);
+            len = Integer.valueOf(readString(sr, SIZE_OPTHDR_LENGTH), 0x10);
+            hdata = readString(sr, len - SIZE_OPTHDR_ID - SIZE_OPTHDR_LENGTH);
+            ret.put(hbi, hdata);
+        }
+        return ret;
+    }
+
+    protected static int calcOptionalHeaderLength(Map<String, String> optHdrs) {
+        ToIntFunction<String> entryLength = e -> {
+                int l = SIZE_OPTHDR_ID + SIZE_OPTHDR_LENGTH;
+                if (e != null)
+                    l += e.length();
+
+                return l;
+        };
+        Collection<String> c = optHdrs.values();
+        return c.stream().mapToInt(entryLength).sum();
+    }
+
+    public SecureKeyBlock build(CharSequence data) throws IllegalArgumentException {
+        Objects.requireNonNull(data, "The key block data cannot be null");
+        SecureKeyBlock skb = new SecureKeyBlock();
+        String keyblock = data.toString();
+        if (keyblock.length() < SIZE_HEADER)
+            throw new IllegalArgumentException("The key block data cannot be shorter than 16");
+
+        StringReader sr = new StringReader(data.toString());
+        skb.keyBlockVersion = readChar(sr);
+        skb.keyBlockLength = Integer.valueOf(readString(sr, SIZE_KEYBLOCK_LENGTH));
+        String ku = readString(sr, SIZE_KEYUSAGE);
+        skb.keyUsage = ExtKeyUsage.valueOfByCode(ku);
+        skb.algorithm = Algorithm.valueOfByCode(readChar(sr));
+        skb.modeOfUse = ModeOfUse.valueOfByCode(readChar(sr));
+        skb.keyVersion = readString(sr, SIZE_KEY_VERSION);
+        skb.exportability = Exportability.valueOfByCode(readChar(sr));
+        int numOfBlocks = Integer.valueOf(readString(sr, SIZE_NUMOFOPTHDR));
+        skb.reserved = readString(sr, SIZE_RESERVED);
+        skb.optionalHeaders = parseOptionalHeader(sr, numOfBlocks);
+        int consumed = SIZE_HEADER + calcOptionalHeaderLength(skb.getOptionalHeaders());
+
+        if (skb.getKeyBlockLength() <= consumed)
+            // it can be but it should not occur
+            return skb;
+
+        int remain = skb.getKeyBlockLength() - consumed;
+        int macLen = getMACLength(skb);
+        String keyEnc = readString(sr, remain - macLen);
+        if (!keyEnc.isEmpty())
+            skb.setKeyBytes(ISOUtil.hex2byte(keyEnc));
+
+        String mac = readString(sr, macLen);
+        skb.keyBlockMAC = ISOUtil.hex2byte(mac);
+        return skb;
+    }
+
+    public String toKeyBlock(SecureKeyBlock skb) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(skb.getKeyBlockVersion());
+        sb.append(String.format("%04d", skb.getKeyBlockLength()));
+        sb.append(skb.getKeyUsage().getCode());
+        sb.append(skb.getAlgorithm().getCode());
+        sb.append(skb.getModeOfUse().getCode());
+        sb.append(skb.getKeyVersion());
+        sb.append(skb.getExportability().getCode());
+
+        Map<String, String> optHdr = skb.getOptionalHeaders();
+        sb.append(String.format("%02d", optHdr.size()));
+        sb.append(skb.getReserved());
+
+        for (Entry<String, String> ent : optHdr.entrySet()) {
+            sb.append(ent.getKey());
+            sb.append(String.format("%02X", ent.getValue().length() + SIZE_OPTHDR_ID + SIZE_OPTHDR_LENGTH));
+            sb.append(ent.getValue());
+        }
+
+        byte[] b = skb.getKeyBytes();
+        if (b != null)
+            sb.append(ISOUtil.hexString(b));
+
+        b = skb.getKeyBlockMAC();
+        if (b != null)
+            sb.append(ISOUtil.hexString(skb.getKeyBlockMAC()));
+
+        return sb.toString();
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/security/SecureKeySpec.java
+++ b/jpos/src/main/java/org/jpos/security/SecureKeySpec.java
@@ -1,0 +1,527 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package  org.jpos.security;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import org.jpos.util.Loggeable;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.jpos.iso.ISOUtil;
+
+/**
+ * This class contains a set of desirable key properties that can be passed to
+ * an HSM device for example to generate a key or import it.
+ * <p>
+ * This class is not intended to use for key storage. It can contain
+ * confidentional data like key length. That is why they should not be kept
+ * persistently anywhere.
+ *
+ * @author Robert Demski
+ */
+public class SecureKeySpec
+        implements Serializable, Loggeable {
+
+    private static final long serialVersionUID = -3145281298749096305L;
+
+    /**
+     * Key scheme indicates protection metchod appiled to this key by
+     * a security module.
+     */
+    protected KeyScheme scheme;
+
+    /**
+     * The key length is expressed in bits and refers to clear key <i>(before
+     * LMK protection)</i>.
+     */
+    protected int keyLength;
+
+    /**
+     * Key Type is useful for stating what this key can be used for.
+     * <p>
+     * The value of Key Type specifies whether this encryped key is a
+     * <ul>
+     *   <li>{@link SMAdapter#TYPE_TMK} Terminal Master Key
+     *   <li>{@link SMAdapter#TYPE_ZPK} Zone PIN Key
+     *   <li>or others
+     * </ul>
+     */
+    protected String keyType;
+
+    /**
+     * Indicates key protection variant metchod appiled to this key by a security module.
+     */
+    protected int variant;
+
+    /**
+     * Secure Key Bytes.
+     */
+    protected byte[] keyBytes = null;
+
+    /**
+     * The keyCheckValue allows identifying which clear key does this
+     * secure key represent.
+     */
+    protected byte[] keyCheckValue;
+
+    /**
+     * Identifies the method by which the key block is cryptographically
+     * protected and the content layout of the block.
+     */
+    protected char keyBlockVersion;
+
+    /**
+     * The primary usage of the key contained in the key block.
+     */
+    protected KeyUsage keyUsage;
+
+    /**
+     * The cryptographic algorithm with which the key contained in key block
+     * will be used.
+     */
+    protected Algorithm algorithm;
+
+    /**
+     * The operation that the key contained in the key block can perform.
+     */
+    protected ModeOfUse modeOfUse;
+
+    /**
+     * Version number to optionally indicate that the contents of the key block
+     * is a component (key part), or to prevent re-injection of an old key.
+     */
+    protected String keyVersion;
+
+    /**
+     * The conditions under which the key can be exported outside the
+     * cryptographic domain.
+     */
+    protected Exportability exportability;
+
+    /**
+     * This element is not specified by TR-31 (should contain two ASCII zeros).
+     * <p>
+     * In proprietary derivatives can be used as e.g: LMK identifier.
+     */
+    protected String reserved;
+
+    /**
+     * The TR-31 Key Block format allows a key block to contain up to 99
+     * Optional Header Blocks which can be used to include additional (optional)
+     * data within the Key Block.
+     */
+    protected final Map<String, String> optionalHeaders = new LinkedHashMap<>();
+
+    /**
+     * The key block MAC ensures the integrity of the key block, and is
+     * calculated over the Header, Optional Header Blocks and the encrypted Key
+     * Data.
+     */
+    protected byte[] keyBlockMAC;
+
+    /**
+     * Optional key name.
+     */
+    protected String keyName;
+
+    public SecureKeySpec() {
+        super();
+    }
+
+    /**
+     * Key scheme indicates protection metchod appiled to this key by
+     * the security module.
+     *
+     * @param scheme key scheme used to protect this key.
+     */
+    public void setScheme(KeyScheme scheme) {
+        this.scheme = scheme;
+    }
+
+    /**
+     * Gets the key scheme used to protect this key.
+     *
+     * @return key scheme used to protect this key.
+     */
+    public KeyScheme getScheme() {
+        return scheme;
+    }
+
+    /**
+     * Sets the length of the key.
+     * <p>
+     * The key length is expressed in bits and refers to clear key <i>(before
+     * LMK protection)</i>
+     * This might be different than the bit length of the secureKeyBytes.
+     *
+     * @param keyLength
+     */
+    public void setKeyLength(int keyLength) {
+        this.keyLength = keyLength;
+    }
+
+    /**
+     * Gets the length of the key.
+     * <p>
+     * The key length is expressed in bits and refers to clear key <i>(before
+     * LMK protection)</i>
+     *
+     * @return The length of the clear key
+     */
+    public int getKeyLength() {
+        return keyLength;
+    }
+
+    /**
+     * Key Type is useful for stating what this key can be used for.
+     * <p>
+     * The value of Key Type specifies whether this secure key is a
+     * <ul>
+     *   <li>{@link SMAdapter#TYPE_TMK} Terminal Master Key
+     *   <li>{@link SMAdapter#TYPE_ZPK} Zone PIN Key
+     *   <li>or others
+     * </ul>
+     *
+     * @param keyType type of the key
+     */
+    public void setKeyType(String keyType) {
+        this.keyType = keyType;
+    }
+
+    /**
+     * Key Type is useful for stating what this key can be used for.
+     * <p>
+     * The value of Key Type specifies whether this secure key is a
+     * <ul>
+     *   <li>{@link SMAdapter#TYPE_TMK} Terminal Master Key
+     *   <li>{@link SMAdapter#TYPE_ZPK} Zone PIN Key
+     *   <li>or others
+     * </ul>
+     *
+     * @return keyType type of the key
+     */
+    public String getKeyType() {
+        return this.keyType;
+    }
+
+    /**
+     * Sets key protection variant metchod appiled to this key by the security module.
+     *
+     * @param variant key variant method used to protect this key.
+     */
+    public void setVariant(int variant) {
+        this.variant = variant;
+    }
+
+    /**
+     * Gets the key variant method used to protect this key.
+     *
+     * @return key variant method used to protect this key.
+     */
+    public int getVariant() {
+        return this.variant;
+    }
+
+    /**
+     * Identifies the method by which the key block is cryptographically
+     * protected and the content layout of the block.
+     *
+     * @return The key block version that corresponds to byte 0 of the key block.
+     */
+    public char getKeyBlockVersion() {
+        return keyBlockVersion;
+    }
+
+    public void setKeyBlockVersion(char keyBlockVersion) {
+        this.keyBlockVersion = keyBlockVersion;
+    }
+
+    /**
+     * The primary usage of the key contained in the key block.
+     *
+     * @return The key usage that corresponds to bytes 5-6 of the key block.
+     */
+    public KeyUsage getKeyUsage() {
+        return keyUsage;
+    }
+
+    public void setKeyUsage(KeyUsage keyUsage) {
+        this.keyUsage = keyUsage;
+    }
+
+    /**
+     * The cryptographic algorithm with which the key contained in key block
+     * will be used.
+     *
+     * @return The key algorithm that corresponds to byte 7 of the key block.
+     */
+    public Algorithm getAlgorithm() {
+        return algorithm;
+    }
+
+    public void setAlgorithm(Algorithm algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    /**
+     * The operation that the key contained in the key block can perform.
+     *
+     * @return The mode of use that corresponds to byte 8 of the key block.
+     */
+    public ModeOfUse getModeOfUse() {
+        return modeOfUse;
+    }
+
+    public void setModeOfUse(ModeOfUse modeOfUse) {
+        this.modeOfUse = modeOfUse;
+    }
+
+    /**
+     * Version number to optionally indicate that the contents of the key block
+     * is a component (key part), or to prevent re-injection of an old key.
+     *
+     * @return The key version that corresponds to bytes 9-10 of the key block.
+     */
+    public String getKeyVersion() {
+        return keyVersion;
+    }
+
+    public void setKeyVersion(String keyVersion) {
+        this.keyVersion = keyVersion;
+    }
+
+    /**
+     * The conditions under which the key can be exported outside the
+     * cryptographic domain.
+     *
+     * @return The key exportability that corresponds to byte 11 of the key block.
+     */
+    public Exportability getExportability() {
+        return exportability;
+    }
+
+    public void setExportability(Exportability exportability) {
+        this.exportability = exportability;
+    }
+
+    /**
+     * This element is not specified by TR-31 (should contain two ASCII zeros).
+     * <p>
+     * In proprietary derivatives can be used as e.g: LMK identifier.
+     *
+     * @return The reserved that corresponds to bytes 14-15 of the key block.
+     */
+    public String getReserved() {
+        return reserved;
+    }
+
+    public void setReserved(String reserved) {
+        this.reserved = reserved;
+    }
+
+    /**
+     * The key blok Optional Header Blocks.
+     * <p>
+     * The number of optional heders corresponds to bytes 12-13 of the key block.
+     * <p>
+     * The order of the elements in the map is preserved by {@code LinkedHashMap}
+     *
+     * @return map of Optional Key Blok Heders.
+     */
+    public Map<String, String> getOptionalHeaders() {
+        return optionalHeaders;
+    }
+
+    /**
+     * The key block MAC ensures the integrity of the key block.
+     * <p>
+     * It is calculated over the Header, Optional Header Blocks and the
+     * encrypted Key Data.
+     * The length of the MAC depends on the type of LMK key:
+     * <ul>
+     *   <li>4 bytes for DES Key Block LMK
+     *   <li>8 bytes for AES Key Block LMK
+     * </ul>
+     *
+     * @return calculated key block MAC value.
+     */
+    public byte[] getKeyBlockMAC() {
+        return keyBlockMAC;
+    }
+
+    public void setKeyBlockMAC(byte[] keyBlockMAC) {
+        this.keyBlockMAC = keyBlockMAC;
+    }
+
+    /**
+     * Sets the secure key bytes.
+     *
+     * @param keyBytes bytes representing the secured key
+     */
+    public void setKeyBytes(byte[] keyBytes) {
+        this.keyBytes = keyBytes;
+    }
+
+    /**
+     * @return The bytes representing the secured key
+     */
+    public byte[] getKeyBytes() {
+        return keyBytes;
+    }
+
+    /**
+     * The Key Check Value is typically a 24-bits (3 bytes) formed by encrypting a
+     * block of zeros under the secure key when the secure key is clear.
+     * <p>
+     * This check value allows identifying if two secure keys map to the
+     * same clear key.
+     *
+     * @param keyCheckValue the Key Check Value
+     */
+    public void setKeyCheckValue(byte[] keyCheckValue) {
+        this.keyCheckValue = keyCheckValue;
+    }
+
+    /**
+     * The Key Check Value is typically a 24-bits (3 bytes) formed by encrypting
+     * a block of zeros under the secure key when the secure key is clear.
+     *
+     * @return the Key Check Value
+     */
+    public byte[] getKeyCheckValue() {
+        return keyCheckValue;
+    }
+
+    /**
+     * Gets optional key name.
+     *
+     * @return name of the key
+     */
+    public String getKeyName() {
+        return this.keyName;
+    }
+
+    /**
+     * Sets optional key name.
+     *
+     * @param keyName name of the key
+     */
+    public void setKeyName(String keyName) {
+        this.keyName = keyName;
+    }
+
+    /**
+     * Dumps SecureKeySpec information.
+     *
+     * @param p a print stream usually supplied by Logger
+     * @param indent indention string, usually suppiled by Logger
+     * @see org.jpos.util.Loggeable
+     */
+    @Override
+    public void dump(PrintStream p, String indent) {
+        String inner = indent + "  ";
+        p.print(indent + "<secure-key-spec");
+
+        if (scheme != null)
+            p.print(" scheme=\"" + scheme + "\"");
+
+        if (keyName != null)
+            p.print(" name=\"" + keyName + "\"");
+
+        p.println(">");
+
+        if (getKeyLength() > 0)
+            p.println(inner + "<length>" + getKeyLength() + "</length>");
+
+        if (getKeyType() != null) {
+            p.println(inner + "<type>" + getKeyType() + "</type>");
+            p.println(inner + "<variant>" + getVariant() + "</variant>");
+        }
+
+        String keyblok = formKeyHeader(inner);
+        if (keyblok != null) {
+            p.println(inner + "<header>");
+            p.print(keyblok);
+            p.println(inner + "</header>");
+        }
+
+        if (!optionalHeaders.isEmpty()) {
+            p.println(inner + "<optional-header>");
+            String inner2 = inner + "  ";
+            for (Entry<String, String> ent : optionalHeaders.entrySet())
+                p.println(inner2 + "<entry id=\""+ ent.getKey() + "\" value=\""+ ent.getValue()+ "\"/>");
+            p.println(inner + "</optional-header>");
+        }
+
+        if (getKeyBytes() != null)
+            p.println(inner + "<data>" + ISOUtil.hexString(getKeyBytes()) + "</data>");
+
+        if (getKeyBlockMAC() != null)
+            p.println(inner + "<mac>" + ISOUtil.hexString(getKeyBlockMAC()) + "</mac>");
+
+        if (getKeyCheckValue() != null)
+            p.println(inner + "<check-value>" + ISOUtil.hexString(getKeyCheckValue()) + "</check-value>");
+
+        p.println(indent + "</secure-key-spec>");
+    }
+
+    protected String formKeyHeader(String indent) {
+        String inner = indent + "  ";
+        try (
+                ByteArrayOutputStream os = new ByteArrayOutputStream();
+                PrintStream p = new PrintStream(os);
+        ) {
+            if (keyBlockVersion != 0)
+                p.println(inner + "<version>" + keyBlockVersion + "</version>");
+
+            if (keyUsage != null)
+                p.println(inner + "<key-usage>" + keyUsage.getCode() + "</key-usage>");
+
+            if (algorithm != null)
+                p.println(inner + "<algorithm>" + algorithm.getCode() + "</algorithm>");
+
+            if (modeOfUse != null)
+                p.println(inner + "<mode-of-use>" + modeOfUse.getCode() + "</mode-of-use>");
+
+            if (keyVersion != null)
+                p.println(inner + "<key-version>" + keyVersion + "</key-version>");
+
+            if (exportability != null)
+                p.println(inner + "<exportability>" + exportability.getCode() + "</exportability>");
+
+            if (reserved != null)
+                p.println(inner + "<reserved>" + reserved + "</reserved>");
+
+            String ret = os.toString();
+            if (ret.isEmpty())
+                return null;
+
+            return ret;
+        } catch (IOException ex) {
+            // for close(), it should never happens
+            return null;
+        }
+    }
+
+}
+

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -65,7 +65,7 @@ import javax.crypto.Cipher;
  * @version $Revision$ $Date$
  */
 @SuppressWarnings("unchecked")
-public class JCESecurityModule extends BaseSMAdapter {
+public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     /**
      * Pattern representing key type string value.
      */

--- a/jpos/src/test/java/org/jpos/security/ExtKeyUsageTest.java
+++ b/jpos/src/test/java/org/jpos/security/ExtKeyUsageTest.java
@@ -1,0 +1,74 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.Map;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class ExtKeyUsageTest {
+
+    private static final String TEST_EXTERNAL_KEYUSAGES = "META-INF/org/jpos/security/proprietary-invalid.properties";
+
+
+    @Test
+    public void testValueOfByCodeTEK() {
+        KeyUsage ret = ExtKeyUsage.valueOfByCode("32");
+        assertEquals("32", ret.getCode());
+        assertEquals("Terminal Encryption Key", ret.getName());
+        assertSame(ExtKeyUsage.TEK, ret);
+    }
+
+    @Test
+    public void testValueOfByCodeZPK() {
+        KeyUsage ret = ExtKeyUsage.valueOfByCode("27");
+        assertEquals("27", ret.getCode());
+        assertEquals("Zone PIN Encryption Key", ret.getName());
+        assertSame(ExtKeyUsage.ZPK, ret);
+    }
+
+    @Test
+    public void testValueOfByCodeKEK() {
+        KeyUsage ret = ExtKeyUsage.valueOfByCode("K0");
+        assertEquals("K0", ret.getCode());
+        assertSame(KeyUsage.KEK, ret);
+    }
+
+    @Test
+    public void testEntries() {
+        Map<String, KeyUsage> ret = ExtKeyUsage.entries();
+        assertTrue(ret.containsKey("D0"));
+        assertTrue(ret.containsKey("K0"));
+        assertTrue(ret.containsKey("M0"));
+        assertTrue(ret.containsKey("V0"));
+        assertTrue(ret.containsKey("12"));
+        assertTrue(ret.containsKey("15"));
+        assertTrue(ret.containsKey("17"));
+    }
+
+    @Test
+    public void testLoadPropertiesFromClasspath() {
+        ExtKeyUsage.loadKeyUsagesFromClasspath(TEST_EXTERNAL_KEYUSAGES);
+    }
+
+}

--- a/jpos/src/test/java/org/jpos/security/SecureKeyBlockBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/security/SecureKeyBlockBuilderTest.java
@@ -1,0 +1,216 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import org.jpos.iso.ISOUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class SecureKeyBlockBuilderTest {
+
+    private static final byte[] KEYBLOCK_MAC8 = ISOUtil.hex2byte("A1B2C3D4");
+
+    private static final byte[] KEYBLOCK_MAC4 = ISOUtil.hex2byte("E1F2");
+
+    private static final byte[] KEYBLOCK_ENCKEY = ISOUtil.hex2byte("A9B8C7D6E5F49382");
+
+    private static final String OPTHEADER_KS = "KS0ETest KS.12";
+
+    private static final String OPTHEADER_KV = "KV08abcd";
+
+    SecureKeyBlockBuilder instance;
+
+    SecureKeyBlock ret;
+
+    @Before
+    public void setUp() {
+        instance = SecureKeyBlockBuilder.newBuilder();
+    }
+
+    /**
+     * Test of build method, of class SecureKeyBlock.
+     */
+    @Test(expected = NullPointerException.class)
+    public void testBuildNull() {
+        instance.build(null);
+    }
+
+    /**
+     * Test of build method, of class SecureKeyBlock.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuildToShort() {
+        String data = "10024V2TG17N00";
+        instance.build(data);
+    }
+
+    /**
+     * Test of build method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testBuildWithoutEncKey() {
+        String data = "10024V2TG17N0033" + ISOUtil.hexString(KEYBLOCK_MAC8);
+        ret = instance.build(data);
+
+        assertEquals('1', ret.getKeyBlockVersion());
+        assertEquals(24, ret.getKeyBlockLength());
+        assertEquals(KeyUsage.VISAPVV, ret.getKeyUsage());
+        assertEquals(Algorithm.TDES, ret.getAlgorithm());
+        assertEquals(ModeOfUse.GENONLY, ret.getModeOfUse());
+        assertEquals("17", ret.getKeyVersion());
+        assertEquals(Exportability.NONE, ret.getExportability());
+        assertEquals("33", ret.getReserved());
+        assertNull(ret.getKeyBytes());
+        assertArrayEquals(KEYBLOCK_MAC8, ret.getKeyBlockMAC());
+    }
+
+    /**
+     * Test of build method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testBuildWithoutEncKeyAndMAC() {
+        String data = "00016V2DN17N0033";
+        ret = instance.build(data);
+
+        assertEquals('0', ret.getKeyBlockVersion());
+        assertEquals(16, ret.getKeyBlockLength());
+        assertEquals(KeyUsage.VISAPVV, ret.getKeyUsage());
+        assertEquals(Algorithm.DES, ret.getAlgorithm());
+        assertEquals(ModeOfUse.ANY, ret.getModeOfUse());
+        assertEquals("17", ret.getKeyVersion());
+        assertEquals(Exportability.NONE, ret.getExportability());
+        assertEquals("33", ret.getReserved());
+        assertNull(ret.getKeyBytes());
+        assertNull(ret.getKeyBlockMAC());
+    }
+
+    /**
+     * Test of build method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testBuildWithoutWithoutEncKey() {
+        String data = "00020P0ANc4S0021" + ISOUtil.hexString(KEYBLOCK_MAC4);
+        ret = instance.build(data);
+
+        assertEquals('0', ret.getKeyBlockVersion());
+        assertEquals(20, ret.getKeyBlockLength());
+        assertEquals(KeyUsage.PINENC, ret.getKeyUsage());
+        assertEquals(Algorithm.AES, ret.getAlgorithm());
+        assertEquals(ModeOfUse.ANY, ret.getModeOfUse());
+        assertEquals("c4", ret.getKeyVersion());
+        assertEquals(Exportability.TRUSTED, ret.getExportability());
+        assertEquals("21", ret.getReserved());
+        assertNull(ret.getKeyBytes());
+        assertArrayEquals(KEYBLOCK_MAC4, ret.getKeyBlockMAC());
+    }
+
+    /**
+     * Test of build method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testBuildMAC8() {
+        String data = "00036V2RG17N0003" + ISOUtil.hexString(KEYBLOCK_ENCKEY) + ISOUtil.hexString(KEYBLOCK_MAC4);
+        ret = instance.build(data);
+
+        assertEquals('0', ret.getKeyBlockVersion());
+        assertEquals(36, ret.getKeyBlockLength());
+        assertEquals(KeyUsage.VISAPVV, ret.getKeyUsage());
+        assertEquals(Algorithm.RSA, ret.getAlgorithm());
+        assertEquals(ModeOfUse.GENONLY, ret.getModeOfUse());
+        assertEquals("17", ret.getKeyVersion());
+        assertEquals(Exportability.NONE, ret.getExportability());
+        assertEquals("03", ret.getReserved());
+        assertArrayEquals(KEYBLOCK_ENCKEY, ret.getKeyBytes());
+        assertArrayEquals(KEYBLOCK_MAC4, ret.getKeyBlockMAC());
+    }
+
+    @Test
+    public void testBuildWithOptHeaders() {
+        String data = "D0046V2TGc3E0233" + OPTHEADER_KV + OPTHEADER_KS + ISOUtil.hexString(KEYBLOCK_MAC8);
+        ret = instance.build(data);
+
+        assertEquals('D', ret.getKeyBlockVersion());
+        assertEquals(46, ret.getKeyBlockLength());
+
+        assertNull(ret.getKeyBytes());
+        assertArrayEquals(KEYBLOCK_MAC8, ret.getKeyBlockMAC());
+
+        Map<String, String> ophdr = ret.getOptionalHeaders();
+        assertEquals(2, ophdr.size());
+
+        // Check optional headers content AND ORDER
+        Entry<String, String>[] entries = ophdr.entrySet().toArray(new Entry[0]);
+        assertEquals("KV", entries[0].getKey());
+        assertEquals("abcd", entries[0].getValue());
+        assertEquals("KS", entries[1].getKey());
+        assertEquals("Test KS.12", entries[1].getValue());
+    }
+
+    @Test
+    public void testBuildOptHeadersReversed() {
+        String data = "E0046V2TGc3E0233" + OPTHEADER_KS + OPTHEADER_KV + ISOUtil.hexString(KEYBLOCK_MAC8);
+        ret = instance.build(data);
+
+        assertEquals('E', ret.getKeyBlockVersion());
+        assertEquals(46, ret.getKeyBlockLength());
+
+        assertNull(ret.getKeyBytes());
+        assertArrayEquals(KEYBLOCK_MAC8, ret.getKeyBlockMAC());
+
+        Map<String, String> ophdr = ret.getOptionalHeaders();
+        assertEquals(2, ophdr.size());
+
+        // Check optional headers content AND ORDER
+        Entry<String, String>[] entries = ophdr.entrySet().toArray(new Entry[0]);
+        assertEquals("KV", entries[1].getKey());
+        assertEquals("abcd", entries[1].getValue());
+        assertEquals("KS", entries[0].getKey());
+        assertEquals("Test KS.12", entries[0].getValue());
+    }
+
+    /**
+     * Test of toKeyBlock method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testToKeyBlock() {
+        String data = "E0046V2TGc3E0233" + OPTHEADER_KS + OPTHEADER_KV + ISOUtil.hexString(KEYBLOCK_MAC8);
+        ret = instance.build(data);
+
+        assertEquals(data, instance.toKeyBlock(ret));
+    }
+
+    /**
+     * Test of toKeyBlock method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testToKeyBlockReversed() {
+        String data = "E0046V2TGc3E0233" + OPTHEADER_KV + OPTHEADER_KS + ISOUtil.hexString(KEYBLOCK_MAC8);
+        ret = instance.build(data);
+
+        assertEquals(data, instance.toKeyBlock(ret));
+    }
+
+}

--- a/jpos/src/test/java/org/jpos/security/SecureKeyBlockTest.java
+++ b/jpos/src/test/java/org/jpos/security/SecureKeyBlockTest.java
@@ -1,0 +1,216 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jpos.iso.ISOUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class SecureKeyBlockTest {
+
+    private static final String NL = System.getProperty("line.separator");
+
+    private static final byte[] KEYBLOCK_MAC8 = ISOUtil.hex2byte("A1B2C3D4");
+
+    private static final byte[] KEYBLOCK_MAC4 = ISOUtil.hex2byte("E1F2");
+
+    private static final byte[] KEYBLOCK_ENCKEY = ISOUtil.hex2byte("A9B8C7D6E5F49382");
+
+    private static final byte[] KEYBLOCK_KCV = ISOUtil.hex2byte("A1B2C3");
+
+
+    PrintStream ps;
+    ByteArrayOutputStream os;
+
+    SecureKeyBlock instance;
+
+    @Before
+    public void setUp() {
+        os = new ByteArrayOutputStream();
+        ps = new PrintStream(os);
+        instance = Mockito.spy(SecureKeyBlock.class);
+    }
+
+    /**
+     * Test of setKeyCheckValue method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testSetKeyCheckValue() {
+        byte[] keyCheckValue = null;
+        instance.setKeyCheckValue(keyCheckValue);
+    }
+
+    /**
+     * Test of getKeyCheckValue method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testGetKeyCheckValue() {
+        byte[] expResult = null;
+        byte[] result = instance.getKeyCheckValue();
+        assertArrayEquals(expResult, result);
+    }
+
+    /**
+     * Test of setKeyType method, of class SecureKeyBlock.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetKeyType() {
+        instance.setKeyType("");
+    }
+
+    /**
+     * Test of getKeyType method, of class SecureKeyBlock.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetKeyType() {
+        instance.getKeyType();
+    }
+
+    /**
+     * Test of setKeyLength method, of class SecureKeyBlock.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetKeyLength() {
+        instance.setKeyLength((short) 128);
+    }
+
+    /**
+     * Test of getKeyLength method, of class SecureKeyBlock.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetKeyLength() {
+        instance.getKeyLength();
+    }
+
+    /**
+     * Test of getScheme method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testGetScheme() {
+        KeyScheme expResult = null;
+        KeyScheme result = instance.getScheme();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of getOptionalHeaders method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testGetOptionalHeaders() {
+        Map<String, String> expResult = new LinkedHashMap<>();
+        Map<String, String> result = instance.getOptionalHeaders();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of dump method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testDump() {
+        String indent = "____";
+        instance.setScheme(KeyScheme.R);
+        instance.keyBlockVersion = 'D';
+        instance.keyUsage = KeyUsage.CVK;
+        instance.algorithm = Algorithm.TDES;
+        instance.modeOfUse = ModeOfUse.ENCDEC;
+        instance.keyVersion = "c2";
+        instance.exportability = Exportability.ANY;
+        instance.setKeyBytes(KEYBLOCK_ENCKEY);
+        instance.keyBlockMAC = KEYBLOCK_MAC8;
+        instance.setKeyCheckValue(KEYBLOCK_KCV);
+
+        instance.dump(ps, indent);
+
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(indent).append("<secure-key-block scheme=\"R\">").append(NL);
+        sb.append(indent).append("  <header>").append(NL);
+        sb.append(indent).append("    <version>D</version>").append(NL);
+        sb.append(indent).append("    <key-usage>C0</key-usage>").append(NL);
+        sb.append(indent).append("    <algorithm>T</algorithm>").append(NL);
+        sb.append(indent).append("    <mode-of-use>B</mode-of-use>").append(NL);
+        sb.append(indent).append("    <key-version>c2</key-version>").append(NL);
+        sb.append(indent).append("    <exportability>E</exportability>").append(NL);
+        sb.append(indent).append("  </header>").append(NL);
+        sb.append(indent).append("  <data>").append(ISOUtil.hexString(KEYBLOCK_ENCKEY)).append("</data>").append(NL);
+        sb.append(indent).append("  <mac>").append(ISOUtil.hexString(KEYBLOCK_MAC8)).append("</mac>").append(NL);
+        sb.append(indent).append("  <check-value>").append(ISOUtil.hexString(KEYBLOCK_KCV)).append("</check-value>").append(NL);
+        sb.append(indent).append("</secure-key-block>").append(NL);
+
+        assertEquals(sb.toString(), os.toString());
+    }
+
+    /**
+     * Test of dump method, of class SecureKeyBlock.
+     */
+    @Test
+    public void testDumpWithNameAndOptHeader() {
+        String indent = "____";
+        instance.setScheme(KeyScheme.S);
+        instance.keyBlockVersion = 'D';
+        instance.keyUsage = KeyUsage.CVK;
+        instance.algorithm = Algorithm.AES;
+        instance.modeOfUse = ModeOfUse.ENCDEC;
+        instance.keyVersion = "c2";
+        instance.exportability = Exportability.ANY;
+        instance.reserved = "19";
+        instance.setKeyBytes(KEYBLOCK_ENCKEY);
+        instance.keyBlockMAC = KEYBLOCK_MAC8;
+        instance.setKeyCheckValue(KEYBLOCK_KCV);
+        instance.setKeyName("Test key block key");
+        LinkedHashMap<String, String> optHdr = new LinkedHashMap<>();
+        instance.optionalHeaders = optHdr;
+        optHdr.put("KS", "Test KS.12");
+        optHdr.put("KV", "abcd");
+
+        instance.dump(ps, indent);
+
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(indent).append("<secure-key-block scheme=\"S\" name=\"Test key block key\">").append(NL);
+        sb.append(indent).append("  <header>").append(NL);
+        sb.append(indent).append("    <version>D</version>").append(NL);
+        sb.append(indent).append("    <key-usage>C0</key-usage>").append(NL);
+        sb.append(indent).append("    <algorithm>A</algorithm>").append(NL);
+        sb.append(indent).append("    <mode-of-use>B</mode-of-use>").append(NL);
+        sb.append(indent).append("    <key-version>c2</key-version>").append(NL);
+        sb.append(indent).append("    <exportability>E</exportability>").append(NL);
+        sb.append(indent).append("    <reserved>19</reserved>").append(NL);
+        sb.append(indent).append("  </header>").append(NL);
+        sb.append(indent).append("  <optional-header>").append(NL);
+        sb.append(indent).append("    <entry id=\"KS\" value=\"Test KS.12\"/>").append(NL);
+        sb.append(indent).append("    <entry id=\"KV\" value=\"abcd\"/>").append(NL);
+        sb.append(indent).append("  </optional-header>").append(NL);
+        sb.append(indent).append("  <data>").append(ISOUtil.hexString(KEYBLOCK_ENCKEY)).append("</data>").append(NL);
+        sb.append(indent).append("  <mac>").append(ISOUtil.hexString(KEYBLOCK_MAC8)).append("</mac>").append(NL);
+        sb.append(indent).append("  <check-value>").append(ISOUtil.hexString(KEYBLOCK_KCV)).append("</check-value>").append(NL);
+        sb.append(indent).append("</secure-key-block>").append(NL);
+
+        assertEquals(sb.toString(), os.toString());
+    }
+
+}

--- a/jpos/src/test/java/org/jpos/security/SecureKeySpecTest.java
+++ b/jpos/src/test/java/org/jpos/security/SecureKeySpecTest.java
@@ -1,0 +1,175 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Map;
+import org.jpos.iso.ISOUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class SecureKeySpecTest {
+
+    private static final String NL = System.getProperty("line.separator");
+
+    private static final byte[] KEYBLOCK_MAC8 = ISOUtil.hex2byte("A1B2C3D4");
+
+    private static final byte[] KEYBLOCK_ENCKEY = ISOUtil.hex2byte("A9B8C7D6E5F49382");
+
+    private static final byte[] KCV_KEYBLOCK = ISOUtil.hex2byte("A1B2C3");
+
+    private static final byte[] KCV_VARIANT  = ISOUtil.hex2byte("F9E8D7");
+
+
+    PrintStream ps;
+    ByteArrayOutputStream os;
+
+    SecureKeySpec instance;
+
+    @Before
+    public void setUp() {
+        os = new ByteArrayOutputStream();
+        ps = new PrintStream(os);
+
+        instance = new SecureKeySpec();
+    }
+
+    /**
+     * Test of dump method, of class SecureKeySpec.
+     */
+    @Test
+    public void testDumpEmpty() {
+        String indent = "____";
+
+        instance.dump(ps, indent);
+
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(indent).append("<secure-key-spec>").append(NL);
+        sb.append(indent).append("</secure-key-spec>").append(NL);
+
+        assertEquals(sb.toString(), os.toString());
+    }
+
+    /**
+     * Test of dump method, of class SecureKeySpec.
+     */
+    @Test
+    public void testDumpVariant() {
+        String indent = "____";
+        instance.setScheme(KeyScheme.U);
+        instance.setKeyLength(SMAdapter.LENGTH_DES3_2KEY);
+        instance.setKeyType(SMAdapter.TYPE_CVK);
+        instance.setVariant(3);
+        instance.setKeyCheckValue(KCV_VARIANT);
+        instance.setKeyName("Test variant key");
+
+        instance.dump(ps, indent);
+
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(indent).append("<secure-key-spec scheme=\"U\" name=\"Test variant key\">").append(NL);
+        sb.append(indent).append("  <length>128</length>").append(NL);
+        sb.append(indent).append("  <type>CVK</type>").append(NL);
+        sb.append(indent).append("  <variant>3</variant>").append(NL);
+        sb.append(indent).append("  <check-value>").append(ISOUtil.hexString(KCV_VARIANT)).append("</check-value>").append(NL);
+        sb.append(indent).append("</secure-key-spec>").append(NL);
+
+        assertEquals(sb.toString(), os.toString());
+    }
+
+    /**
+     * Test of dump method, of class SecureKeySpec.
+     */
+    @Test
+    public void testDumpKeyBlock() {
+        String indent = "____";
+        instance.setScheme(KeyScheme.S);
+        instance.setKeyBlockVersion('1');
+        instance.setKeyUsage(KeyUsage.KEK);
+        instance.setAlgorithm(Algorithm.DSA);
+        instance.setModeOfUse(ModeOfUse.GENONLY);
+        instance.setKeyVersion("39");
+        instance.setExportability(Exportability.NONE);
+        instance.setReserved("04");
+        instance.setKeyBytes(KEYBLOCK_ENCKEY);
+        instance.setKeyBlockMAC(KEYBLOCK_MAC8);
+        instance.setKeyCheckValue(KCV_KEYBLOCK);
+        instance.setKeyName("Test key block key");
+
+        instance.dump(ps, indent);
+
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(indent).append("<secure-key-spec scheme=\"S\" name=\"Test key block key\">").append(NL);
+        sb.append(indent).append("  <header>").append(NL);
+        sb.append(indent).append("    <version>1</version>").append(NL);
+        sb.append(indent).append("    <key-usage>K0</key-usage>").append(NL);
+        sb.append(indent).append("    <algorithm>S</algorithm>").append(NL);
+        sb.append(indent).append("    <mode-of-use>G</mode-of-use>").append(NL);
+        sb.append(indent).append("    <key-version>39</key-version>").append(NL);
+        sb.append(indent).append("    <exportability>N</exportability>").append(NL);
+        sb.append(indent).append("    <reserved>04</reserved>").append(NL);
+        sb.append(indent).append("  </header>").append(NL);
+        sb.append(indent).append("  <data>").append(ISOUtil.hexString(KEYBLOCK_ENCKEY)).append("</data>").append(NL);
+        sb.append(indent).append("  <mac>").append(ISOUtil.hexString(KEYBLOCK_MAC8)).append("</mac>").append(NL);
+        sb.append(indent).append("  <check-value>").append(ISOUtil.hexString(KCV_KEYBLOCK)).append("</check-value>").append(NL);
+        sb.append(indent).append("</secure-key-spec>").append(NL);
+
+        assertEquals(sb.toString(), os.toString());
+    }
+
+    /**
+     * Test of dump method, of class SecureKeySpec.
+     */
+    @Test
+    public void testDumpKeyBlockWithOptionalHeader() {
+        String indent = "____";
+        instance.setScheme(KeyScheme.R);
+        instance.setKeyBlockVersion('D');
+        instance.setKeyUsage(KeyUsage.CVK);
+        instance.setModeOfUse(ModeOfUse.GENVER);
+        Map optHdr = instance.getOptionalHeaders();
+        optHdr.put("KS", "Test KS.12");
+        optHdr.put("KV", "abcd");
+        optHdr.put("99", "quick brown fox");
+
+        instance.dump(ps, indent);
+
+        StringBuilder sb = new StringBuilder(128);
+        sb.append(indent).append("<secure-key-spec scheme=\"R\">").append(NL);
+        sb.append(indent).append("  <header>").append(NL);
+        sb.append(indent).append("    <version>D</version>").append(NL);
+        sb.append(indent).append("    <key-usage>C0</key-usage>").append(NL);
+        sb.append(indent).append("    <mode-of-use>C</mode-of-use>").append(NL);
+        sb.append(indent).append("  </header>").append(NL);
+        sb.append(indent).append("  <optional-header>").append(NL);
+        sb.append(indent).append("    <entry id=\"KS\" value=\"Test KS.12\"/>").append(NL);
+        sb.append(indent).append("    <entry id=\"KV\" value=\"abcd\"/>").append(NL);
+        sb.append(indent).append("    <entry id=\"99\" value=\"quick brown fox\"/>").append(NL);
+        sb.append(indent).append("  </optional-header>").append(NL);
+        sb.append(indent).append("</secure-key-spec>").append(NL);
+
+        assertEquals(sb.toString(), os.toString());
+    }
+
+}

--- a/jpos/src/test/resources/META-INF/org/jpos/security/proprietary-hsm-invalid.properties
+++ b/jpos/src/test/resources/META-INF/org/jpos/security/proprietary-hsm-invalid.properties
@@ -1,0 +1,32 @@
+# Example configuration of proprietary key usages
+#
+# Please define entries according to the rules:
+#  * the codes should be two digits (proprietary codes)
+#  * each code can be registered only once
+#  * unused entries, for example if HSM has no equivalent, delete or comment whole line with #
+#
+
+# External Key Usage section (with 'ku.' prefix)
+ku.DEK       =12,Data Encryption Key
+ku.ZEK       =22,Zone Encryption Key
+ku.TEK       =32,Terminal Encryption Key
+ku.RSAPK     =20,RSA Public Key
+ku.RSASK     =33,RSA Private Key for signing or key mgt
+ku.RSASKICC  =40,RSA Private Key for ICC
+ku.RSASKPIN  =50,RSA Private Key for PIN translation
+ku.RSASKTLS  =60,RSA Private Key for TLS
+ku.TMK       =15,Terminal Master Key
+ku.ZMK       =25,Zone Master Key
+ku.HMACSHA1  =16,HMAC key using SHA-1
+ku.HMACSHA224=26,HMAC key using SHA-224
+ku.HMACSHA256=36,HMAC key using SHA-256
+ku.HMACSHA384=46,HMAC key using SHA-384
+ku.HMACSHA512=56,HMAC key using SHA-512
+ku.TPK       =17,Terminal PIN Encryption Key
+ku.ZPK       =27,Zone PIN Encryption Key
+
+# External Optional Headers section (with 'oh.' prefix)
+oh.KEYSTAUS  =00,Key Status
+oh.KEYEFFECT =30,Effective Date/Time
+oh.KEYEXPIRE =40,Expire Date/Time
+oh.KEYDESCR  =50,Description

--- a/jpos/src/test/resources/META-INF/org/jpos/security/proprietary-hsm.properties
+++ b/jpos/src/test/resources/META-INF/org/jpos/security/proprietary-hsm.properties
@@ -1,0 +1,32 @@
+# Example configuration of proprietary key usages
+#
+# Please define entries according to the rules:
+#  * the codes should be two digits (proprietary codes)
+#  * each code can be registered only once
+#  * unused entries, for example if HSM has no equivalent, delete or comment whole line with #
+#
+
+# External Key Usage section (with 'ku.' prefix)
+ku.DEK       =12,Data Encryption Key
+ku.ZEK       =22,Zone Encryption Key
+ku.TEK       =32,Terminal Encryption Key
+ku.RSAPK     =20,RSA Public Key
+ku.RSASK     =33,RSA Private Key for signing or key mgt
+ku.RSASKICC  =40,RSA Private Key for ICC
+ku.RSASKPIN  =50,RSA Private Key for PIN translation
+ku.RSASKTLS  =60,RSA Private Key for TLS
+ku.TMK       =15,Terminal Master Key
+ku.ZMK       =25,Zone Master Key
+ku.HMACSHA1  =16,HMAC key using SHA-1
+ku.HMACSHA224=26,HMAC key using SHA-224
+ku.HMACSHA256=36,HMAC key using SHA-256
+ku.HMACSHA384=46,HMAC key using SHA-384
+ku.HMACSHA512=56,HMAC key using SHA-512
+ku.TPK       =17,Terminal PIN Encryption Key
+ku.ZPK       =27,Zone PIN Encryption Key
+
+# External Optional Headers section (with 'oh.' prefix)
+oh.KEYSTAUS  =00,Key Status
+oh.KEYEFFECT =30,Effective Date/Time
+oh.KEYEXPIRE =40,Expire Date/Time
+oh.KEYDESCR  =50,Description


### PR DESCRIPTION
A set of commits that enables key block support via the `SMAdapter`.

### After applying the commit 36b3e32, the custom HSM driver will not compile.
In order to solve this problem it is required to modify such driver.

In the minimal version, add `<SecureDESKey>` _(to stay with variants LMK handling only)_
``` java
public class SomeCustomHSMDriver extends BaseSMAdapter<SecureDESKey>
```
See file change `JCESecurityModule.java` in 36b3e32

In order to fully operate the key block by `SomeCustomHSMDriver` is required to add
``` java
public class SomeCustomHSMDriver extends BaseSMAdapter<SecureKey>
```
adjust _(to support key block)_ all used by `SomeCustomHSMDriver` methods and if required implement some new version of methods:
  * generateKey
  * importKey
  * exportKey
  * translateKeyFromOldLMK
  * generateKeyPair

To use `ExtKeyUsage` from b46ccaa with proprietary specific key usages is required to define custom resource `META-INF/org/jpos/security/proprietary-hsm.properties`. For example see at
`jpos/src/test/resources/META-INF/org/jpos/security/proprietary-hsm.properties`