### PR TITLE
Ensure tests using JESpace are run as separate processes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,19 @@ subprojects {
             events "passed", "skipped", "failed"
         }
         systemProperty 'user.language', 'en'
+        exclude '**/JESpaceTestCase.*'
+        exclude '**/TransactionManagerTestCase.*'
+        dependsOn "JESpaceTest"
+    }
+    task JESpaceTest(type: Test) {
+        useJUnitPlatform()
+        testLogging {
+            events "passed", "skipped", "failed"
+        }
+        systemProperty 'user.language', 'en'
+        include '**/JESpaceTestCase.*'
+        include '**/TransactionManagerTestCase.*'
+        forkEvery = 1
     }
 }
 


### PR DESCRIPTION
This might be enough by itself to fix most of the `java.lang.OutOfMemoryError` errors. I was attempting to find a way to kill the background threads in #231 but couldn't find a way to do that(that PR also includes this change).