### PR TITLE
Correct field 30: original amounts (a.k.a. replacement amounts)

### DIFF
--- a/jpos/src/main/resources/packager/cmf.xml
+++ b/jpos/src/main/resources/packager/cmf.xml
@@ -210,10 +210,11 @@
       class="org.jpos.iso.IFB_NUMERIC"/>
   <isofieldpackager
       id="30"
-      length="32"
+      length="16"
       name="Amounts original"
       class="org.jpos.iso.IFB_BINARY"
-      emitBitmap="false" 
+      emitBitmap="false"
+      firstField="0"
       packager="org.jpos.iso.packager.GenericSubFieldPackager">
       <isofield
           id="0"


### PR DESCRIPTION
- inner fields are 16 nibbles wide (i.e. 8 bytes) each
- first subfield is 0