### PR TITLE
Run tests against all recent jdk versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,35 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: java
 jdk:
-- oraclejdk8
+  - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
+  - openjdk12
 before_script:
-- echo $JAVA_OPTS
-- export JAVA_OPTS=-Xmx4G
+  - echo $JAVA_OPTS
+  - export JAVA_OPTS=-Xmx4G
 install: true
 script:
-- sudo apt-get update && sudo apt-get install oracle-java8-installer
-- java -version
-- ulimit -a
-- TERM=dumb ./gradlew jpos:assemble jpos:check --info
-after_success: .travis/update-gh-pages.sh
-after_failure: .travis/update-gh-pages.sh
+  - java -version
+  - ulimit -a
+  - TERM=dumb ./gradlew jpos:assemble jpos:check --info
+deploy:
+  provider: script
+  script: bash .travis/update-gh-pages.sh
+  on:
+    branch: master
 env:
   global:
     secure: ZWDnTNCsRaxOV4hPiWslj1ieKwYjuxBA4COHFVApxr8TBcQEwhPAzo+b+WbDsi45rJkk/Ee9Du0+mbT//x3TTK78fePg6EDk0WBSmWRUFC3eITgTmUJe7Qh5VOUZOdz9vFaYH8080/CB4VyygJuSp2XLte+S/MVSoXVVABrNggU=
 notifications:
   slack:
     secure: opKU+4jJWYuhq5STCVW2cvxEq/1/xY17xpxGKoJXWA+RbhPo+viT5uJLmb67HwdmvQNwUVAW6uOLO7SDOmpGh5oAwpI74DrA0y6uEzN6GgzutZDBY5oCMRYCGi/5xNOuzDdsryDtSJvXWLxyCysnTrAqqQ9XdOnRK/ZqSIeQg+s=
+matrix:
+  include:
+    - jdk: oraclejdk8
+      dist: trusty
+  allow_failures:
+    - jdk: openjdk9
+    - jdk: openjdk10

--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -28,10 +28,12 @@ dependencies {
     compile libraries.hdrhistogram
     compile libraries.yaml;
 
+    testCompile libraries.commons_lang3
     testCompile libraries.hamcrest
     testCompile libraries.fest_assert
     testCompile libraries.xmlunit
     testCompile libraries.junit
+    testRuntime libraries.junit_vintage
     testCompile(libraries.mockito) {
         exclude(module: 'hamcrest-core')
     }

--- a/jpos/libraries.gradle
+++ b/jpos/libraries.gradle
@@ -4,6 +4,7 @@ ext {
         jdbm: 'jdbm:jdbm:1.0',
         sleepycat_je: 'com.sleepycat:je:18.3.12',
         commons_cli: 'commons-cli:commons-cli:1.4',
+        commons_lang3: 'org.apache.commons:commons-lang3:3.9',
         jline: 'org.jline:jline:3.9.0',
         beanshell: 'org.apache-extras.beanshell:bsh:2.0b6',
         javatuples: 'org.javatuples:javatuples:1.2',
@@ -13,6 +14,7 @@ ext {
         fest_assert: 'org.easytesting:fest-assert:1.4',
         xmlunit: 'xmlunit:xmlunit:1.6',
         junit: 'junit:junit:4.12',
+        junit_vintage: 'org.junit.vintage:junit-vintage-engine:5.4.2',
         bouncycastle: [
             'org.bouncycastle:bcprov-jdk15on:1.61',
             'org.bouncycastle:bcpg-jdk15on:1.61'

--- a/jpos/src/main/java/org/jpos/iso/ISODate.java
+++ b/jpos/src/main/java/org/jpos/iso/ISODate.java
@@ -107,8 +107,7 @@ public class ISODate {
     public static Date parseDateTime(String s, TimeZone timeZone) {
         Date d = null;
         SimpleDateFormat df =
-            (SimpleDateFormat) DateFormat.getDateTimeInstance(
-                DateFormat.SHORT, DateFormat.MEDIUM, Locale.UK);
+            new SimpleDateFormat("dd/MM/yy hh:mm:ss", Locale.UK);
 
         df.setTimeZone (timeZone);
         try {

--- a/jpos/src/test/java/org/jpos/bsh/BSHLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/bsh/BSHLogListenerTest.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Properties;
@@ -291,7 +294,11 @@ public class BSHLogListenerTest {
             BSHLogListener.replace(src, patterns, to);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/AsciiHexInterpreter2Test.java
+++ b/jpos/src/test/java/org/jpos/iso/AsciiHexInterpreter2Test.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.junit.Test;
 
 public class AsciiHexInterpreter2Test {
@@ -70,7 +73,11 @@ public class AsciiHexInterpreter2Test {
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
             assertEquals("b[0]", (byte) 48, b[0]);
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
             assertEquals("b.length", 1, b.length);
         }
     }
@@ -83,7 +90,11 @@ public class AsciiHexInterpreter2Test {
             AsciiHexInterpreter.INSTANCE.interpret(data, b, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "100", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "100", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+            }
             assertEquals("b.length", 0, b.length);
         }
     }
@@ -97,7 +108,11 @@ public class AsciiHexInterpreter2Test {
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
             assertEquals("b[0]", (byte) 48, b[0]);
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
             assertEquals("b.length", 3, b.length);
         }
     }
@@ -126,7 +141,11 @@ public class AsciiHexInterpreter2Test {
             AsciiHexInterpreter.INSTANCE.uninterpret(rawData, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "68", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "68", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 68 out of bounds for length 68", ex.getMessage());
+            }
         }
     }
 
@@ -141,7 +160,11 @@ public class AsciiHexInterpreter2Test {
             AsciiHexInterpreter.INSTANCE.uninterpret(rawData, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "68", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "68", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 68 out of bounds for length 68", ex.getMessage());
+            }
         }
     }
 
@@ -156,7 +179,11 @@ public class AsciiHexInterpreter2Test {
             AsciiHexInterpreter.INSTANCE.uninterpret(rawData, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "68", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "68", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 68 out of bounds for length 68", ex.getMessage());
+            }
         }
     }
 
@@ -169,7 +196,11 @@ public class AsciiHexInterpreter2Test {
             AsciiHexInterpreter.INSTANCE.uninterpret(rawData, 65, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "67", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "67", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 67 out of bounds for length 67", ex.getMessage());
+            }
         }
     }
 
@@ -182,7 +213,11 @@ public class AsciiHexInterpreter2Test {
             AsciiHexInterpreter.INSTANCE.uninterpret(rawData, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -195,7 +230,11 @@ public class AsciiHexInterpreter2Test {
             AsciiHexInterpreter.INSTANCE.uninterpret(rawData, 1, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "5", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "5", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 5 out of bounds for length 5", ex.getMessage());
+            }
         }
     }
 
@@ -206,7 +245,11 @@ public class AsciiHexInterpreter2Test {
             AsciiHexInterpreter.INSTANCE.uninterpret(rawData, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -218,7 +261,11 @@ public class AsciiHexInterpreter2Test {
             new AsciiHexInterpreter().uninterpret(rawData, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -229,7 +276,11 @@ public class AsciiHexInterpreter2Test {
             new AsciiHexInterpreter().uninterpret(rawData, 100, -1);
             fail("Expected NegativeArraySizeException to be thrown");
         } catch (NegativeArraySizeException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/AsciiInterpreter2Test.java
+++ b/jpos/src/test/java/org/jpos/iso/AsciiInterpreter2Test.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.junit.Test;
 
 public class AsciiInterpreter2Test {
@@ -88,7 +91,11 @@ public class AsciiInterpreter2Test {
             new AsciiInterpreter().uninterpret(rawData, 100, -1);
             fail("Expected NegativeArraySizeException to be thrown");
         } catch (NegativeArraySizeException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/AsciiPrefixer2Test.java
+++ b/jpos/src/test/java/org/jpos/iso/AsciiPrefixer2Test.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.junit.Test;
 
 public class AsciiPrefixer2Test {
@@ -79,7 +82,11 @@ public class AsciiPrefixer2Test {
             new AsciiPrefixer(100).decodeLength(b, 0);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -114,7 +121,11 @@ public class AsciiPrefixer2Test {
             new AsciiPrefixer(1).encodeLength(100, b);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
             assertEquals("b.length", 0, b.length);
         }
     }

--- a/jpos/src/test/java/org/jpos/iso/BaseChannelTest.java
+++ b/jpos/src/test/java/org/jpos/iso/BaseChannelTest.java
@@ -26,6 +26,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.*;
@@ -690,7 +693,11 @@ public class BaseChannelTest {
             nACChannel.readHeader(-1);
             fail("Expected NegativeArraySizeException to be thrown");
         } catch (NegativeArraySizeException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            }
             assertNull("(NACChannel) nACChannel.serverIn", ((NACChannel) nACChannel).serverIn);
         }
     }

--- a/jpos/src/test/java/org/jpos/iso/BcdPrefixer2Test.java
+++ b/jpos/src/test/java/org/jpos/iso/BcdPrefixer2Test.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.junit.Test;
 
 public class BcdPrefixer2Test {
@@ -54,7 +57,11 @@ public class BcdPrefixer2Test {
             new BcdPrefixer(100).decodeLength(b, 0);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -89,7 +96,11 @@ public class BcdPrefixer2Test {
             BcdPrefixer.LLL.encodeLength(100, b);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
             assertEquals("b.length", 1, b.length);
         }
     }

--- a/jpos/src/test/java/org/jpos/iso/BinaryPrefixer2Test.java
+++ b/jpos/src/test/java/org/jpos/iso/BinaryPrefixer2Test.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.junit.Test;
 
 public class BinaryPrefixer2Test {
@@ -54,7 +57,11 @@ public class BinaryPrefixer2Test {
             new BinaryPrefixer(100).decodeLength(b, 0);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -65,7 +72,11 @@ public class BinaryPrefixer2Test {
             new BinaryPrefixer(100).decodeLength(b, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "100", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "100", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 100 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -100,7 +111,11 @@ public class BinaryPrefixer2Test {
             new BinaryPrefixer(1).encodeLength(100, b);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
             assertEquals("b.length", 0, b.length);
         }
     }

--- a/jpos/src/test/java/org/jpos/iso/EbcdicPrefixer2Test.java
+++ b/jpos/src/test/java/org/jpos/iso/EbcdicPrefixer2Test.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.junit.Test;
 
 public class EbcdicPrefixer2Test {
@@ -54,7 +57,11 @@ public class EbcdicPrefixer2Test {
             new EbcdicPrefixer(100).decodeLength(b, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "100", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "100", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 
@@ -65,7 +72,11 @@ public class EbcdicPrefixer2Test {
             new EbcdicPrefixer(100).decodeLength(b, 0);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "50", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "50", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 50 out of bounds for length 50", ex.getMessage());
+            }
         }
     }
 
@@ -108,7 +119,11 @@ public class EbcdicPrefixer2Test {
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
             assertEquals("b[1]", (byte) -16, b[1]);
-            assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index -1 out of bounds for length 10", ex.getMessage());
+            }
             assertEquals("b.length", 2, b.length);
         }
     }
@@ -120,7 +135,11 @@ public class EbcdicPrefixer2Test {
             new EbcdicPrefixer(2).encodeLength(100, b);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
             assertEquals("b.length", 1, b.length);
         }
     }

--- a/jpos/src/test/java/org/jpos/iso/ISOFieldPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/ISOFieldPackagerTest.java
@@ -24,6 +24,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_1_8;
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
@@ -100,7 +104,11 @@ public class ISOFieldPackagerTest {
             iFEB_LLLNUM.readBytes(in, -1);
             fail("Expected NegativeArraySizeException to be thrown");
         } catch (NegativeArraySizeException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            }
             assertEquals("(ByteArrayInputStream) in.available()", 10, in.available());
         }
     }
@@ -156,7 +164,11 @@ public class ISOFieldPackagerTest {
             new IFEB_LLLNUM().unpack(new ISOMsg("testISOFieldPackagerMti"), in);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 2", ex.getMessage());
+            }
             assertEquals("(ByteArrayInputStream) in.available()", 0, in.available());
         }
     }
@@ -186,7 +198,11 @@ public class ISOFieldPackagerTest {
             new Base1_BITMAP126(-1, "testISOFieldPackagerDescription").unpack(new IFB_AMOUNT().createComponent(100), in);
             fail("Expected NegativeArraySizeException to be thrown");
         } catch (NegativeArraySizeException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            }
             assertEquals("(ByteArrayInputStream) in.available()", 0, in.available());
         }
     }
@@ -212,7 +228,11 @@ public class ISOFieldPackagerTest {
             iFB_AMOUNT.unpack(new ISOMsg(), in);
             fail("Expected StringIndexOutOfBoundsException to be thrown");
         } catch (StringIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "String index out of range: 1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_1_8)) {
+                assertEquals("ex.getMessage()", "String index out of range: 1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "offset 0, count 1, length 0", ex.getMessage());
+            }
             assertEquals("(ByteArrayInputStream) in.available()", 10, in.available());
         }
     }

--- a/jpos/src/test/java/org/jpos/iso/ISOUtilTest.java
+++ b/jpos/src/test/java/org/jpos/iso/ISOUtilTest.java
@@ -31,6 +31,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.nio.ByteBuffer;
@@ -477,7 +480,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 62, true);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "71", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "71", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 71 out of bounds for length 71", ex.getMessage());
+            }
         }
     }
 
@@ -489,7 +496,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, true);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -500,7 +511,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 100, 64);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "100", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "100", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 100 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -512,7 +527,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, false);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -523,7 +542,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, false);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -534,7 +557,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, true);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -545,7 +572,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 100, false);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "100", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "100", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 
@@ -556,7 +587,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 100, true);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "100", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "100", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 
@@ -588,7 +623,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 1, 1000);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "12", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "12", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 12 out of bounds for length 12", ex.getMessage());
+            }
         }
     }
 
@@ -600,7 +639,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, 128);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -612,7 +655,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 1, 129);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -624,7 +671,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 1, 127);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -636,7 +687,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, 63);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -648,7 +703,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, 129);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -660,7 +719,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, 64);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -671,7 +734,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, 128);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -682,7 +749,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, 63);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -693,7 +764,11 @@ public class ISOUtilTest {
             ISOUtil.byte2BitSet(b, 0, 129);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -2535,7 +2610,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, true);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "19", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "19", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 19 out of bounds for length 19", ex.getMessage());
+            }
         }
     }
 
@@ -2547,7 +2626,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, false);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -2559,7 +2642,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, 65);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "19", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "19", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 19 out of bounds for length 19", ex.getMessage());
+            }
         }
     }
 
@@ -2571,7 +2658,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 66, 127);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "83", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "83", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 83 out of bounds for length 83", ex.getMessage());
+            }
         }
     }
 
@@ -2582,7 +2673,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, 65);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "19", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "19", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 19 out of bounds for length 19", ex.getMessage());
+            }
         }
     }
 
@@ -2594,7 +2689,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "20", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "20", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 20 out of bounds for length 20", ex.getMessage());
+            }
         }
     }
 
@@ -2605,7 +2704,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, 1000);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "18", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "18", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 18 out of bounds for length 18", ex.getMessage());
+            }
         }
     }
 
@@ -2617,7 +2720,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, 64);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -2628,7 +2735,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, 65);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -2639,7 +2750,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, 63);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -2650,7 +2765,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, true);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -2661,7 +2780,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 0, false);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -2672,7 +2795,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 100, false);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "100", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "100", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 100 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -2683,7 +2810,11 @@ public class ISOUtilTest {
             ISOUtil.hex2BitSet(b, 100, true);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "100", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "100", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 
@@ -2770,7 +2901,11 @@ public class ISOUtilTest {
             ISOUtil.hex2byte(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -3008,7 +3143,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "19", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "19", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 19 out of bounds for length 19", ex.getMessage());
+            }
         }
     }
 
@@ -3021,7 +3160,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "34", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "34", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 34 out of bounds for length 34", ex.getMessage());
+            }
         }
     }
 
@@ -3032,7 +3175,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -3044,7 +3191,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -3056,7 +3207,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "10", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "10", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 10 out of bounds for length 10", ex.getMessage());
+            }
         }
     }
 
@@ -3069,7 +3224,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -3081,7 +3240,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "9", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "9", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 9 out of bounds for length 9", ex.getMessage());
+            }
         }
     }
 
@@ -3093,7 +3256,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -3105,7 +3272,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 10, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "18", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "18", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 18 out of bounds for length 18", ex.getMessage());
+            }
         }
     }
 
@@ -3118,7 +3289,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "12", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "12", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 12 out of bounds for length 12", ex.getMessage());
+            }
         }
     }
 
@@ -3131,7 +3306,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -3143,7 +3322,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -3156,7 +3339,11 @@ public class ISOUtilTest {
             ISOUtil.hexdump(b, 7, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "9", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "9", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 9 out of bounds for length 9", ex.getMessage());
+            }
         }
     }
 
@@ -3217,7 +3404,11 @@ public class ISOUtilTest {
             ISOUtil.hexString(b, 100, 1000);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "100", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "100", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 100 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -3228,7 +3419,11 @@ public class ISOUtilTest {
             ISOUtil.hexString(b, 0, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 1", ex.getMessage());
+            }
         }
     }
 
@@ -3655,7 +3850,11 @@ public class ISOUtilTest {
             ISOUtil.parseInt(cArray, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 
@@ -3666,7 +3865,11 @@ public class ISOUtilTest {
             ISOUtil.parseInt(cArray);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 
@@ -3677,7 +3880,11 @@ public class ISOUtilTest {
             ISOUtil.parseInt(bArray, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 
@@ -3688,7 +3895,11 @@ public class ISOUtilTest {
             ISOUtil.parseInt(bArray);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/RightTPadderTest.java
+++ b/jpos/src/test/java/org/jpos/iso/RightTPadderTest.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_1_8;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.junit.Test;
 
 public class RightTPadderTest {
@@ -61,7 +64,11 @@ public class RightTPadderTest {
             new RightTPadder(' ').pad("testRightTPadderData", -1);
             fail("Expected StringIndexOutOfBoundsException to be thrown");
         } catch (StringIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "String index out of range: -1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_1_8)) {
+                assertEquals("ex.getMessage()", "String index out of range: -1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "begin 0, end -1, length 20", ex.getMessage());
+            }
         }
     }
 }

--- a/jpos/src/test/java/org/jpos/iso/SignedEbcdicNumberInterpreter2Test.java
+++ b/jpos/src/test/java/org/jpos/iso/SignedEbcdicNumberInterpreter2Test.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.junit.Test;
 
 public class SignedEbcdicNumberInterpreter2Test {
@@ -111,7 +114,11 @@ public class SignedEbcdicNumberInterpreter2Test {
             new SignedEbcdicNumberInterpreter().uninterpret(rawData, 100, 1000);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1099", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1099", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1099 out of bounds for length 3", ex.getMessage());
+            }
             assertEquals("rawData.length", 3, rawData.length);
         }
     }

--- a/jpos/src/test/java/org/jpos/iso/channel/VAPChannelTest.java
+++ b/jpos/src/test/java/org/jpos/iso/channel/VAPChannelTest.java
@@ -27,6 +27,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import java.net.ServerSocket;
 
 import org.jpos.core.Configuration;
@@ -161,7 +164,11 @@ public class VAPChannelTest {
             vAPChannel.sendMessageHeader(m, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -299,7 +306,11 @@ public class VAPChannelTest {
             vAPChannel.shouldIgnore(b);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 }

--- a/jpos/src/test/java/org/jpos/iso/filter/StatefulFilterTest.java
+++ b/jpos/src/test/java/org/jpos/iso/filter/StatefulFilterTest.java
@@ -27,6 +27,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.jpos.core.Configuration;
 import org.jpos.core.SimpleConfiguration;
 import org.jpos.core.SubConfiguration;
@@ -413,7 +416,11 @@ public class StatefulFilterTest {
 	    new StatefulFilter().getIgnoredField(100);
 	    fail("Expected ArrayIndexOutOfBoundsException to be thrown");
 	} catch (ArrayIndexOutOfBoundsException ex) {
-	    assertEquals("ex.getMessage()", "100", ex.getMessage());
+		if (isJavaVersionAtMost(JAVA_10)) {
+			assertEquals("ex.getMessage()", "100", ex.getMessage());
+	    } else {
+			assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+	    }
 	}
     }
 
@@ -491,7 +498,11 @@ public class StatefulFilterTest {
 	    statefulFilter.getKey(100);
 	    fail("Expected ArrayIndexOutOfBoundsException to be thrown");
 	} catch (ArrayIndexOutOfBoundsException ex) {
-	    assertEquals("ex.getMessage()", "100", ex.getMessage());
+		if (isJavaVersionAtMost(JAVA_10)) {
+			assertEquals("ex.getMessage()", "100", ex.getMessage());
+	    } else {
+			assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+	    }
 	}
     }
 
@@ -548,7 +559,11 @@ public class StatefulFilterTest {
 	    statefulFilter2.getSavedField(100);
 	    fail("Expected ArrayIndexOutOfBoundsException to be thrown");
 	} catch (ArrayIndexOutOfBoundsException ex) {
-	    assertEquals("ex.getMessage()", "100", ex.getMessage());
+		if (isJavaVersionAtMost(JAVA_10)) {
+			assertEquals("ex.getMessage()", "100", ex.getMessage());
+	    } else {
+			assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+	    }
 	}
     }
 
@@ -619,7 +634,11 @@ public class StatefulFilterTest {
 	    statefulFilter.setIgnoredField(100, 1000);
 	    fail("Expected ArrayIndexOutOfBoundsException to be thrown");
 	} catch (ArrayIndexOutOfBoundsException ex) {
-	    assertEquals("ex.getMessage()", "100", ex.getMessage());
+		if (isJavaVersionAtMost(JAVA_10)) {
+			assertEquals("ex.getMessage()", "100", ex.getMessage());
+	    } else {
+			assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+	    }
 	    assertSame("m_statefulFilter.getIgnoredFields()", ignoredFields,
 		    statefulFilter.getIgnoredFields());
 	}
@@ -684,7 +703,11 @@ public class StatefulFilterTest {
 	    statefulFilter.setKey(100, 1000);
 	    fail("Expected ArrayIndexOutOfBoundsException to be thrown");
 	} catch (ArrayIndexOutOfBoundsException ex) {
-	    assertEquals("ex.getMessage()", "100", ex.getMessage());
+		if (isJavaVersionAtMost(JAVA_10)) {
+			assertEquals("ex.getMessage()", "100", ex.getMessage());
+	    } else {
+			assertEquals("ex.getMessage()", "Index 100 out of bounds for length 1", ex.getMessage());
+	    }
 	    assertSame("m_statefulFilter.getKey()", key,
 		    statefulFilter.getKey());
 	}
@@ -738,7 +761,11 @@ public class StatefulFilterTest {
 	    statefulFilter.setSavedField(100, 1000);
 	    fail("Expected ArrayIndexOutOfBoundsException to be thrown");
 	} catch (ArrayIndexOutOfBoundsException ex) {
-	    assertEquals("ex.getMessage()", "100", ex.getMessage());
+		if (isJavaVersionAtMost(JAVA_10)) {
+			assertEquals("ex.getMessage()", "100", ex.getMessage());
+	    } else {
+			assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+	    }
 	    assertSame("m_statefulFilter.getSavedFields()", savedFields,
 		    statefulFilter.getSavedFields());
 	}

--- a/jpos/src/test/java/org/jpos/iso/header/BASE1HeaderTest.java
+++ b/jpos/src/test/java/org/jpos/iso/header/BASE1HeaderTest.java
@@ -18,6 +18,9 @@
 
 package org.jpos.iso.header;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.jpos.iso.ISOUtil;
 import org.junit.Test;
 
@@ -52,7 +55,11 @@ public class BASE1HeaderTest {
             new BASE1Header("testBASE1HeaderSource", "");
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "arraycopy: last source index 3 out of bounds for byte[0]", ex.getMessage());
+            }
         }
     }
 
@@ -62,7 +69,11 @@ public class BASE1HeaderTest {
             new BASE1Header("", "testBASE1HeaderDestination");
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "arraycopy: last source index 3 out of bounds for byte[0]", ex.getMessage());
+            }
         }
     }
 
@@ -110,7 +121,11 @@ public class BASE1HeaderTest {
             bASE1Header.getFormat();
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -129,7 +144,11 @@ public class BASE1HeaderTest {
             bASE1Header.getHLen();
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 
@@ -227,7 +246,11 @@ public class BASE1HeaderTest {
             bASE1Header.setBatchNumber(100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "17", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "17", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 17 out of bounds for length 3", ex.getMessage());
+            }
             assertTrue("bASE1Header.header", Arrays.equals(header, bASE1Header.header));
         }
     }
@@ -247,7 +270,11 @@ public class BASE1HeaderTest {
             new BASE1Header().setDestination("");
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "arraycopy: last source index 3 out of bounds for byte[0]", ex.getMessage());
+            }
         }
     }
 
@@ -277,7 +304,11 @@ public class BASE1HeaderTest {
             bASE1Header.setFlags(100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "12", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "12", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 12 out of bounds for length 9", ex.getMessage());
+            }
             assertTrue("bASE1Header.header", Arrays.equals(header, bASE1Header.header));
         }
     }
@@ -291,7 +322,11 @@ public class BASE1HeaderTest {
             bASE1Header.setFlags(100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "13", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "13", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 13 out of bounds for length 13", ex.getMessage());
+            }
             assertNotEquals("bASE1Header.header", header, bASE1Header.header);
         }
     }
@@ -312,7 +347,11 @@ public class BASE1HeaderTest {
             bASE1Header.setFormat(100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "2", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "2", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 2 out of bounds for length 2", ex.getMessage());
+            }
             assertNotEquals("bASE1Header.header", header, bASE1Header.header);
         }
     }
@@ -340,7 +379,11 @@ public class BASE1HeaderTest {
             bASE1Header.setLen(100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "4", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "4", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 4 out of bounds for length 4", ex.getMessage());
+            }
             assertTrue("bASE1Header.header", Arrays.equals(header, bASE1Header.header));
         }
     }
@@ -354,7 +397,11 @@ public class BASE1HeaderTest {
             clone.setLen(100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "3", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "3", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 3 out of bounds for length 3", ex.getMessage());
+            }
             assertTrue("clone.header", Arrays.equals(header, clone.header));
         }
     }
@@ -377,7 +424,11 @@ public class BASE1HeaderTest {
             bASE1Header.setRtCtl(100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "11", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "11", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 11 out of bounds for length 2", ex.getMessage());
+            }
             assertTrue("bASE1Header.header", Arrays.equals(header, bASE1Header.header));
         }
     }
@@ -397,7 +448,11 @@ public class BASE1HeaderTest {
             new BASE1Header().setSource("");
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "arraycopy: last source index 3 out of bounds for byte[0]", ex.getMessage());
+            }
         }
     }
 
@@ -429,7 +484,11 @@ public class BASE1HeaderTest {
             bASE1Header.setStatus(100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "15", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "15", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 15 out of bounds for length 15", ex.getMessage());
+            }
         }
     }
 
@@ -442,7 +501,11 @@ public class BASE1HeaderTest {
             bASE1Header.setStatus(100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "14", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "14", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 14 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/packager/Base1SubFieldPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/Base1SubFieldPackagerTest.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.jpos.iso.ISOFieldPackager;
 import org.jpos.iso.ISOMsg;
 import org.jpos.iso.X92_BITMAP;
@@ -60,8 +63,11 @@ public class Base1SubFieldPackagerTest {
             f126Packager.emitBitMap();
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
-
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/packager/Base1_BITMAP126Test.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/Base1_BITMAP126Test.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import java.util.BitSet;
 
 import org.jpos.iso.ISOBinaryField;
@@ -94,7 +97,11 @@ public class Base1_BITMAP126Test {
             new Base1_BITMAP126().unpack(c, b, 100);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "100", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "100", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 100 out of bounds for length 0", ex.getMessage());
+            }
             assertEquals("(ISOMsg) c.getDirection()", 0, ((ISOMsg) c).getDirection());
         }
     }

--- a/jpos/src/test/java/org/jpos/iso/packager/CTCSubElementPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/CTCSubElementPackagerTest.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.jpos.iso.IFA_AMOUNT;
 import org.jpos.iso.IFA_LCHAR;
 import org.jpos.iso.IFA_LLBNUM;
@@ -119,7 +122,11 @@ public class CTCSubElementPackagerTest {
             cTCSubElementPackager.unpack(new ISOMsg(), b);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/packager/GenericPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/GenericPackagerTest.java
@@ -24,6 +24,9 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.util.EmptyStackException;
@@ -274,7 +277,11 @@ public class GenericPackagerTest {
                     "testGenericContentHandlerQName", null);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
         }
     }
@@ -288,7 +295,11 @@ public class GenericPackagerTest {
                     "testGenericContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
             assertEquals("(AttributesImpl) atts.getLength()", 0, atts.getLength());
         }
@@ -303,7 +314,11 @@ public class GenericPackagerTest {
                     .startElement("testGenericContentHandlerNamespaceURI", null, "testGenericContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
         }
     }
@@ -317,7 +332,11 @@ public class GenericPackagerTest {
                     "testGenericContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
             assertEquals("(AttributesImpl) atts.getLength()", 0, atts.getLength());
         }
@@ -332,7 +351,11 @@ public class GenericPackagerTest {
                     "testGenericContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertEquals("ex.getMessage()", "null", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "null", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NumberFormatException: null", ex.getMessage());
+            }
             assertEquals("ex.getException().getMessage()", "null", ex.getException().getMessage());
         }
     }
@@ -357,7 +380,11 @@ public class GenericPackagerTest {
             genericPackager.getBitMapfieldPackager();
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 1 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/packager/GenericValidatingPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/GenericValidatingPackagerTest.java
@@ -26,6 +26,9 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import java.io.ByteArrayInputStream;
 import java.util.EmptyStackException;
 import java.util.HashMap;
@@ -375,7 +378,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertEquals("ex.getMessage()", "null", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "null", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NumberFormatException: null", ex.getMessage());
+            }
             assertEquals("ex.getException().getMessage()", "null", ex.getException().getMessage());
             assertEquals("(AttributesImpl) atts.getLength()", 0, atts.getLength());
         }
@@ -390,7 +397,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
             assertEquals("(AttributesImpl) atts.getLength()", 0, atts.getLength());
         }
@@ -405,7 +416,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
         }
     }
@@ -418,7 +433,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", null);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
         }
     }
@@ -432,7 +451,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
         }
     }
@@ -445,7 +468,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", null);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
         }
     }
@@ -458,7 +485,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", null);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
         }
     }
@@ -472,7 +503,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
             assertEquals("(AttributesImpl) atts.getLength()", 0, atts.getLength());
         }
@@ -486,7 +521,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", null);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
         }
     }
@@ -500,7 +539,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
             assertEquals("(AttributesImpl) atts.getLength()", 0, atts.getLength());
         }
@@ -515,7 +558,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", null);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
         }
     }
@@ -529,7 +576,11 @@ public class GenericValidatingPackagerTest {
                     "testGenericValidatorContentHandlerQName", atts);
             fail("Expected SAXException to be thrown");
         } catch (SAXException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "java.lang.NullPointerException", ex.getMessage());
+            }
             assertNull("ex.getException().getMessage()", ex.getException().getMessage());
             assertEquals("(AttributesImpl) atts.getLength()", 0, atts.getLength());
         }

--- a/jpos/src/test/java/org/jpos/q2/qbean/QExecTest.java
+++ b/jpos/src/test/java/org/jpos/q2/qbean/QExecTest.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.junit.Test;
 
 public class QExecTest {
@@ -98,7 +101,11 @@ public class QExecTest {
             qExec.stopService();
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "0", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "0", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 0 out of bounds for length 0", ex.getMessage());
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCEHandlerTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCEHandlerTest.java
@@ -25,6 +25,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import java.security.Key;
 import java.security.Provider;
 
@@ -196,7 +199,11 @@ public class JCEHandlerTest {
             new JCEHandler((Provider) null).encryptDESKey((short) 64, clearDESKey, encryptingKey);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "arraycopy: last source index 8 out of bounds for byte[1]", ex.getMessage());
+            }
             assertEquals("(SecretKeySpec) clearDESKey.getAlgorithm()", "DESde", clearDESKey.getAlgorithm());
             assertEquals("(SecretKeySpec) encryptingKey.getAlgorithm()", "testJCEHandlerParam2",
                     encryptingKey.getAlgorithm());
@@ -240,7 +247,11 @@ public class JCEHandlerTest {
             jCEHandler2.extractDESKeyMaterial((short) 128, clearDESKey);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "arraycopy: last source index 16 out of bounds for byte[1]", ex.getMessage());
+            }
             assertEquals("(SecretKeySpec) clearDESKey.getAlgorithm()", "DESede", clearDESKey.getAlgorithm());
         }
     }
@@ -306,7 +317,11 @@ public class JCEHandlerTest {
             jCEHandler.formDESKey((short) 128, clearKeyBytes);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertNull("ex.getMessage()", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertNull("ex.getMessage()", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "arraycopy: last source index 16 out of bounds for byte[1]", ex.getMessage());
+            }
         }
     }
 

--- a/jpos/src/test/java/org/jpos/space/JDBMSpaceTest.java
+++ b/jpos/src/test/java/org/jpos/space/JDBMSpaceTest.java
@@ -24,6 +24,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_10;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+
 import org.junit.Test;
 
 public class JDBMSpaceTest {
@@ -49,7 +52,11 @@ public class JDBMSpaceTest {
             JDBMSpace.getLong(b, -1);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index -1 out of bounds for length 9", ex.getMessage());
+            }
         }
     }
 
@@ -60,7 +67,11 @@ public class JDBMSpaceTest {
             JDBMSpace.getLong(b, -4);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index -1 out of bounds for length 7", ex.getMessage());
+            }
         }
     }
 
@@ -71,7 +82,11 @@ public class JDBMSpaceTest {
             JDBMSpace.getLong(b, -6);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index -1 out of bounds for length 5", ex.getMessage());
+            }
         }
     }
 
@@ -82,7 +97,11 @@ public class JDBMSpaceTest {
             JDBMSpace.getLong(b, -7);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index -1 out of bounds for length 2", ex.getMessage());
+            }
         }
     }
 
@@ -93,7 +112,11 @@ public class JDBMSpaceTest {
             JDBMSpace.getLong(b, -2);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index -1 out of bounds for length 8", ex.getMessage());
+            }
         }
     }
 
@@ -104,7 +127,11 @@ public class JDBMSpaceTest {
             JDBMSpace.getLong(b, -3);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index -1 out of bounds for length 5", ex.getMessage());
+            }
         }
     }
 
@@ -115,7 +142,11 @@ public class JDBMSpaceTest {
             JDBMSpace.getLong(b, -5);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index -1 out of bounds for length 3", ex.getMessage());
+            }
         }
     }
 
@@ -181,7 +212,11 @@ public class JDBMSpaceTest {
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
             assertEquals("b[0]", (byte) 0, b[0]);
-            assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "-1", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index -1 out of bounds for length 2", ex.getMessage());
+            }
             assertEquals("b.length", 2, b.length);
         }
     }
@@ -193,7 +228,11 @@ public class JDBMSpaceTest {
             JDBMSpace.putLong(b, 100, 100L);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "107", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "107", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 107 out of bounds for length 3", ex.getMessage());
+            }
             assertEquals("b.length", 3, b.length);
         }
     }
@@ -241,7 +280,11 @@ public class JDBMSpaceTest {
             ref.deserialize(serialized);
             fail("Expected ArrayIndexOutOfBoundsException to be thrown");
         } catch (ArrayIndexOutOfBoundsException ex) {
-            assertEquals("ex.getMessage()", "7", ex.getMessage());
+            if (isJavaVersionAtMost(JAVA_10)) {
+                assertEquals("ex.getMessage()", "7", ex.getMessage());
+            } else {
+                assertEquals("ex.getMessage()", "Index 7 out of bounds for length 2", ex.getMessage());
+            }
             assertEquals("ref.recid", 100L, ref.recid);
             assertEquals("ref.expires", 1000L, ref.expires);
             assertEquals("ref.next", -1L, ref.next);


### PR DESCRIPTION
This includes #222 .

Most test failures were just due to exception message syntax changes which is straightforward to handle without breaking compatibility with jdk8.