### PR TITLE
Run tests against jdk 11 and 12 while allowing failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: java
 jdk:
-- oraclejdk8
+  - oraclejdk8
+  - openjdk8
+  - openjdk11
+  - openjdk12
 before_script:
-- echo $JAVA_OPTS
-- export JAVA_OPTS=-Xmx4G
+  - echo $JAVA_OPTS
+  - export JAVA_OPTS=-Xmx4G
 install: true
 script:
-- sudo apt-get update && sudo apt-get install oracle-java8-installer
-- java -version
-- ulimit -a
-- TERM=dumb ./gradlew jpos:assemble jpos:check --info
+  - java -version
+  - ulimit -a
+  - TERM=dumb ./gradlew jpos:assemble jpos:check --info
 after_success: .travis/update-gh-pages.sh
 after_failure: .travis/update-gh-pages.sh
 env:
@@ -20,3 +22,7 @@ env:
 notifications:
   slack:
     secure: opKU+4jJWYuhq5STCVW2cvxEq/1/xY17xpxGKoJXWA+RbhPo+viT5uJLmb67HwdmvQNwUVAW6uOLO7SDOmpGh5oAwpI74DrA0y6uEzN6GgzutZDBY5oCMRYCGi/5xNOuzDdsryDtSJvXWLxyCysnTrAqqQ9XdOnRK/ZqSIeQg+s=
+matrix:
+  allow_failures:
+    - jdk: openjdk11
+    - jdk: openjdk12

--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     testCompile libraries.fest_assert
     testCompile libraries.xmlunit
     testCompile libraries.junit
+    testRuntime libraries.junit_vintage
     testCompile(libraries.mockito) {
         exclude(module: 'hamcrest-core')
     }

--- a/jpos/libraries.gradle
+++ b/jpos/libraries.gradle
@@ -13,6 +13,7 @@ ext {
         fest_assert: 'org.easytesting:fest-assert:1.4',
         xmlunit: 'xmlunit:xmlunit:1.6',
         junit: 'junit:junit:4.12',
+        junit_vintage: 'org.junit.vintage:junit-vintage-engine:5.4.2',
         bouncycastle: [
             'org.bouncycastle:bcprov-jdk15on:1.61',
             'org.bouncycastle:bcpg-jdk15on:1.61'


### PR DESCRIPTION
This approach avoids disabling any tests like #220 does while still running the build against jdk 11 and 12(but with failures for those ignored).

This should make it easier to incrementally fix the tests under jdk 11 and jdk 12.