### PR TITLE
Break on ConcurrentModificationException when logging in Logger.log

### DIFF
--- a/jpos/src/main/java/org/jpos/util/Logger.java
+++ b/jpos/src/main/java/org/jpos/util/Logger.java
@@ -25,6 +25,7 @@ import org.jpos.q2.Q2;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
 
@@ -97,6 +98,8 @@ public class Logger implements LogProducer,Configurable
             while (i.hasNext() && evt != null) {
                 try {
                     evt = ((LogListener) i.next()).log(evt);
+                } catch (ConcurrentModificationException e) {
+                    break;
                 } catch (Throwable t) {
                     evt.addMessage (t);
                 }


### PR DESCRIPTION
While `Logger.log` is running through a Logger's list of listeners and logging to each one, if that list is modified (such as when a LoggerAdaptor is undeployed and removes its listeners), then a `ConcurrentModificationException` is thrown. That Exception is attached to the `LogEvent`'s payload and the loop resumes, which throws another `ConcurrentModificationException` and it repeats until the `LogEvent`'s payload fills all of the available memory.

The change in this PR is to simply break when a `ConcurrentModificationException` occurs. Since this is in the logger, I'm not sure how to properly report any errors so I didn't add any additional checks.