### PR TITLE
Make AsciiPrefixer fail if input doesn't contain digits

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/AsciiPrefixer.java
+++ b/jpos/src/main/java/org/jpos/iso/AsciiPrefixer.java
@@ -86,12 +86,16 @@ public class AsciiPrefixer implements Prefixer
     }
 
     @Override
-    public int decodeLength(byte[] b, int offset)
-    {
+    public int decodeLength(byte[] b, int offset) throws ISOException {
         int len = 0;
         for (int i = 0; i < nDigits; i++)
         {
-            len = len * 10 + b[offset + i] - (byte)'0';
+            byte d = b[offset + i];
+            if(d < '0' || d > '9')
+            {
+                throw new ISOException("Invalid character found. Expected digit.");
+            }
+            len = len * 10 + d - (byte)'0';
         }
         return len;
     }

--- a/jpos/src/test/java/org/jpos/iso/AsciiPrefixer2Test.java
+++ b/jpos/src/test/java/org/jpos/iso/AsciiPrefixer2Test.java
@@ -35,8 +35,12 @@ public class AsciiPrefixer2Test {
     @Test
     public void testDecodeLength() throws Throwable {
         byte[] bytes = new byte[2];
-        int result = AsciiPrefixer.LL.decodeLength(bytes, 0);
-        assertEquals("result", -528, result);
+        try {
+            int result = AsciiPrefixer.LL.decodeLength(bytes, 0);
+            fail("Expected ISOException to be thrown");
+        } catch (ISOException ex) {
+            assertEquals("ex.getMessage()", "Invalid character found. Expected digit.", ex.getMessage());
+        }
     }
 
     @Test
@@ -47,8 +51,30 @@ public class AsciiPrefixer2Test {
     }
 
     @Test
+    public void testDecodeBadLength1DigitThrowsISOException() throws Throwable {
+        byte[] bytes = new byte[] {'9'+1};
+        try {
+            int result = AsciiPrefixer.L.decodeLength(bytes, 0);
+            fail("Expected ISOException to be thrown");
+        } catch (ISOException ex) {
+            assertEquals("ex.getMessage()", "Invalid character found. Expected digit.", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testDecodeBadLength2DigitsDoesntFail() throws Throwable {
+        byte[] bytes = new byte[] {'1', '0'-1, '0'};
+        try {
+            int result = AsciiPrefixer.LLL.decodeLength(bytes, 0);
+            fail("Expected ISOException to be thrown");
+        } catch (ISOException ex) {
+            assertEquals("ex.getMessage()", "Invalid character found. Expected digit.", ex.getMessage());
+        }
+    }
+
+    @Test
     public void testDecodeLengthThrowsArrayIndexOutOfBoundsException() throws Throwable {
-        byte[] b = new byte[3];
+        byte[] b = new byte[] {'0', '0', '0'};
         try {
             new AsciiPrefixer(100).decodeLength(b, 0);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");

--- a/jpos/src/test/java/org/jpos/iso/packager/CTCSubElementPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/CTCSubElementPackagerTest.java
@@ -152,12 +152,12 @@ public class CTCSubElementPackagerTest {
             fail("Expected ISOException to be thrown");
         } catch (ISOException ex) {
             assertEquals("ex.getMessage()", "org.jpos.iso.IFA_LCHAR: Problem unpacking field 0", ex.getMessage());
-            assertNull("ex.getNested().getMessage()", ex.getNested().getMessage());
+            assertEquals("ex.getNested().getMessage()", "Invalid character found. Expected digit.", ex.getNested().getMessage());
         }
     }
 
     @Test
-    public void testUnpackThrowsNegativeArraySizeException() throws Throwable {
+    public void testUnpackThrowsISOExceptionOnBadInputData() throws Throwable {
         byte[] b = new byte[3];
         ISOFieldPackager[] fld = new ISOFieldPackager[3];
         fld[0] = new IFA_LLBNUM();
@@ -166,8 +166,8 @@ public class CTCSubElementPackagerTest {
         try {
             cTCSubElementPackager.unpack(new ISOBinaryField(), b);
             fail("Expected NegativeArraySizeException to be thrown");
-        } catch (NegativeArraySizeException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+        } catch (ISOException ex) {
+            assertEquals("ex.getMessage()", "Invalid character found. Expected digit.", ex.getMessage());
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/packager/CTCSubFieldPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/CTCSubFieldPackagerTest.java
@@ -117,7 +117,7 @@ public class CTCSubFieldPackagerTest {
             fail("Expected ISOException to be thrown");
         } catch (ISOException ex) {
             assertEquals("ex.getMessage()", "org.jpos.iso.IFA_LLLLCHAR: Problem unpacking field 0", ex.getMessage());
-            assertNull("ex.getNested().getMessage()", ex.getNested().getMessage());
+            assertEquals("ex.getNested().getMessage()", "Invalid character found. Expected digit.", ex.getNested().getMessage());
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/packager/GenericSubFieldPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/GenericSubFieldPackagerTest.java
@@ -116,7 +116,7 @@ public class GenericSubFieldPackagerTest {
             fail("Expected ISOException to be thrown");
         } catch (ISOException ex) {
             assertEquals("ex.getMessage()", "org.jpos.iso.IFA_LCHAR: Problem unpacking field -1", ex.getMessage());
-            assertNull("ex.getNested().getMessage()", ex.getNested().getMessage());
+            assertEquals("ex.getNested().getMessage()", "Invalid character found. Expected digit.", ex.getNested().getMessage());
         }
     }
 
@@ -190,7 +190,7 @@ public class GenericSubFieldPackagerTest {
             fail("Expected ISOException to be thrown");
         } catch (ISOException ex) {
             assertEquals("ex.getMessage()", "org.jpos.iso.IFA_LLLLCHAR: Problem unpacking field -1", ex.getMessage());
-            assertNull("ex.getNested().getMessage()", ex.getNested().getMessage());
+            assertEquals("ex.getNested().getMessage()", "Invalid character found. Expected digit.", ex.getNested().getMessage());
         }
     }
 


### PR DESCRIPTION
`AsciiPrefixer.decodeLength()` accepted input characters that were not digits. It also produced a bad length as a result. This is a dangerous situation, as the behaviour of the parser can then not be predicted. This pull request tried to keep style and algorithm, but justs throws an exception if input characters are not correct. 