### PR TITLE
Optimize Context.dumpMap to avoid locking during dumpEntry

### DIFF
--- a/jpos/src/main/java/org/jpos/transaction/Context.java
+++ b/jpos/src/main/java/org/jpos/transaction/Context.java
@@ -247,9 +247,12 @@ public class Context implements Externalizable, Loggeable, Pausable, Cloneable {
 
     protected void dumpMap (PrintStream p, String indent) {
         if (map != null) {
-             synchronized(map) {
-                map.entrySet().forEach(e -> dumpEntry(p, indent, e));
-             }
+            Map<Object,Object> cloned;
+            cloned = Collections.synchronizedMap (new LinkedHashMap<>());
+            synchronized(map) {
+                cloned.putAll(map);
+            }
+            cloned.entrySet().forEach(e -> dumpEntry(p, indent, e));
         }
     }
 


### PR DESCRIPTION
This should fix an issue where testConcurrentException is extremely slow on some systems.