### PR TITLE
Attempt to fix java.lang.OutOfMemoryError.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ jdk:
   - openjdk10
   - openjdk11
   - openjdk12
-before_script:
-  - echo $JAVA_OPTS
-  - export JAVA_OPTS=-Xmx4G
 install: true
 script:
   - java -version

--- a/build.gradle
+++ b/build.gradle
@@ -105,10 +105,25 @@ subprojects {
     }
     test {
         useJUnitPlatform()
+        maxHeapSize = "4g"
         testLogging {
             events "passed", "skipped", "failed"
         }
         systemProperty 'user.language', 'en'
+        exclude '**/JESpaceTestCase.*'
+        exclude '**/TransactionManagerTestCase.*'
+        dependsOn "JESpaceTest"
+    }
+    task JESpaceTest(type: Test) {
+        useJUnitPlatform()
+        maxHeapSize = "4g"
+        testLogging {
+            events "passed", "skipped", "failed"
+        }
+        systemProperty 'user.language', 'en'
+        include '**/JESpaceTestCase.*'
+        include '**/TransactionManagerTestCase.*'
+        forkEvery = 1
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.caching=true
 org.gradle.daemon=true
 org.gradle.parallel=true
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1G
 

--- a/jpos/src/main/java/org/jpos/q2/Q2.java
+++ b/jpos/src/main/java/org/jpos/q2/Q2.java
@@ -924,6 +924,7 @@ public class Q2 implements FileFilter, Runnable {
             try {
                 osgiFramework.stop();
                 osgiFramework.waitForStop(0L);
+                osgiFramework.uninstall();
             } catch (Exception e) {
                 getLog().warn(e);
             }

--- a/jpos/src/test/java/org/jpos/iso/packagers/PackagerTestCase.java
+++ b/jpos/src/test/java/org/jpos/iso/packagers/PackagerTestCase.java
@@ -27,7 +27,9 @@ import org.jpos.iso.TestUtils;
 import org.jpos.iso.packager.*;
 import org.jpos.util.Profiler;
 import org.jpos.util.TPS;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -37,6 +39,7 @@ import java.io.FileOutputStream;
 import java.util.Arrays;
 import java.util.Date;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PackagerTestCase {
     private XMLPackager xmlPackager;
     public static final String PREFIX = "build/resources/test/org/jpos/iso/packagers/";
@@ -76,9 +79,14 @@ public class PackagerTestCase {
         }
     }
 
-    @BeforeEach
+    @BeforeAll
     public void setUp () throws Exception {
         xmlPackager = new XMLPackager();
+    }
+    @AfterAll
+    public void tearDown() {
+        xmlPackager = null;
+        System.gc();
     }
     @Test
     public void testPostPackager () throws Exception {

--- a/jpos/src/test/java/org/jpos/q2/iso/QMUXTestCase.java
+++ b/jpos/src/test/java/org/jpos/q2/iso/QMUXTestCase.java
@@ -99,7 +99,8 @@ public class QMUXTestCase implements ISOResponseListener {
     public void tearDown() throws Exception {
         Thread.sleep(2000L); // let the thing run
         q2.shutdown(true);
-        Thread.sleep(2000L);
+        q2 = null;
+        System.gc();
     }
 
     private ISOMsg createMsg(String stan) throws ISOException {

--- a/jpos/src/test/java/org/jpos/space/JESpaceTestCase.java
+++ b/jpos/src/test/java/org/jpos/space/JESpaceTestCase.java
@@ -28,10 +28,13 @@ import org.jpos.iso.ISOMsg;
 import org.jpos.transaction.Context;
 import org.jpos.util.Profiler;
 import org.jpos.iso.ISOUtil;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class JESpaceTestCase {
     public static final int COUNT = 100;
     JESpace<String,Object> sp;
@@ -39,6 +42,13 @@ public class JESpaceTestCase {
     public void setUp () {
         sp = (JESpace<String,Object>) 
             JESpace.getSpace ("space-test", "build/resources/test/space-test");
+    }
+    @AfterAll
+    public void tearDown() {
+        sp.gc();
+        sp.close();
+        sp = null;
+        System.gc();
     }
     @Test
     public void testSimpleOut() throws Exception {

--- a/jpos/src/test/java/org/jpos/space/TSpaceTestCase.java
+++ b/jpos/src/test/java/org/jpos/space/TSpaceTestCase.java
@@ -48,6 +48,7 @@ public class TSpaceTestCase implements SpaceListener {
         }
         sp.gc();
         sp = null;
+        System.gc();
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/transaction/TransactionManagerTestCase.java
+++ b/jpos/src/test/java/org/jpos/transaction/TransactionManagerTestCase.java
@@ -62,5 +62,7 @@ public class TransactionManagerTestCase {
     public void tearDown() throws Exception {
         Thread.sleep (5000); // let the thing run
         q2.stop();
+        q2 = null;
+        System.gc();
     }
 }


### PR DESCRIPTION
Not sure if I caught all the sources of these errors but these changes seem to reduce how often they occur. I've been completely unable to reproduce any of these `java.lang.OutOfMemoryError` failures locally and am assuming that the main environment difference is that travis has very little CPU power allocated to run background garbage collection unlike my development systems.

It also seems to be nearly impossible to actually terminate all JESpace background threads and clean up resources properly, as a workaround I have those tests now running in isolated processes(#232 is that change separated out for reference).