### PR TITLE
XMLPackager and XML2003Packager refactoring

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/packager/XML2003Packager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/XML2003Packager.java
@@ -49,7 +49,7 @@ public class XML2003Packager extends DefaultHandler
     protected String realm = null;
     private ByteArrayOutputStream out;
     private PrintStream p;
-    private XMLReader reader = null;
+    private XMLReader reader;
     private Stack stk;
 
     public static final String ISOMSG_TAG    = "isomsg";
@@ -124,6 +124,7 @@ public class XML2003Packager extends DefaultHandler
             ISOMsg m1 = (ISOMsg) stk.pop();
             m.merge (m1);
             m.setHeader (m1.getHeader());
+
             fixup (m, BINARY_FIELDS);
 
             if (logger != null) 
@@ -187,13 +188,13 @@ public class XML2003Packager extends DefaultHandler
                 try {
                     fieldNumber = Integer.parseInt (id);
                 } catch (NumberFormatException ex) {
-                    throw new SAXException ("Invalid idr " + id);
+                    throw new SAXException ("Invalid id " + id);
                 }
             }
             if (name.equals (ISOMSG_TAG)) {
                 if (fieldNumber >= 0) {
                     if (stk.empty())
-                        throw new SAXException ("inner without outter");
+                        throw new SAXException ("inner without outer");
 
                     ISOMsg inner = new ISOMsg(fieldNumber);
                     ((ISOMsg)stk.peek()).set (inner);
@@ -215,6 +216,7 @@ public class XML2003Packager extends DefaultHandler
                             )
                         )
                     );
+
                 }
                 else if (TYPE_AMOUNT.equals (type)) {
                     ISOAmount amount = new ISOAmount(
@@ -286,7 +288,7 @@ public class XML2003Packager extends DefaultHandler
         }
     }
     private XMLReader createXMLReader () throws SAXException {
-        XMLReader reader = null;
+        XMLReader reader;
         try {
             reader = XMLReaderFactory.createXMLReader();
         } catch (SAXException e) {

--- a/jpos/src/main/java/org/jpos/iso/packager/XML2003Packager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/XML2003Packager.java
@@ -19,290 +19,32 @@
 package org.jpos.iso.packager;
 
 import org.jpos.iso.*;
-import org.jpos.iso.header.BaseHeader;
-import org.jpos.util.LogEvent;
-import org.jpos.util.LogSource;
-import org.jpos.util.Logger;
-import org.xml.sax.Attributes;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.DefaultHandler;
-import org.xml.sax.helpers.XMLReaderFactory;
 
-import java.io.*;
-import java.math.BigDecimal;
-import java.util.Stack;
 
 /**
  * packs/unpacks ISOMsgs into XML representation
  *
  * @author apr@cs.com.uy
- * @version $Id: XMLPackager.java 2594 2008-01-22 16:41:31Z apr $
+ * @version $Id$
  * @see ISOPackager
+ *
  */
-@SuppressWarnings("unchecked")
-public class XML2003Packager extends DefaultHandler
-                         implements ISOPackager, LogSource
+public class XML2003Packager extends XMLPackager
 {
-    protected Logger logger = null;
-    protected String realm = null;
-    private ByteArrayOutputStream out;
-    private PrintStream p;
-    private XMLReader reader;
-    private Stack stk;
-
-    public static final String ISOMSG_TAG    = "isomsg";
-    public static final String ISOFIELD_TAG  = "field";
-    public static final String ID_ATTR       = "id";
-    public static final String VALUE_ATTR    = "value";
-    public static final String TYPE_ATTR     = "type";
-    public static final String TYPE_BINARY   = "binary";
-    public static final String TYPE_BITMAP   = "bitmap";
-    public static final String TYPE_AMOUNT   = "amount";
-    public static final String CURRENCY_ATTR = "currency";
-    public static final String HEADER_TAG    = "header";
-    public static final int[] BINARY_FIELDS  = new int[] { 72 };
+    private final int[] BINARY_FIELDS  = new int[] { 72 };
 
     public XML2003Packager() throws ISOException {
         super();
-        out = new ByteArrayOutputStream();
+        forceBinary(BINARY_FIELDS);
+
+        // For backward compatibility with older implementation of XML2003Packager
+        // we revert certain restrictions that XMLPackager sets
         try {
-            p   = new PrintStream(out, false, "utf-8");
-        } catch (UnsupportedEncodingException ignored) {
-            // utf-8 is a supported encoding
-        }
-        stk = new Stack();
-        try {
-            reader = createXMLReader();
+            setXMLParserFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
+            setXMLParserFeature("http://xml.org/sax/features/external-general-entities", true);
+            setXMLParserFeature("http://xml.org/sax/features/external-parameter-entities", true);
         } catch (Exception e) {
-            throw new ISOException (e.toString());
+            throw new ISOException(e.toString(), e);
         }
-    }
-    public byte[] pack (ISOComponent c) throws ISOException {
-        LogEvent evt = new LogEvent (this, "pack");
-        try {
-            if (!(c instanceof ISOMsg))
-                throw new ISOException ("cannot pack "+c.getClass());
-            ISOMsg m = (ISOMsg) c;
-            byte[] b;
-            synchronized (this) {
-                m.setDirection(0);  // avoid "direction=xxxxxx" in XML msg
-                m.dump (p, "");
-                b = out.toByteArray();
-                out.reset();
-            }
-            if (logger != null)
-                evt.addMessage (m);
-            return b;
-        } catch (ISOException e) {
-            evt.addMessage (e);
-            throw e;
-        } finally {
-            Logger.log(evt);
-        }
-    }
-
-    public synchronized int unpack (ISOComponent c, byte[] b) 
-        throws ISOException
-    {
-        LogEvent evt = new LogEvent (this, "unpack");
-        try {
-            if (!(c instanceof ISOMsg))
-                throw new ISOException 
-                    ("Can't call packager on non Composite");
-
-            while (!stk.empty())    // purge from possible previous error
-                stk.pop();
-
-            InputSource src = new InputSource (new ByteArrayInputStream(b));
-            reader.parse (src);
-            if (stk.empty())
-                throw new ISOException ("error parsing");
-
-            ISOMsg m = (ISOMsg) c;
-            ISOMsg m1 = (ISOMsg) stk.pop();
-            m.merge (m1);
-            m.setHeader (m1.getHeader());
-
-            fixup (m, BINARY_FIELDS);
-
-            if (logger != null) 
-                evt.addMessage (m);
-            return b.length;
-        } catch (ISOException e) {
-            evt.addMessage (e);
-            throw e;
-        } catch (IOException e) {
-            evt.addMessage (e);
-            throw new ISOException (e.toString());
-        } catch (SAXException e) {
-            evt.addMessage (e);
-            throw new ISOException (e.toString());
-        } finally {
-            Logger.log (evt);
-        }
-    }
-
-    public synchronized void unpack (ISOComponent c, InputStream in) 
-        throws ISOException, IOException
-    {
-        LogEvent evt = new LogEvent (this, "unpack");
-        try {
-            if (!(c instanceof ISOMsg))
-                throw new ISOException 
-                    ("Can't call packager on non Composite");
-
-            while (!stk.empty())    // purge from possible previous error
-                stk.pop();
-
-            reader.parse (new InputSource (in));
-            if (stk.empty())
-                throw new ISOException ("error parsing");
-
-            ISOMsg m = (ISOMsg) c;
-            m.merge ((ISOMsg) stk.pop());
-            fixup (m, BINARY_FIELDS);
-
-            if (logger != null) 
-                evt.addMessage (m);
-        } catch (ISOException e) {
-            evt.addMessage (e);
-            throw e;
-        } catch (SAXException e) {
-            evt.addMessage (e);
-            throw new ISOException (e.toString());
-        } finally {
-            Logger.log (evt);
-        }
-    }
-
-    public void startElement 
-        (String ns, String name, String qName, Attributes atts)
-        throws SAXException
-    {
-        int fieldNumber = -1;
-        try {
-            String id       = atts.getValue(ID_ATTR);
-            if (id != null) {
-                try {
-                    fieldNumber = Integer.parseInt (id);
-                } catch (NumberFormatException ex) {
-                    throw new SAXException ("Invalid id " + id);
-                }
-            }
-            if (name.equals (ISOMSG_TAG)) {
-                if (fieldNumber >= 0) {
-                    if (stk.empty())
-                        throw new SAXException ("inner without outer");
-
-                    ISOMsg inner = new ISOMsg(fieldNumber);
-                    ((ISOMsg)stk.peek()).set (inner);
-                    stk.push (inner);
-                } else {
-                    stk.push (new ISOMsg(0));
-                }
-            } else if (name.equals (ISOFIELD_TAG)) {
-                ISOMsg m     = (ISOMsg) stk.peek();
-                String value = atts.getValue(VALUE_ATTR);
-                String type  = atts.getValue(TYPE_ATTR);
-                if (id == null || value == null)
-                    throw new SAXException ("invalid field");   
-                if (TYPE_BINARY.equals (type)) {
-                    m.set (new ISOBinaryField (
-                        fieldNumber, 
-                            ISOUtil.hex2byte (
-                                value.getBytes(), 0, value.length()/2
-                            )
-                        )
-                    );
-
-                }
-                else if (TYPE_AMOUNT.equals (type)) {
-                    ISOAmount amount = new ISOAmount(
-                        fieldNumber,
-                        Integer.parseInt (atts.getValue(CURRENCY_ATTR)),
-                        new BigDecimal (value)
-                    );
-                    m.set (amount);
-                }
-                else {
-                    m.set (new ISOField (fieldNumber, value));
-                }
-                
-            } else if (HEADER_TAG.equals (name)) {
-                stk.push (new BaseHeader());
-            }
-        } catch (ISOException e) {
-            throw new SAXException 
-                ("ISOException unpacking "+fieldNumber);
-        }
-    }
-    public void characters (char ch[], int start, int length) {
-        if (stk.peek() instanceof BaseHeader) {
-            ((BaseHeader)stk.peek()).unpack (
-                ISOUtil.hex2byte (new String(ch,start,length))
-            );
-        }
-    }
-    public void endElement (String ns, String name, String qname) 
-        throws SAXException
-    {
-        if (name.equals (ISOMSG_TAG)) {
-            ISOMsg m = (ISOMsg) stk.pop();
-            if (stk.empty())
-                stk.push (m); // push outter message
-        } else if (HEADER_TAG.equals (name)) {
-            BaseHeader h = (BaseHeader) stk.pop();
-            ISOMsg m = (ISOMsg) stk.peek ();
-            m.setHeader (h);
-        }
-    }
-
-    public String getFieldDescription(ISOComponent m, int fldNumber) {
-        return "Data element " + fldNumber;
-    }
-    public void setLogger (Logger logger, String realm) {
-        this.logger = logger;
-        this.realm  = realm;
-    }
-    public String getRealm () {
-        return realm;
-    }
-    public Logger getLogger() {
-        return logger;
-    }
-    public ISOMsg createISOMsg () {
-        return new ISOMsg();
-    }
-    public String getDescription () {
-        return getClass().getName();
-    }    
-    private void fixup (ISOMsg m, int[] bfields) throws ISOException {
-        for (int f : bfields) {
-            if (m.hasField(f)) {
-                ISOComponent c = m.getComponent(f);
-                if (c instanceof ISOField)
-                    m.set(f, ((ISOField) c).getBytes());
-            }
-        }
-    }
-    private XMLReader createXMLReader () throws SAXException {
-        XMLReader reader;
-        try {
-            reader = XMLReaderFactory.createXMLReader();
-        } catch (SAXException e) {
-            reader = XMLReaderFactory.createXMLReader (
-                System.getProperty( 
-                    "org.xml.sax.driver", 
-                    "org.apache.crimson.parser.XMLReaderImpl"
-                )
-            );
-        }
-        reader.setFeature ("http://xml.org/sax/features/validation",false);
-        reader.setContentHandler(this);
-        reader.setErrorHandler(this);
-        return reader;
     }
 }
-

--- a/jpos/src/main/java/org/jpos/iso/packager/XMLPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/XMLPackager.java
@@ -79,6 +79,12 @@ public class XMLPackager extends DefaultHandler
         stk = new Stack();
         try {
             reader = createXMLReader();
+
+            // some parser restrictions have been set for security and maybe PCI compliance
+            setXMLParserFeature("http://xml.org/sax/features/validation", false);
+            setXMLParserFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            setXMLParserFeature("http://xml.org/sax/features/external-general-entities", false);
+            setXMLParserFeature("http://xml.org/sax/features/external-parameter-entities", false);
         } catch (Exception e) {
             throw new ISOException (e.toString());
         }
@@ -340,13 +346,14 @@ public class XMLPackager extends DefaultHandler
                 )
             );
         }
-        reader.setFeature ("http://xml.org/sax/features/validation",false);
-        reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+
         reader.setContentHandler(this);
         reader.setErrorHandler(this);
         return reader;
+    }
+
+    public void setXMLParserFeature(String fname, boolean val) throws SAXException  {
+        reader.setFeature(fname, val);
     }
 }
 

--- a/jpos/src/main/java/org/jpos/iso/packager/XMLPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/XMLPackager.java
@@ -101,13 +101,13 @@ public class XMLPackager extends DefaultHandler
         }
     }
 
-    public synchronized int unpack (ISOComponent c, byte[] b) 
+    public synchronized int unpack (ISOComponent c, byte[] b)
         throws ISOException
     {
         LogEvent evt = new LogEvent (this, "unpack");
         try {
             if (!(c instanceof ISOMsg))
-                throw new ISOException 
+                throw new ISOException
                     ("Can't call packager on non Composite");
 
             while (!stk.empty())    // purge from possible previous error
@@ -123,7 +123,7 @@ public class XMLPackager extends DefaultHandler
             m.merge (m1);
             m.setHeader (m1.getHeader());
 
-            if (logger != null) 
+            if (logger != null)
                 evt.addMessage (m);
             return b.length;
         } catch (ISOException e) {
@@ -140,13 +140,13 @@ public class XMLPackager extends DefaultHandler
         }
     }
 
-    public synchronized void unpack (ISOComponent c, InputStream in) 
+    public synchronized void unpack (ISOComponent c, InputStream in)
         throws ISOException, IOException
     {
         LogEvent evt = new LogEvent (this, "unpack");
         try {
             if (!(c instanceof ISOMsg))
-                throw new ISOException 
+                throw new ISOException
                     ("Can't call packager on non Composite");
 
             while (!stk.empty())    // purge from possible previous error
@@ -161,7 +161,7 @@ public class XMLPackager extends DefaultHandler
             m.merge (m1);
             m.setHeader (m1.getHeader());
 
-            if (logger != null) 
+            if (logger != null)
                 evt.addMessage (m);
         } catch (ISOException e) {
             evt.addMessage (e);
@@ -174,7 +174,7 @@ public class XMLPackager extends DefaultHandler
         }
     }
 
-    public void startElement 
+    public void startElement
         (String ns, String name, String qName, Attributes atts)
         throws SAXException
     {
@@ -208,7 +208,7 @@ public class XMLPackager extends DefaultHandler
                 ISOComponent ic;
                 if (TYPE_BINARY.equals (type)) {
                     ic = new ISOBinaryField (
-                        fieldNumber, 
+                        fieldNumber,
                             ISOUtil.hex2byte (
                                 value.getBytes(), 0, value.length()/2
                             )
@@ -226,7 +226,7 @@ public class XMLPackager extends DefaultHandler
                 stk.push (bh);
             }
         } catch (ISOException e) {
-            throw new SAXException 
+            throw new SAXException
                 ("ISOException unpacking "+fieldNumber);
         }
     }
@@ -255,13 +255,13 @@ public class XMLPackager extends DefaultHandler
             }
         }
     }
-    public void endElement (String ns, String name, String qname) 
+    public void endElement (String ns, String name, String qname)
         throws SAXException
     {
         if (name.equals (ISOMSG_TAG)) {
             ISOMsg m = (ISOMsg) stk.pop();
             if (stk.empty())
-                stk.push (m); // push outter message
+                stk.push (m); // push outer message
         } else if (ISOFIELD_TAG.equals (name)) {
             stk.pop();
         } else if (HEADER_TAG.equals (name)) {
@@ -296,8 +296,8 @@ public class XMLPackager extends DefaultHandler
             reader = XMLReaderFactory.createXMLReader();
         } catch (SAXException e) {
             reader = XMLReaderFactory.createXMLReader (
-                System.getProperty( 
-                    "org.xml.sax.driver", 
+                System.getProperty(
+                    "org.xml.sax.driver",
                     "org.apache.crimson.parser.XMLReaderImpl"
                 )
             );

--- a/jpos/src/main/java/org/jpos/iso/packager/XMLPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/XMLPackager.java
@@ -236,7 +236,6 @@ public class XMLPackager extends DefaultHandler
                                 value.getBytes(), 0, value.length()/2
                             )
                         );
-
                 }
                 else if (TYPE_AMOUNT.equals (type)) {
                     ic =  new ISOAmount(

--- a/jpos/src/main/java/org/jpos/iso/packager/XMLPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/XMLPackager.java
@@ -31,6 +31,7 @@ import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
 
 import java.io.*;
+import java.math.BigDecimal;
 import java.util.Stack;
 
 /**
@@ -58,6 +59,8 @@ public class XMLPackager extends DefaultHandler
     public static final String TYPE_ATTR     = "type";
     public static final String TYPE_BINARY   = "binary";
     public static final String TYPE_BITMAP   = "bitmap";
+    public static final String TYPE_AMOUNT   = "amount";
+    public static final String CURRENCY_ATTR = "currency";
     public static final String HEADER_TAG    = "header";
     public static final String ENCODING_ATTR = "encoding";
     public static final String ASCII_ENCODING= "ascii";
@@ -184,7 +187,9 @@ public class XMLPackager extends DefaultHandler
             if (id != null) {
                 try {
                     fieldNumber = Integer.parseInt (id);
-                } catch (NumberFormatException ignored) { }
+                } catch (NumberFormatException ex) {
+                    throw new SAXException ("Invalid id " + id);
+                }
             }
             if (name.equals (ISOMSG_TAG)) {
                 if (fieldNumber >= 0) {
@@ -214,6 +219,13 @@ public class XMLPackager extends DefaultHandler
                             )
                         );
 
+                }
+                else if (TYPE_AMOUNT.equals (type)) {
+                    ic =  new ISOAmount(
+                        fieldNumber,
+                        Integer.parseInt (atts.getValue(CURRENCY_ATTR)),
+                        new BigDecimal (value)
+                    );
                 }
                 else {
                     ic = new ISOField (fieldNumber, ISOUtil.stripUnicode(value));
@@ -272,7 +284,7 @@ public class XMLPackager extends DefaultHandler
     }
 
     public String getFieldDescription(ISOComponent m, int fldNumber) {
-        return "<notavailable/>";
+        return "Data element " + fldNumber;
     }
     public void setLogger (Logger logger, String realm) {
         this.logger = logger;

--- a/jpos/src/test/java/org/jpos/iso/packager/XMLPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/XMLPackagerTest.java
@@ -125,7 +125,11 @@ public class XMLPackagerTest {
     public void testGetFieldDescription() throws Throwable {
         ISOComponent m = new ISOMsg(100);
         String result = xMLPackager.getFieldDescription(m, 100);
-        assertEquals("<notavailable/>", result, "result");
+        // old version
+        // assertEquals("<notavailable/>", result, "result");
+
+        // new version, inspired in XML2003Packager
+        assertEquals("Data element "+100, result, "result");
     }
 
     @Test


### PR DESCRIPTION
XMLPackager has inherited all features from XML2003Packager
XML2003Packager **actually** `inherits` from XMLPackager  :-)

Not much for XML2003Packager anymore, but let for compatibility (and it's more permissive with respect to parser restrictions that were recently added to XMLPackager)