### PR TITLE
Lower default je cache percentage and make it configurable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ dist: trusty
 language: java
 jdk:
 - oraclejdk8
-before_script:
-- echo $JAVA_OPTS
-- export JAVA_OPTS=-Xmx4G
 install: true
 script:
 - sudo apt-get update && sudo apt-get install oracle-java8-installer
@@ -16,7 +13,9 @@ after_success: .travis/update-gh-pages.sh
 after_failure: .travis/update-gh-pages.sh
 env:
   global:
-    secure: ZWDnTNCsRaxOV4hPiWslj1ieKwYjuxBA4COHFVApxr8TBcQEwhPAzo+b+WbDsi45rJkk/Ee9Du0+mbT//x3TTK78fePg6EDk0WBSmWRUFC3eITgTmUJe7Qh5VOUZOdz9vFaYH8080/CB4VyygJuSp2XLte+S/MVSoXVVABrNggU=
+    - JAVA_OPTS="-Xmx4G -XX:+UseCompressedOops"
+    - GRADLE_OPTS="-Xmx4G -XX:+UseCompressedOops"
+    - secure: ZWDnTNCsRaxOV4hPiWslj1ieKwYjuxBA4COHFVApxr8TBcQEwhPAzo+b+WbDsi45rJkk/Ee9Du0+mbT//x3TTK78fePg6EDk0WBSmWRUFC3eITgTmUJe7Qh5VOUZOdz9vFaYH8080/CB4VyygJuSp2XLte+S/MVSoXVVABrNggU=
 notifications:
   slack:
     secure: opKU+4jJWYuhq5STCVW2cvxEq/1/xY17xpxGKoJXWA+RbhPo+viT5uJLmb67HwdmvQNwUVAW6uOLO7SDOmpGh5oAwpI74DrA0y6uEzN6GgzutZDBY5oCMRYCGi/5xNOuzDdsryDtSJvXWLxyCysnTrAqqQ9XdOnRK/ZqSIeQg+s=

--- a/jpos/src/main/java/org/jpos/space/JESpace.java
+++ b/jpos/src/main/java/org/jpos/space/JESpace.java
@@ -62,6 +62,7 @@ public class JESpace<K,V> extends Log implements LocalSpace<K,V>, Loggeable, Run
     LocalSpace<Object,SpaceListener> sl;
     private static final long NRD_RESOLUTION = 500L;
     public static final long GC_DELAY = 15*1000L;
+    public static final int DEFAULT_CACHE_PERCENT = 25;
     public static final long DEFAULT_TXN_TIMEOUT = 30*1000L;
     public static final long DEFAULT_LOCK_TIMEOUT = 120*1000L;
     private Future gcTask;
@@ -78,6 +79,7 @@ public class JESpace<K,V> extends Log implements LocalSpace<K,V>, Loggeable, Run
             String path = p[0];
             envConfig.setAllowCreate (true);
             envConfig.setTransactional(true);
+            envConfig.setCachePercent(getParam("cache.percent", p, DEFAULT_CACHE_PERCENT));
             envConfig.setLockTimeout(getParam("lock.timeout", p, DEFAULT_LOCK_TIMEOUT), TimeUnit.MILLISECONDS);
             envConfig.setTxnTimeout(getParam("txn.timeout", p, DEFAULT_TXN_TIMEOUT), TimeUnit.MILLISECONDS);
             storeConfig.setAllowCreate (true);
@@ -592,6 +594,17 @@ public class JESpace<K,V> extends Log implements LocalSpace<K,V>, Loggeable, Run
             p.printf ("%s<key size='%d'>%s</key>\n", indent, count, key);
         else
             p.printf ("%s<key>%s</key>\n", indent, key);
+    }
+
+    private int getParam (String name, String[] params, int defaultValue) {
+        for (String s : params) {
+            if (s.contains(name)) {
+                int pos = s.indexOf('=');
+                if (pos >=0 && s.length() > pos)
+                    return Integer.valueOf(s.substring(pos+1).trim());
+            }
+        }
+        return defaultValue;
     }
 
     private long getParam (String name, String[] params, long defaultValue) {


### PR DESCRIPTION
This is an attempt at fixing the frequent `java.lang.OutOfMemoryError` errors in travis.