### PR TITLE
Improved handling undefined tags by GenericTaggedFieldsPackager

### DIFF
--- a/compat_1_5_2/src/main/java/org/jpos/tpl/RowMap.java
+++ b/compat_1_5_2/src/main/java/org/jpos/tpl/RowMap.java
@@ -22,7 +22,7 @@ import org.jpos.iso.ISODate;
 
 import java.math.BigDecimal;
 import java.util.Date;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -35,7 +35,7 @@ import java.util.Map;
 public class RowMap {
     protected Map map;
     public RowMap () {
-        map = new Hashtable();
+        map = new HashMap();
     }
     public void set (String name, String value) {
         map.put (name, value != null ? "'"+escape(value)+"'" : "null");

--- a/compat_1_5_2/src/main/java/org/jpos/util/SimpleLockManager.java
+++ b/compat_1_5_2/src/main/java/org/jpos/util/SimpleLockManager.java
@@ -46,7 +46,7 @@ package org.jpos.util;
  * @version $Id$
  */
 
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Map;
 
 @SuppressWarnings("unchecked")
@@ -54,7 +54,7 @@ public class SimpleLockManager implements LockManager {
     Map locks;
 
     public SimpleLockManager () {
-        locks = new Hashtable();
+        locks = new HashMap();
     }
 
     public class SimpleTicket implements Ticket {

--- a/jpos/src/main/java/org/jpos/bsh/BSHLogListener.java
+++ b/jpos/src/main/java/org/jpos/bsh/BSHLogListener.java
@@ -29,8 +29,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /** This is a log listener that reads its actions from Bean Shell scripts.
  * You can define many scripts, and the order in wich they are called, also you
@@ -91,11 +92,12 @@ public class BSHLogListener implements org.jpos.util.LogListener, org.jpos.core.
     /**Holds the configuration for this object*/
     protected Configuration cfg;
     protected static final String[] patterns = {"tag", "realm"};
-    protected Map<String,ScriptInfo> scripts = new Hashtable<String,ScriptInfo>();
+    protected Map<String, ScriptInfo> scripts = new HashMap<>();
     /** Creates a new instance of BSHLogListener */
     public BSHLogListener() {
     }
-    
+
+    @Override
     public void setConfiguration(org.jpos.core.Configuration cfg) {
         this.cfg = cfg;
     }
@@ -122,6 +124,8 @@ public class BSHLogListener implements org.jpos.util.LogListener, org.jpos.core.
         }
         return ret;
     }
+
+    @Override
     public LogEvent log(LogEvent ev) {
         LogEvent ret = ev;
         boolean processed = false;
@@ -192,11 +196,14 @@ public class BSHLogListener implements org.jpos.util.LogListener, org.jpos.core.
         }
         return buf.toString();
     }
-    
+
     protected ScriptInfo getScriptInfo(String filename){
+        Objects.requireNonNull(filename, "The script file name cannot be null");
         return scripts.get(filename);
     }
+
     protected void addScriptInfo(String filename, String code, long lastModified){
+        Objects.requireNonNull(filename, "The script file name cannot be null");
         scripts.put(filename, new ScriptInfo(code, lastModified));
     }
     protected static class ScriptInfo{

--- a/jpos/src/main/java/org/jpos/iso/ISOComponent.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOComponent.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.util.Hashtable;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -101,11 +101,11 @@ public abstract class ISOComponent implements Cloneable {
         return 0;
     }
     /**
-     * dummy behaviour - return 0 elements Hashtable
+     * dummy behaviour - return empty map
      * @return children (in this case 0 children)
      */
     public Map getChildren() {
-        return new Hashtable();
+        return Collections.emptyMap();
     }
     /**
      * changes this Component field number<br>

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
@@ -37,7 +37,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.Map;

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericTaggedFieldsPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericTaggedFieldsPackager.java
@@ -139,9 +139,25 @@ public class GenericTaggedFieldsPackager extends GenericPackager
 
             for (int i : keys) {
                 c = fields.get(i);
-                if (fld[i] == null)
-                    // skip undefined
+                if (fld[i] == null) {
+                    // process undefined in packager
+                    if (!(c instanceof ISOField))
+                        // skip other than character fields
+                        continue;
+
+                    String tag = tagMapper.getTagForField(fieldId, i);
+                    if (tag == null)
+                        // skip when undefined and unmapped
+                        continue;
+
+                    CharTagMap tm = tagMapBuilder.build();
+                    @SuppressWarnings("unchecked")
+                    String value = (String) c.getValue();
+                    tm.addTag(tag, value);
+                    b = tm.pack().getBytes(ISOUtil.CHARSET);
+                    bout.write(b);
                     continue;
+                }
 
                 try {
                     b = fld[i].pack(c);

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericTaggedFieldsPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericTaggedFieldsPackager.java
@@ -24,8 +24,6 @@ import org.jpos.util.Logger;
 import org.xml.sax.Attributes;
 
 import java.io.ByteArrayOutputStream;
-import java.io.EOFException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Set;
@@ -119,59 +117,9 @@ public class GenericTaggedFieldsPackager extends GenericPackager
     }
 
     @Override
-    public void unpack(ISOComponent m, InputStream in) throws IOException, ISOException {
-        LogEvent evt = new LogEvent(this, "unpack");
-        try {
-            if (m.getComposite() != m)
-                throw new ISOException("Can't call packager on non Composite");
-
-            // if ISOMsg and headerLength defined
-            if (m instanceof ISOMsg && ((ISOMsg) m).getHeader() == null && headerLength > 0) {
-                byte[] h = new byte[headerLength];
-                in.read(h, 0, headerLength);
-                ((ISOMsg) m).setHeader(h);
-            }
-
-            if (!(fld[0] instanceof ISOMsgFieldPackager) &&
-                    !(fld[0] instanceof ISOBitMapPackager)) {
-                ISOComponent mti = fld[0].createComponent(0);
-                fld[0].unpack(mti, in);
-                m.set(mti);
-            }
-
-            int maxField = fld.length;
-            for (int i = getFirstField(); i < maxField; i++) {
-                if (fld[i] == null)
-                    continue;
-
-                ISOComponent c = fld[i].createComponent(i);
-                fld[i].unpack(c, in);
-                if (logger != null) {
-                    evt.addMessage("<unpack fld=\"" + i
-                            + "\" packager=\""
-                            + fld[i].getClass().getName() + "\">");
-                    if (c.getValue() instanceof ISOMsg)
-                        evt.addMessage(c.getValue());
-                    else
-                        evt.addMessage("  <value>"
-                                + c.getValue().toString()
-                                + "</value>");
-                    evt.addMessage("</unpack>");
-                }
-                m.set(c);
-
-            }
-        } catch (ISOException e) {
-            evt.addMessage(e);
-            throw e;
-        } catch (EOFException e) {
-            throw e;
-        } catch (Exception e) {
-            evt.addMessage(e);
-            throw new ISOException(e);
-        } finally {
-            Logger.log(evt);
-        }
+    public void unpack(ISOComponent m, InputStream in) {
+        // This method is not called anywhere so is usless
+        throw new UnsupportedOperationException("The on InputStream is not supported");
     }
 
     /**

--- a/jpos/src/main/java/org/jpos/security/CryptographicServiceMessage.java
+++ b/jpos/src/main/java/org/jpos/security/CryptographicServiceMessage.java
@@ -21,9 +21,12 @@ package org.jpos.security;
 import org.jpos.util.Loggeable;
 
 import java.io.PrintStream;
-import java.util.Hashtable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 /**
  * Cryptographic Service Message (CSM for short).
@@ -40,8 +43,8 @@ import java.util.Vector;
 
 @SuppressWarnings("unchecked")
 public class CryptographicServiceMessage implements Loggeable {
-    Hashtable fields = new Hashtable();
-    Vector orderedTags = new Vector();
+    Map<String, String> fields = new HashMap<>();
+    List<String> orderedTags = new ArrayList<>();
     String mcl;
 
     public static final String MCL_RSI = "RSI";
@@ -94,6 +97,8 @@ public class CryptographicServiceMessage implements Loggeable {
      * @throws NullPointerException if tag or content is null
      */
     public void addField(String tag, String content) {
+        Objects.requireNonNull(tag, "The tag is required");
+        Objects.requireNonNull(content, "The content is required");
         tag = tag.toUpperCase();
         fields.put(tag, content);
         orderedTags.add(tag);
@@ -105,7 +110,7 @@ public class CryptographicServiceMessage implements Loggeable {
      * @return field Field Content, or null if tag not found
      */
     public String getFieldContent(String tag) {
-        return (String) fields.get(tag.toUpperCase());
+        return fields.get(tag.toUpperCase());
     }
 
 
@@ -114,13 +119,13 @@ public class CryptographicServiceMessage implements Loggeable {
      * This is the inverse of parse
      * @return the CSM in string format
      */
+    @Override
     public String toString() {
         StringBuilder csm = new StringBuilder();
         csm.append("CSM(MCL/");
         csm.append(getMCL());
         csm.append(" ");
-        for (Object tagObject : orderedTags) {
-            String tag = (String) tagObject;
+        for (String tag : orderedTags) {
             csm.append(tag);
             csm.append("/");
             csm.append(getFieldContent(tag));
@@ -138,13 +143,13 @@ public class CryptographicServiceMessage implements Loggeable {
      * @param indent indention string, usually suppiled by Logger
      * @see org.jpos.util.Loggeable
      */
+    @Override
     public void dump (PrintStream p, String indent) {
         String inner = indent + "  ";
         p.print(indent + "<csm");
         p.print(" class=\"" + getMCL() + "\"");
         p.println(">");
-        for (Object tagObject : orderedTags) {
-            String tag = (String) tagObject;
+        for (String tag : orderedTags) {
             p.println(inner + "<field tag=\"" + tag + "\" value=\"" + getFieldContent(tag) + "\"/>");
         }
         p.println(indent + "</csm>");

--- a/jpos/src/main/java/org/jpos/security/SimpleKeyFile.java
+++ b/jpos/src/main/java/org/jpos/security/SimpleKeyFile.java
@@ -31,7 +31,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -69,25 +69,28 @@ public class SimpleKeyFile
         }
     }
 
+    @Override
     public void setLogger (Logger logger, String realm) {
         this.logger = logger;
         this.realm = realm;
     }
 
+    @Override
     public Logger getLogger () {
         return  logger;
     }
 
+    @Override
     public String getRealm () {
         return  realm;
     }
-
 
     /**
      *
      * @param cfg configuration object
      * @throws ConfigurationException
      */
+    @Override
     public void setConfiguration (Configuration cfg) throws ConfigurationException {
         try {
             init(cfg.get("key-file"));
@@ -97,6 +100,7 @@ public class SimpleKeyFile
         }
     }
 
+    @Override
     public synchronized SecureKey getKey (String alias) throws SecureKeyStoreException {
         SecureKey secureKey = null;
         LogEvent evt = logger != null ? new LogEvent(this, "get-key") : null;
@@ -129,6 +133,7 @@ public class SimpleKeyFile
         return  secureKey;
     }
 
+    @Override
     public synchronized void setKey (String alias, SecureKey secureKey) throws SecureKeyStoreException {
         LogEvent evt = new LogEvent(this, "set-key");
         evt.addMessage("alias", alias);
@@ -198,8 +203,9 @@ public class SimpleKeyFile
         props.setProperty(key, value);
     }
 
-    public Map<String,SecureKey> getKeys() throws SecureKeyStoreException {
-        Map<String,SecureKey> keys = new Hashtable<String,SecureKey>();
+    @Override
+    public Map<String, SecureKey> getKeys() throws SecureKeyStoreException {
+        Map<String, SecureKey> keys = new HashMap<>();
         for (Object k : props.keySet()) {
             String keyStr = (String) k;
             String alias = keyStr.substring(0, keyStr.lastIndexOf('.'));

--- a/jpos/src/main/java/org/jpos/tlv/CharTag.java
+++ b/jpos/src/main/java/org/jpos/tlv/CharTag.java
@@ -39,6 +39,8 @@ public class CharTag {
     private final String tagId;
     private final String value;
 
+    private boolean swapTagWithLength;
+
     /**
      * Internal Tag constructor.
      *
@@ -62,6 +64,15 @@ public class CharTag {
     }
 
     /**
+     * Swap tag with length.
+     *
+     * @param swap indicates if tag element will be swapped with length element
+     */
+    protected void withTagLengthSwap(boolean swap) {
+        swapTagWithLength = swap;
+    }
+
+    /**
      * Form TLV for this tag.
      *
      * @return TLV string
@@ -71,7 +82,13 @@ public class CharTag {
         if (value != null)
             vLen = value.length();
 
-        String tlv = tagId + ISOUtil.zeropad(vLen, lengthSize);
+        String length = ISOUtil.zeropad(vLen, lengthSize);
+        String tlv;
+        if (swapTagWithLength)
+            tlv = length + tagId;
+        else
+            tlv = tagId + length;
+
         if (vLen == 0)
             return tlv;
 

--- a/jpos/src/main/java/org/jpos/tlv/CharTag.java
+++ b/jpos/src/main/java/org/jpos/tlv/CharTag.java
@@ -1,0 +1,118 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2016 Alejandro P. Revilla
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.tlv;
+
+import org.jpos.iso.ISOUtil;
+
+/**
+ * Class represents TLV Tag stored as sequence of characters.
+ * <p>
+ * Processing format:
+ * <ul>
+ *   <li><tt>TAG</tt> - the identifier of the tag</li>
+ *   <li><tt>LEN</tt> - the length <i>(encoded as decimal digits)</i> of the tag value</li>
+ *   <li><tt>VAL</tt> - the value of the tag or missing if length is 0</li>
+ * </ul>
+ *
+ * @author Robert Demski <drdemsey@gmail.com>
+ */
+public class CharTag {
+
+    protected int lengthSize = 0x03;
+
+    private final String tagId;
+    private final String value;
+
+    /**
+     * Internal Tag constructor.
+     *
+     * @apiNote this is internal method should stay in protected scope
+     *
+     * @param tagId tag identifier, not {@code null}
+     * @param value tag value
+     */
+    protected CharTag(String tagId, String value) {
+        this.tagId = tagId;
+        this.value = value;
+    }
+
+    /**
+     * Sets size of length element.
+     *
+     * @param size size of length elament
+     */
+    protected void setLengthSize(int size) {
+        lengthSize = size;
+    }
+
+    /**
+     * Form TLV for this tag.
+     *
+     * @return TLV string
+     */
+    public String getTLV() {
+        int vLen = 0;
+        if (value != null)
+            vLen = value.length();
+
+        String tlv = tagId + ISOUtil.zeropad(vLen, lengthSize);
+        if (vLen == 0)
+            return tlv;
+
+        return tlv + value;
+    }
+
+    /**
+     * Gets tag identifier.
+     *
+     * @return tag identifier
+     */
+    public String getTagId() {
+        return tagId;
+    }
+
+    /**
+     * Gets tag value.
+     *
+     * @return tag value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        int vLen = 0;
+        if (value != null)
+            vLen = value.length();
+
+        int sbSize = tagId.length() + lengthSize + vLen + 32;
+        StringBuilder sb = new StringBuilder(sbSize)
+            .append("tag: ")
+            .append(tagId)
+            .append(", len: ")
+            .append(vLen);
+        if (vLen > 0)
+            sb.append(", value: ")
+              .append(value);
+
+        return sb.toString();
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/tlv/CharTagMap.java
+++ b/jpos/src/main/java/org/jpos/tlv/CharTagMap.java
@@ -1,0 +1,240 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2016 Alejandro P. Revilla
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.tlv;
+
+import java.math.BigDecimal;
+import java.nio.CharBuffer;
+import java.util.HashMap;
+
+/**
+ * Class represents TLV tag map encoded as sequence of characters.
+ * <p>
+ * The {@code CharTagMap} features:
+ * <ul>
+ *   <li>operates ({@code pack} and {@code unpack}) on character sequences
+ *   <li>only one occurrence of the tag in the sequence is possible
+ *   <li>after build the tag size and length size are fixed
+ *   <li>length is encoded as decimal characters
+ * </ul>
+ *
+ * @author Grzegorz Wieczorek <grw1@wp.pl>
+ */
+public class CharTagMap extends HashMap<String, CharTag> {
+
+    static final String EXCEPTION_PREFIX = "BAD TLV FORMAT:";
+
+    private int tagLen = 0x02;
+    private int lenLen = 0x03;
+
+    /**
+     * Creates new empty instance of text TLV tag map.
+     * <p>
+     * This method creates default TLV tag map which works on TLV data with
+     * followng parameters:
+     * <ul>
+     *   <li><em>TT</em> - 2 <tt>ASCII</tt> characters of tag identifier
+     *   <li><em>LLL</em> - 3 <tt>ASCII</tt> encoded decimal digits represents
+     *      tag value length
+     *   </li>
+     *   <li><em>VAL</em> - 0 or more <i>(up to 999)</i> <tt>ASCII</tt>
+     *      encoded characters represents tag value
+     *   </li>
+     * </ul>
+     * @return
+     */
+    public static CharTagMap getInstance() {
+        return new CharTagMap();
+    }
+
+    /**
+     * Sets size of tag element.
+     *
+     * @param size size of tag elament
+     */
+    protected void setTagSize(int size) throws IllegalArgumentException {
+        if (size < 1)
+            throw new IllegalArgumentException("The size of the tag should be greater than 0");
+
+        if (size > 4)
+            throw new IllegalArgumentException("The size of the tag should not be greater than 4");
+
+        tagLen = size;
+    }
+
+    /**
+     * Sets size of length element.
+     *
+     * @param size size of length elament
+     */
+    protected void setLengthSize(int size) throws IllegalArgumentException {
+        if (size < 1)
+            throw new IllegalArgumentException("The size of the length should be greater than 0");
+
+        if (size > 5)
+            throw new IllegalArgumentException("The size of the length should be less than 5");
+
+        lenLen = size;
+    }
+
+    /**
+     * Unpack string to TLV tag map.
+     *
+     * @param data sequence of characters encoded as TLV
+     * @throws IllegalArgumentException if {@code null} or parsing error occurs
+     */
+    public void unpack(CharSequence data) throws IllegalArgumentException {
+        if (data == null)
+            throw new IllegalArgumentException("TLV data are required to unpack");
+
+        CharBuffer buffer = CharBuffer.wrap(data);
+        CharTag currentTag;
+        while (buffer.hasRemaining()) {
+            currentTag = getTLVMsg(buffer);
+            put(currentTag.getTagId(), currentTag);
+        }
+    }
+
+    /**
+     * Pack TLV Tags.
+     *
+     * @return string containing tags in TLV Format
+     */
+    public String pack() {
+        StringBuilder sb = new StringBuilder();
+        for (CharTag tag : values())
+            sb.append(tag.getTLV());
+        return sb.toString();
+    }
+
+    /**
+     * Adds a new tag to map.
+     *
+     * @param tagId tag identifier, not {@code null}
+     * @param value tag value
+     * @return tag map instance for chaining
+     * @throws IllegalArgumentException if {@code tagId} is {@code null} or has
+     * invalid length.
+     */
+    public CharTagMap addTag(String tagId, String value) throws IllegalArgumentException {
+        put(tagId, createTLV(tagId, value));
+        return this;
+    }
+
+    /**
+     * Create new TLV tag.
+     *
+     * @param tagId tag identifier, not {@code null}
+     * @param value tag value
+     * @return TLV instance
+     * @throws IllegalArgumentException if {@code tagId} is {@code null} or has
+     * invalid length.
+     */
+    public CharTag createTLV(String tagId, String value) throws IllegalArgumentException {
+        validateTag(tagId);
+
+        int maxValueLength = (int) Math.pow(BigDecimal.TEN.doubleValue(), lenLen) - 1;
+        if (value != null && value.length() > maxValueLength)
+            throw new IllegalArgumentException(
+                String.format("The value size %d of the tag '%s' has"
+                        + " exceeded the maximum allowable value %d"
+                        , value.length(), tagId, maxValueLength
+                )
+            );
+
+        CharTag tag = new CharTag(tagId, value);
+        tag.setLengthSize(lenLen);
+        return tag;
+    }
+
+    protected void validateTag(String tagId) throws IllegalArgumentException {
+        if (tagId == null)
+            throw new IllegalArgumentException("Tag identifier have to be specified");
+
+        if (tagId.length() != tagLen)
+            throw new IllegalArgumentException(
+                String.format("Invalid tag '%s' size: expected %d, but got %d"
+                        , tagId, tagLen, tagId.length()
+                )
+            );
+    }
+
+    /**
+     * Gets the value of the tag with given tagId from map.
+     *
+     * @param tagId tag identifier
+     * @return value tag value
+     */
+    public String getTagValue(String tagId) {
+        CharTag t = get(tagId);
+        return t == null ? null : t.getValue();
+    }
+
+    /**
+     * Chceck if the tag with given tag identifier is in this tag map.
+     *
+     * @param tagId tag identifier
+     * @return {@code true} if this map contains the tag, otherwise return {@code false}
+     */
+    public boolean hasTag(String tagId) {
+        return containsKey(tagId);
+    }
+
+    private String stripTagId(CharBuffer buffer) throws IllegalArgumentException {
+        if (buffer.remaining() < tagLen)
+            throw new IllegalArgumentException(
+                String.format(
+                    "%s tag id requires %d characters", EXCEPTION_PREFIX, tagLen
+                )
+            );
+
+        return getStr(buffer, tagLen);
+    }
+
+    private int stripLength(CharBuffer buffer) throws IllegalArgumentException {
+        if (buffer.remaining() < lenLen)
+            throw new IllegalArgumentException(
+                String.format(
+                    "%s tag length requires %d digits", EXCEPTION_PREFIX, lenLen
+                )
+            );
+
+        return Integer.parseInt(getStr(buffer, lenLen));
+    }
+
+    private CharTag getTLVMsg(CharBuffer buffer) throws IllegalArgumentException {
+        String tagId = stripTagId(buffer);
+        int len = stripLength(buffer);
+        if (buffer.remaining() < len)
+            throw new IllegalArgumentException(
+                String.format("%s tag '%s' length '%03d' exceeds available"
+                        + " data length '%03d'.", EXCEPTION_PREFIX
+                        , tagId, len, buffer.remaining()
+                )
+            );
+        String value = getStr(buffer, len);
+        return createTLV(tagId, value);
+    }
+
+    private String getStr(CharBuffer buffer, int len) {
+        char[] ca = new char[len];
+        buffer.get(ca);
+        return String.valueOf(ca);
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/tlv/CharTagMap.java
+++ b/jpos/src/main/java/org/jpos/tlv/CharTagMap.java
@@ -42,6 +42,8 @@ public class CharTagMap extends HashMap<String, CharTag> {
     private int tagLen = 0x02;
     private int lenLen = 0x03;
 
+    private boolean swapTagWithLength;
+
     /**
      * Creates new empty instance of text TLV tag map.
      * <p>
@@ -90,6 +92,15 @@ public class CharTagMap extends HashMap<String, CharTag> {
             throw new IllegalArgumentException("The size of the length should be less than 5");
 
         lenLen = size;
+    }
+
+    /**
+     * Sets size of length element.
+     *
+     * @param swap indicates if tag element will be swapped with length element
+     */
+    protected void withTagLengthSwap(boolean swap) {
+        swapTagWithLength = swap;
     }
 
     /**
@@ -159,6 +170,7 @@ public class CharTagMap extends HashMap<String, CharTag> {
 
         CharTag tag = new CharTag(tagId, value);
         tag.setLengthSize(lenLen);
+        tag.withTagLengthSwap(swapTagWithLength);
         return tag;
     }
 
@@ -218,8 +230,16 @@ public class CharTagMap extends HashMap<String, CharTag> {
     }
 
     private CharTag getTLVMsg(CharBuffer buffer) throws IllegalArgumentException {
-        String tagId = stripTagId(buffer);
-        int len = stripLength(buffer);
+        String tagId;
+        int len;
+        if (swapTagWithLength) {
+            len = stripLength(buffer);
+            tagId = stripTagId(buffer);
+        } else {
+            tagId = stripTagId(buffer);
+            len = stripLength(buffer);
+        }
+
         if (buffer.remaining() < len)
             throw new IllegalArgumentException(
                 String.format("%s tag '%s' length '%03d' exceeds available"

--- a/jpos/src/main/java/org/jpos/tlv/CharTagMapBuilder.java
+++ b/jpos/src/main/java/org/jpos/tlv/CharTagMapBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2016 Alejandro P. Revilla
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.tlv;
+
+/**
+ * Builder to create TLV tag maps stored as sequence of characters.
+ *
+ * @author Robert Demski <drdemsey@gmail.com>
+ */
+public class CharTagMapBuilder {
+
+    protected Integer tagSize;
+    protected Integer lengthSize;
+
+    /**
+     * Constructs a new instance of the builder.
+     */
+    public CharTagMapBuilder() {
+        super();
+    }
+
+    /**
+     * Sets size of length element.
+     *
+     * @param size size of length elament
+     * @return this, for chaining, not {@code null}
+     */
+    public CharTagMapBuilder withLengthSize(int size) {
+        lengthSize = size;
+        return this;
+    }
+
+    /**
+     * Sets size of tag element.
+     *
+     * @param size size of length elament
+     * @return this, for chaining, not {@code null}
+     */
+    public CharTagMapBuilder withTagSize(int size) {
+        tagSize = size;
+        return this;
+    }
+
+    /**
+     * Completes this builder by creating the {@code CharTagMap}.
+     *
+     * @return the created tag map, not {@code null}
+     * @throws IllegalArgumentException if tag ma cannot be created
+     */
+    public CharTagMap build() throws IllegalArgumentException {
+        CharTagMap tm = CharTagMap.getInstance();
+        if (tagSize != null)
+            tm.setTagSize(tagSize);
+
+        if (lengthSize != null)
+            tm.setLengthSize(lengthSize);
+
+        return tm;
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/tlv/CharTagMapBuilder.java
+++ b/jpos/src/main/java/org/jpos/tlv/CharTagMapBuilder.java
@@ -19,7 +19,10 @@
 package org.jpos.tlv;
 
 /**
- * Builder to create TLV tag maps stored as sequence of characters.
+ * Builder to create TLV/LTV tag maps stored as sequence of characters.
+ * <p>
+ * Using {@code withTagLengthSwap(true)} while creating the builder causes
+ * switchs {@code CharTagMap} in LTV mode.
  *
  * @author Robert Demski <drdemsey@gmail.com>
  */
@@ -27,6 +30,8 @@ public class CharTagMapBuilder {
 
     protected Integer tagSize;
     protected Integer lengthSize;
+
+    protected boolean swapTagWithLength;
 
     /**
      * Constructs a new instance of the builder.
@@ -58,6 +63,17 @@ public class CharTagMapBuilder {
     }
 
     /**
+     * Swap Tag with Length.
+     *
+     * @param swap indicates if tag element will be swapped with length element
+     * @return this, for chaining, not {@code null}
+     */
+    public CharTagMapBuilder withTagLengthSwap(boolean swap) {
+        swapTagWithLength = swap;
+        return this;
+    }
+
+    /**
      * Completes this builder by creating the {@code CharTagMap}.
      *
      * @return the created tag map, not {@code null}
@@ -70,6 +86,8 @@ public class CharTagMapBuilder {
 
         if (lengthSize != null)
             tm.setLengthSize(lengthSize);
+
+        tm.withTagLengthSwap(swapTagWithLength);
 
         return tm;
     }

--- a/jpos/src/main/java/org/jpos/util/FilterLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/FilterLogListener.java
@@ -24,7 +24,8 @@ import org.jpos.core.ConfigurationException;
 
 import java.io.PrintStream;
 import java.util.Date;
-import java.util.Hashtable;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -39,16 +40,15 @@ import java.util.Hashtable;
 public class FilterLogListener implements LogListener,Configurable
 {
 
-    private static Hashtable levels;
+    private static final Map<String, Integer> LEVELS = new HashMap<>();
 
-    static{
-            levels = new Hashtable(6);
-            levels.put(Log.TRACE, 1);
-            levels.put(Log.DEBUG, 2);
-            levels.put(Log.INFO, 3);
-            levels.put(Log.WARN, 4);
-            levels.put(Log.ERROR, 5);
-            levels.put(Log.FATAL, 6);
+    static {
+            LEVELS.put(Log.TRACE, 1);
+            LEVELS.put(Log.DEBUG, 2);
+            LEVELS.put(Log.INFO, 3);
+            LEVELS.put(Log.WARN, 4);
+            LEVELS.put(Log.ERROR, 5);
+            LEVELS.put(Log.FATAL, 6);
     }
 
     private String priority = Log.INFO;
@@ -64,12 +64,13 @@ public class FilterLogListener implements LogListener,Configurable
         setPrintStream(p);
     }
 
+    @Override
     public void setConfiguration (Configuration cfg)
         throws ConfigurationException
     {
         try {
             String log_priority = cfg.get("priority");
-            if ( log_priority != null && !log_priority.trim().equals("") && levels.containsKey(log_priority) ) {
+            if ( log_priority != null && !log_priority.trim().equals("") && LEVELS.containsKey(log_priority) ) {
                 priority = log_priority;
             }
         } catch (Exception e) {
@@ -98,18 +99,18 @@ public class FilterLogListener implements LogListener,Configurable
         this.priority = priority;
     }
 
-    public boolean permitLogging(String tagLevel)
-    {
-        Integer I = (Integer)levels.get(tagLevel);
+    public boolean permitLogging(String tagLevel) {
+        Integer i = LEVELS.get(tagLevel);
 
-        if (I == null)
-            I = (Integer)levels.get(Log.INFO);
+        if (i == null)
+            i = LEVELS.get(Log.INFO);
 
-        Integer J = (Integer)levels.get(priority);
+        Integer j = LEVELS.get(priority);
 
-        return I >= J;
+        return i >= j;
     }
 
+    @Override
     public synchronized LogEvent log(LogEvent ev) {
         if (p != null && permitLogging(ev.getTag())) {
             Date d = new Date();

--- a/jpos/src/main/resources/org/jpos/iso/packager/genericpackager.dtd
+++ b/jpos/src/main/resources/org/jpos/iso/packager/genericpackager.dtd
@@ -36,3 +36,6 @@
 <!ATTLIST isofieldpackager firstField  CDATA        #IMPLIED>
 <!ATTLIST isofieldpackager headerLength  CDATA        #IMPLIED>
 <!ATTLIST isofieldpackager tagMapper     CDATA        #IMPLIED>
+<!ATTLIST isofieldpackager tagSize       CDATA        #IMPLIED>
+<!ATTLIST isofieldpackager lenSize       CDATA        #IMPLIED>
+<!ATTLIST isofieldpackager swapTagAndLen (true|false) #IMPLIED>

--- a/jpos/src/test/java/org/jpos/bsh/BSHLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/bsh/BSHLogListenerTest.java
@@ -54,8 +54,8 @@ public class BSHLogListenerTest {
             bSHLogListener.addScriptInfo(null, "testBSHLogListenerCode", 100L);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
-            assertNull(ex.getMessage(), "ex.getMessage()");
-            assertEquals(0, bSHLogListener.scripts.size(), "bSHLogListener.scripts.size()");
+            assertEquals("The script file name cannot be null", ex.getMessage());
+            assertEquals(0, bSHLogListener.scripts.size());
         }
     }
 
@@ -89,8 +89,8 @@ public class BSHLogListenerTest {
             bSHLogListener.getScriptInfo(null);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
-            assertNull(ex.getMessage(), "ex.getMessage()");
-            assertEquals(0, bSHLogListener.scripts.size(), "bSHLogListener.scripts.size()");
+            assertEquals("The script file name cannot be null", ex.getMessage());
+            assertEquals(0, bSHLogListener.scripts.size());
         }
     }
 

--- a/jpos/src/test/java/org/jpos/iso/packager/GenericValidatingPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/GenericValidatingPackagerTest.java
@@ -30,12 +30,11 @@ import static org.apache.commons.lang3.JavaVersion.JAVA_10;
 import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
 
 import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
 import java.util.EmptyStackException;
 import java.util.HashMap;
-import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.Vector;
 
 import org.jpos.iso.ISOBaseValidator;
 import org.jpos.iso.ISOException;
@@ -255,8 +254,8 @@ public class GenericValidatingPackagerTest {
     @Test
     public void testGenericValidatorContentHandlerMakeFieldValidatorArray1() throws Throwable {
         GenericValidatingPackager.GenericValidatorContentHandler genericValidatorContentHandler = new GenericValidatingPackager().new GenericValidatorContentHandler();
-        Hashtable tab = new Properties();
-        tab.put(Integer.valueOf(-4), new IVA_ALPHANUMNOBLANK(true, "testGenericValidatorContentHandlerDescription"));
+        Map tab = new HashMap();
+        tab.put(-4, new IVA_ALPHANUMNOBLANK(true, "testGenericValidatorContentHandlerDescription"));
         ISOFieldValidator[] result = genericValidatorContentHandler.makeFieldValidatorArray(tab);
         assertEquals(1, result.length, "result.length");
     }
@@ -265,9 +264,9 @@ public class GenericValidatingPackagerTest {
     @Test
     public void testGenericValidatorContentHandlerMakeFieldValidatorArray2() throws Throwable {
         GenericValidatingPackager.GenericValidatorContentHandler genericValidatorContentHandler = new GenericValidatingPackager().new GenericValidatorContentHandler();
-        Hashtable tab = new Hashtable(100);
-        tab.put(Integer.valueOf(-2), new IVA_ALPHANUMNOBLANK("testGenericValidatorContentHandlerDescription"));
-        tab.put(Integer.valueOf(-4), new IVA_ALPHANUMNOBLANK(100, 1000, "testGenericValidatorContentHandlerDescription"));
+        Map tab = new HashMap();
+        tab.put(-2, new IVA_ALPHANUMNOBLANK("testGenericValidatorContentHandlerDescription"));
+        tab.put(-4, new IVA_ALPHANUMNOBLANK(100, 1000, "testGenericValidatorContentHandlerDescription"));
         ISOFieldValidator[] result = genericValidatorContentHandler.makeFieldValidatorArray(tab);
         assertEquals(2, result.length, "result.length");
     }
@@ -276,18 +275,16 @@ public class GenericValidatingPackagerTest {
     @Test
     public void testGenericValidatorContentHandlerMakeFieldValidatorArray4() throws Throwable {
         GenericValidatingPackager.GenericValidatorContentHandler genericValidatorContentHandler = new GenericValidatingPackager().new GenericValidatorContentHandler();
-        ISOFieldValidator[] result = genericValidatorContentHandler.makeFieldValidatorArray(new Hashtable(100));
+        ISOFieldValidator[] result = genericValidatorContentHandler.makeFieldValidatorArray(new HashMap());
         assertEquals(0, result.length, "result.length");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testGenericValidatorContentHandlerMakeFieldValidatorArrayThrowsClassCastException1() throws Throwable {
         GenericValidatingPackager.GenericValidatorContentHandler genericValidatorContentHandler = new GenericValidatingPackager().new GenericValidatorContentHandler();
-        Map hashMap = new HashMap();
-        hashMap.put("", "testString");
-        Hashtable tab = new Hashtable(hashMap);
-        tab.put(Integer.valueOf(100), new IVA_ALPHANUMNOZERO_NOBLANK(true, "testGenericValidatorContentHandlerDescription"));
+        Map tab = new HashMap();
+        tab.put("", "testString");
+        tab.put(100, new IVA_ALPHANUMNOZERO_NOBLANK(true, "testGenericValidatorContentHandlerDescription"));
         try {
             genericValidatorContentHandler.makeFieldValidatorArray(tab);
             fail("Expected ClassCastException to be thrown");
@@ -301,7 +298,7 @@ public class GenericValidatingPackagerTest {
     @Test
     public void testGenericValidatorContentHandlerMakeFieldValidatorArrayThrowsClassCastException2() throws Throwable {
         GenericValidatingPackager.GenericValidatorContentHandler genericValidatorContentHandler = new GenericValidatingPackager().new GenericValidatorContentHandler();
-        Hashtable tab = new Hashtable(100);
+        Map tab = new HashMap();
         tab.put("testString", new Object());
         try {
             genericValidatorContentHandler.makeFieldValidatorArray(tab);
@@ -327,10 +324,10 @@ public class GenericValidatingPackagerTest {
     @Test
     public void testGenericValidatorContentHandlerMakeMsgValidatorArray() throws Throwable {
         GenericValidatingPackager.GenericValidatorContentHandler genericValidatorContentHandler = new GenericValidatingPackager().new GenericValidatorContentHandler();
-        Vector vector = new Vector();
-        vector.add(null);
-        Hashtable tab = new Hashtable(100);
-        tab.put(Integer.valueOf(-3), vector);
+        List list = new ArrayList();
+        list.add(null);
+        Map tab = new HashMap();
+        tab.put(-3, list);
         ISOBaseValidator[] result = genericValidatorContentHandler.makeMsgValidatorArray(tab);
         assertEquals(1, result.length, "result.length");
         assertNull(result[0], "result[0]");

--- a/jpos/src/test/java/org/jpos/iso/packager/TaggedFieldPackagerBaseTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/TaggedFieldPackagerBaseTest.java
@@ -128,6 +128,77 @@ public class TaggedFieldPackagerBaseTest {
     }
 
     @Test
+    public void testPackWithUndefied() throws Exception {
+        ISOMsg msg = new ISOMsg(MESSAGE_MTI1);
+        msg.set(2, "123456");
+
+        msg.set("48.1", "48TagA1");
+        msg.set("48.2", "48TagA2"); // undefined in packager
+        msg.set("48.3", "48TagA3");
+
+        msg.set("60.1", "60TagA1");
+
+        msg.setPackager(packager);
+        String expected = "06123456033A10748TagA1A20748TagA2A30748TagA3012A100760TagA1";
+        int expectedLength = MESSAGE_MTI1.length() + MESSAGE_BITMAP1.length + expected.length();
+
+        byte[] packed = msg.pack();
+
+        String packedAscii = toString(packed);
+        assertAll(
+            () -> assertEquals(expectedLength, packed.length),
+            () -> assertEquals(MESSAGE_MTI1, StringUtils.left(packedAscii, 4)),
+            () -> assertEquals(expected, StringUtils.right(packedAscii, expected.length()))
+        );
+    }
+
+    @Test
+    public void testPackWithUndefiedBinary() throws Exception {
+        ISOMsg msg = new ISOMsg(MESSAGE_MTI1);
+        msg.set(2, "123456");
+
+        msg.set("48.1", "48TagA1");
+        msg.set("48.2", "48TagA2".getBytes(ISOUtil.CHARSET)); // undefined in packager
+        msg.set("48.3", "48TagA3");
+
+        msg.set("60.1", "60TagA1");
+
+        msg.setPackager(packager);
+
+        byte[] packed = msg.pack();
+
+        String packedAscii = toString(packed);
+        assertAll(
+            () -> assertEquals(REPR_MESSAGE1.length(), packed.length),
+            () -> assertEquals(MESSAGE_MTI1, StringUtils.left(packedAscii, 4)),
+            () -> assertEquals(MESSAGE_VALUE1, StringUtils.right(packedAscii, 48))
+        );
+    }
+
+    @Test
+    public void testPackWithUndefiedAndUnmapped() throws Exception {
+        ISOMsg msg = new ISOMsg(MESSAGE_MTI1);
+        msg.set(2, "123456");
+
+        msg.set("48.0", "48TagA0"); // undefined in packager and unmapped
+        msg.set("48.1", "48TagA1");
+        msg.set("48.3", "48TagA3");
+
+        msg.set("60.1", "60TagA1");
+
+        msg.setPackager(packager);
+
+        byte[] packed = msg.pack();
+
+        String packedAscii = toString(packed);
+        assertAll(
+            () -> assertEquals(REPR_MESSAGE1.length(), packed.length),
+            () -> assertEquals(MESSAGE_MTI1, StringUtils.left(packedAscii, 4)),
+            () -> assertEquals(MESSAGE_VALUE1, StringUtils.right(packedAscii, 48))
+        );
+    }
+
+    @Test
     public void testUnpack() throws Exception {
         ISOMsg msg = new ISOMsg();
         packager.unpack(msg, toBytes(REPR_MESSAGE1));

--- a/jpos/src/test/java/org/jpos/iso/packager/TaggedFieldPackagerBaseTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/TaggedFieldPackagerBaseTest.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.jpos.iso.ISOPackager;
 import org.jpos.iso.ISOUtil;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 
 /**
  *
@@ -165,12 +164,29 @@ public class TaggedFieldPackagerBaseTest {
             () -> assertEquals("1100", msg.getString(0)),
             () -> assertEquals("123456", msg.getString(2)),
             () -> assertEquals("48TagA1", msg.getString("48.1")),
-            () -> assertNull(msg.getString("48.2")),
+            () -> assertEquals("48TagA2", msg.getString("48.2")),
             () -> assertEquals("60TagA1", msg.getString("60.1"))
         );
     }
 
-    @Disabled("Skipping undefined A2 is impossible in current solution so follwing A3 will be lost")
+    @Test
+    public void testUnpackUndefinedAndUnmappedTag() throws Exception {
+        ISOMsg msg = new ISOMsg();
+        String msgValue = "06123456022A00748TagA0A30748TagA3012A100760TagA1";
+        String reprMessage = MESSAGE_MTI1 + toString(MESSAGE_BITMAP1) + msgValue;
+        packager.unpack(msg, toBytes(reprMessage));
+
+        assertAll(
+            () -> assertEquals("1100", msg.getString(0)),
+            () -> assertEquals("123456", msg.getString(2)),
+            () -> assertNull(msg.getString("48.0")),
+            () -> assertNull(msg.getString("48.1")),
+            () -> assertNull(msg.getString("48.2")),
+            () -> assertEquals("48TagA3", msg.getString("48.3")),
+            () -> assertEquals("60TagA1", msg.getString("60.1"))
+        );
+    }
+
     @Test
     public void testUnpackUndefinedTagWithFollowing() throws Exception {
         ISOMsg msg = new ISOMsg();
@@ -179,7 +195,7 @@ public class TaggedFieldPackagerBaseTest {
         assertAll("Should unpack DE48.3 (A3) and any other standard elements",
             () -> assertEquals("1100", msg.getString(0)),
             () -> assertEquals("123456", msg.getString(2)),
-            () -> assertNull(msg.getString("48.2")),
+            () -> assertEquals("48TagA2", msg.getString("48.2")),
             () -> assertEquals("48TagA3", msg.getString("48.3")),
             () -> assertEquals("60TagA1", msg.getString("60.1"))
         );

--- a/jpos/src/test/java/org/jpos/iso/packager/VISA1PackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/VISA1PackagerTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
-import java.util.Vector;
+import java.io.ByteArrayOutputStream;
 
 import org.jpos.iso.ISOBitMap;
 import org.jpos.iso.ISOComponent;
@@ -116,8 +116,9 @@ public class VISA1PackagerTest {
         int[] sequence = new int[0];
         VISA1Packager vISA1Packager = new VISA1Packager(sequence, 100, "testVISA1PackagerBadResultCode",
                 "testVISA1PackagerOkPattern");
-        Vector v = new Vector(100, 1000);
-        int result = vISA1Packager.handleSpecialField35(new ISOMsg(100), v);
+        ByteArrayOutputStream bout = new ByteArrayOutputStream(100);
+
+        int result = vISA1Packager.handleSpecialField35(new ISOMsg(100), bout);
         assertEquals(0, result, "result");
     }
 
@@ -127,13 +128,14 @@ public class VISA1PackagerTest {
         int[] sequence = new int[0];
         VISA1Packager vISA1Packager = new VISA1Packager(sequence, 100, "testVISA1PackagerBadResultCode",
                 "testVISA1PackagerOkPattern");
-        Vector v = new Vector(100);
+        ByteArrayOutputStream bout = new ByteArrayOutputStream(100);
+
         try {
-            vISA1Packager.handleSpecialField35(null, v);
+            vISA1Packager.handleSpecialField35(null, bout);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
             assertNull(ex.getMessage(), "ex.getMessage()");
-            assertEquals(0, v.size(), "v.size()");
+            assertEquals(0, bout.toByteArray().length);
         }
     }
 

--- a/jpos/src/test/java/org/jpos/q2/QFactory2Test.java
+++ b/jpos/src/test/java/org/jpos/q2/QFactory2Test.java
@@ -26,8 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
-import java.util.Hashtable;
-
 import javax.management.ObjectName;
 
 import org.jdom2.Attribute;
@@ -88,11 +86,11 @@ public class QFactory2Test {
     @Test
     public void testDestroyQBeanThrowsNullPointerException1() throws Throwable {
         String[] args = new String[0];
-        Hashtable<String, String> hashtable = new Hashtable<String, String>(100, 100.0F);
-        hashtable.put("testString", "testString");
+        String keyParam = "testString";
+        String valueParam = "testString";
         Q2 q2 = new Q2(args);
         try {
-            new QFactory(ObjectName.getInstance("testQFactoryParam1", hashtable), null).destroyQBean(q2, new ObjectName(
+            new QFactory(ObjectName.getInstance("testQFactoryParam1", keyParam, valueParam), null).destroyQBean(q2, new ObjectName(
                     "testQFactoryParam1", "testQFactoryParam2", "testQFactoryParam3"), new ChannelAdaptor());
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {

--- a/jpos/src/test/java/org/jpos/security/CryptographicServiceMessageTest.java
+++ b/jpos/src/test/java/org/jpos/security/CryptographicServiceMessageTest.java
@@ -21,220 +21,204 @@ package org.jpos.security;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.NoSuchElementException;
+import org.jpos.security.CryptographicServiceMessage.ParsingException;
+import org.junit.jupiter.api.BeforeEach;
 
 import org.junit.jupiter.api.Test;
 
 public class CryptographicServiceMessageTest {
 
-    @Test
-    public void testAddField() throws Throwable {
-        CryptographicServiceMessage cryptographicServiceMessage = new CryptographicServiceMessage();
-        cryptographicServiceMessage.addField("testCryptographicServiceMessageTag", "testCryptographicServiceMessageContent");
-        assertEquals(1, cryptographicServiceMessage.fields.size(), "cryptographicServiceMessage.fields.size()");
-        assertEquals("testCryptographicServiceMessageContent", cryptographicServiceMessage.fields.get("TESTCRYPTOGRAPHICSERVICEMESSAGETAG"),
-                "cryptographicServiceMessage.fields.get(\"TESTCRYPTOGRAPHICSERVICEMESSAGETAG\")");
-        assertEquals(1, cryptographicServiceMessage.orderedTags.size(), "cryptographicServiceMessage.orderedTags.size()");
-        assertEquals("TESTCRYPTOGRAPHICSERVICEMESSAGETAG", cryptographicServiceMessage.orderedTags.get(0),
-                "cryptographicServiceMessage.orderedTags.get(0)");
+    Exception thrown;
+
+    CryptographicServiceMessage instance;
+
+    @BeforeEach
+    void setUp() {
+        instance = new CryptographicServiceMessage();
     }
 
     @Test
-    public void testAddFieldThrowsNullPointerException() throws Throwable {
-        CryptographicServiceMessage cryptographicServiceMessage = new CryptographicServiceMessage();
-        try {
-            cryptographicServiceMessage.addField("testCryptographicServiceMessageTag", null);
-            fail("Expected NullPointerException to be thrown");
-        } catch (NullPointerException ex) {
-            assertNull(ex.getMessage(), "ex.getMessage()");
-            assertEquals(0, cryptographicServiceMessage.fields.size(), "cryptographicServiceMessage.fields.size()");
-            assertEquals(0, cryptographicServiceMessage.orderedTags.size(), "cryptographicServiceMessage.orderedTags.size()");
-        }
+    void testAddField() {
+        instance.addField("testTag", "testContent");
+        assertEquals(1, instance.fields.size());
+        assertEquals("testContent", instance.fields.get("TESTTAG"));
+        assertEquals(1, instance.orderedTags.size());
+        assertEquals("TESTTAG", instance.orderedTags.get(0));
     }
 
     @Test
-    public void testAddFieldThrowsNullPointerException1() throws Throwable {
-        CryptographicServiceMessage cryptographicServiceMessage = new CryptographicServiceMessage();
-        try {
-            cryptographicServiceMessage.addField(null, "testCryptographicServiceMessageContent");
-            fail("Expected NullPointerException to be thrown");
-        } catch (NullPointerException ex) {
-            assertNull(ex.getMessage(), "ex.getMessage()");
-            assertEquals(0, cryptographicServiceMessage.fields.size(), "cryptographicServiceMessage.fields.size()");
-            assertEquals(0, cryptographicServiceMessage.orderedTags.size(), "cryptographicServiceMessage.orderedTags.size()");
-        }
+    void testAddFieldThrowsNullPointerException() {
+        thrown = assertThrows(NullPointerException.class,
+            () -> instance.addField("testTag", null)
+        );
+        assertEquals("The content is required", thrown.getMessage());
+        assertEquals(0, instance.fields.size());
+        assertEquals(0, instance.orderedTags.size());
     }
 
     @Test
-    public void testConstructor() throws Throwable {
-        CryptographicServiceMessage cryptographicServiceMessage = new CryptographicServiceMessage();
-        assertEquals(0, cryptographicServiceMessage.fields.size(), "cryptographicServiceMessage.fields.size()");
-        assertEquals(0, cryptographicServiceMessage.orderedTags.size(), "cryptographicServiceMessage.orderedTags.size()");
+    void testAddFieldThrowsNullPointerException1() {
+        thrown = assertThrows(NullPointerException.class,
+            () -> instance.addField(null, "testContent")
+        );
+        assertEquals("The tag is required", thrown.getMessage());
+        assertEquals(0, instance.fields.size());
+        assertEquals(0, instance.orderedTags.size());
     }
 
     @Test
-    public void testConstructor1() throws Throwable {
-        CryptographicServiceMessage cryptographicServiceMessage = new CryptographicServiceMessage(
-                "testCryptographicServiceMessageMcl");
-        assertEquals(0, cryptographicServiceMessage.fields.size(), "cryptographicServiceMessage.fields.size()");
-        assertEquals(0, cryptographicServiceMessage.orderedTags.size(), "cryptographicServiceMessage.orderedTags.size()");
-        assertEquals("testCryptographicServiceMessageMcl", cryptographicServiceMessage.mcl, "cryptographicServiceMessage.mcl");
+    void testConstructor() {
+        assertEquals(0, instance.fields.size());
+        assertEquals(0, instance.orderedTags.size());
     }
 
     @Test
-    public void testDump() throws Throwable {
+    void testConstructor1() {
+        instance.setMCL("testMcl");
+        assertEquals(0, instance.fields.size());
+        assertEquals(0, instance.orderedTags.size());
+        assertEquals("testMcl", instance.mcl);
+    }
+
+    @Test
+    void testDump() throws Throwable {
         PrintStream p = new PrintStream(new ByteArrayOutputStream(), true, "UTF-8");
-        new CryptographicServiceMessage("testCryptographicServiceMessageMcl").dump(p, "testCryptographicServiceMessageIndent");
+        instance.setMCL("testMcl");
+        instance.dump(p, "testIndent");
         assertTrue(true, "Test completed without Exception");
     }
 
     @Test
-    public void testDump1() throws Throwable {
-        CryptographicServiceMessage cryptographicServiceMessage = new CryptographicServiceMessage(
-                "testCryptographicServiceMessageMcl");
-        cryptographicServiceMessage.addField("testCryptographicServiceMessageTag", "testCryptographicServiceMessageContent");
+    void testDump1() throws Throwable {
+        instance.setMCL("testMcl");
+        instance.addField("testTag", "testContent");
         PrintStream p = new PrintStream(new ByteArrayOutputStream(), true, "UTF-8");
-        cryptographicServiceMessage.dump(p, "testCryptographicServiceMessageIndent");
+        instance.dump(p, "testIndent");
         assertTrue(true, "Test completed without Exception");
     }
 
     @Test
-    public void testDumpThrowsNullPointerException() throws Throwable {
-        try {
-            new CryptographicServiceMessage("testCryptographicServiceMessageMcl")
-                    .dump(null, "testCryptographicServiceMessageIndent");
-            fail("Expected NullPointerException to be thrown");
-        } catch (NullPointerException ex) {
-            assertNull(ex.getMessage(), "ex.getMessage()");
-        }
+    void testDumpThrowsNullPointerException() {
+        instance.setMCL("testMcl");
+        thrown = assertThrows(NullPointerException.class,
+            () -> instance.dump(null, "testIndent")
+        );
+        assertNull(thrown.getMessage());
     }
 
     @Test
-    public void testGetFieldContent() throws Throwable {
-        String result = new CryptographicServiceMessage("testCryptographicServiceMessageMcl")
-                .getFieldContent("testCryptographicServiceMessageTag");
+    void testGetFieldContent() {
+        instance.setMCL("testMcl");
+        String result = instance.getFieldContent("testTag");
         assertNull(result, "result");
     }
 
     @Test
-    public void testGetFieldContentThrowsNullPointerException() throws Throwable {
-        try {
-            new CryptographicServiceMessage("testCryptographicServiceMessageMcl").getFieldContent(null);
-            fail("Expected NullPointerException to be thrown");
-        } catch (NullPointerException ex) {
-            assertNull(ex.getMessage(), "ex.getMessage()");
-        }
+    void testGetFieldContentThrowsNullPointerException() {
+        instance.setMCL("testMcl");
+        thrown = assertThrows(NullPointerException.class,
+            () -> instance.getFieldContent(null)
+        );
+        assertNull(thrown.getMessage());
     }
 
     @Test
-    public void testGetMCL() throws Throwable {
-        CryptographicServiceMessage cryptographicServiceMessage = new CryptographicServiceMessage();
-        cryptographicServiceMessage.setMCL("testCryptographicServiceMessageMcl");
-        String result = cryptographicServiceMessage.getMCL();
+    void testGetMCL() {
+        instance.setMCL("testCryptographicServiceMessageMcl");
+        String result = instance.getMCL();
         assertEquals("testCryptographicServiceMessageMcl", result, "result");
     }
 
     @Test
-    public void testGetMCL1() throws Throwable {
-        String result = new CryptographicServiceMessage().getMCL();
+    void testGetMCL1() {
+        String result = instance.getMCL();
         assertNull(result, "result");
     }
 
     @Test
-    public void testParse() throws Throwable {
+    void testParse() throws Throwable {
         CryptographicServiceMessage result = CryptographicServiceMessage.parse("CSM(MCL/");
-        assertEquals("", result.getMCL(), "result.getMCL()");
+        assertEquals("", result.getMCL());
     }
 
     @Test
-    public void testParseThrowsNoSuchElementException() throws Throwable {
-        try {
-            CryptographicServiceMessage.parse("");
-            fail("Expected NoSuchElementException to be thrown");
-        } catch (NoSuchElementException ex) {
-            assertNull(ex.getMessage(), "ex.getMessage()");
-        }
+    void testParseThrowsNoSuchElementException() {
+        thrown = assertThrows(NoSuchElementException.class,
+            () -> CryptographicServiceMessage.parse("")
+        );
+        assertNull(thrown.getMessage());
     }
 
     @Test
-    public void testParseThrowsNoSuchElementException1() throws Throwable {
-        try {
-            CryptographicServiceMessage.parse("CSM");
-            fail("Expected NoSuchElementException to be thrown");
-        } catch (NoSuchElementException ex) {
-            assertNull(ex.getMessage(), "ex.getMessage()");
-        }
+    void testParseThrowsNoSuchElementException1() {
+        thrown = assertThrows(NoSuchElementException.class,
+            () -> CryptographicServiceMessage.parse("CSM")
+        );
+        assertNull(thrown.getMessage());
     }
 
     @Test
-    public void testParseThrowsNullPointerException() throws Throwable {
-        try {
-            CryptographicServiceMessage.parse(null);
-            fail("Expected NullPointerException to be thrown");
-        } catch (NullPointerException ex) {
-            assertNull(ex.getMessage(), "ex.getMessage()");
-        }
+    void testParseThrowsNullPointerException() {
+        thrown = assertThrows(NullPointerException.class,
+            () -> CryptographicServiceMessage.parse(null)
+        );
+        assertNull(thrown.getMessage());
     }
 
     @Test
-    public void testParseThrowsParsingException() throws Throwable {
-        try {
-            CryptographicServiceMessage.parse("CSM(MCL");
-            fail("Expected ParsingException to be thrown");
-        } catch (CryptographicServiceMessage.ParsingException ex) {
-            assertEquals("Invalid field, doesn't have a tag: MCL", ex.getMessage(), "ex.getMessage()");
-        }
+    void testParseThrowsParsingException() {
+        thrown = assertThrows(ParsingException.class,
+            () -> CryptographicServiceMessage.parse("CSM(MCL")
+        );
+        assertEquals("Invalid field, doesn't have a tag: MCL", thrown.getMessage());
     }
 
     @Test
-    public void testParseThrowsParsingException1() throws Throwable {
-        try {
-            CryptographicServiceMessage.parse("testCryptographicServiceMessageCsmString");
-            fail("Expected ParsingException to be thrown");
-        } catch (CryptographicServiceMessage.ParsingException ex) {
-            assertEquals("Invalid CSM, doesn't start with the \"CSM(\" tag: testCryptographicServiceMessageCsmString",
-                    ex.getMessage(), "ex.getMessage()");
-        }
+    void testParseThrowsParsingException1() {
+        thrown = assertThrows(ParsingException.class,
+            () -> CryptographicServiceMessage.parse("testCsmString")
+        );
+        assertEquals("Invalid CSM, doesn't start with the \"CSM(\" tag: testCsmString"
+                , thrown.getMessage()
+        );
     }
 
     @Test
-    public void testParsingExceptionConstructor() throws Throwable {
-        CryptographicServiceMessage.ParsingException parsingException = new CryptographicServiceMessage.ParsingException(
-                "testParsingExceptionDetail");
-        assertEquals("testParsingExceptionDetail", parsingException.getMessage(), "parsingException.getMessage()");
+    void testParsingExceptionConstructor() {
+        ParsingException pex = new ParsingException("testExceptionDetail");
+        assertEquals("testExceptionDetail", pex.getMessage());
     }
 
     @Test
-    public void testParsingExceptionConstructor1() throws Throwable {
-        new CryptographicServiceMessage.ParsingException();
+    void testParsingExceptionConstructor1() {
+        new ParsingException();
         assertTrue(true, "Test completed without Exception");
     }
 
     @Test
-    public void testSetMCL() throws Throwable {
-        CryptographicServiceMessage cryptographicServiceMessage = new CryptographicServiceMessage();
-        cryptographicServiceMessage.setMCL("testCryptographicServiceMessageMcl");
-        assertEquals("testCryptographicServiceMessageMcl", cryptographicServiceMessage.mcl, "cryptographicServiceMessage.mcl");
+    void testSetMCL() {
+        instance.setMCL("testMcl");
+        assertEquals("testMcl", instance.mcl);
     }
 
     @Test
-    public void testToString() throws Throwable {
-        String result = new CryptographicServiceMessage("testCryptographicServiceMessageMcl").toString();
-        assertEquals("CSM(MCL/testCryptographicServiceMessageMcl )", result, "result");
+    void testToString() {
+        instance.setMCL("testMcl");
+        String result = instance.toString();
+        assertEquals("CSM(MCL/testMcl )", result);
     }
 
     @Test
-    public void testToString1() throws Throwable {
-        CryptographicServiceMessage cryptographicServiceMessage = new CryptographicServiceMessage(
-                "testCryptographicServiceMessageMcl");
-        cryptographicServiceMessage.addField("testCryptographicServiceMessageTag", "testCryptographicServiceMessageContent");
-        String result = cryptographicServiceMessage.toString();
-        assertEquals(
-                "CSM(MCL/testCryptographicServiceMessageMcl TESTCRYPTOGRAPHICSERVICEMESSAGETAG/testCryptographicServiceMessageContent )",
-                result, "result");
+    void testToString1() {
+        instance = new CryptographicServiceMessage("testMcl");
+        instance.addField("testTag", "testContent");
+        String result = instance.toString();
+        assertEquals("CSM(MCL/testMcl TESTTAG/testContent )", result);
     }
+
 }

--- a/jpos/src/test/java/org/jpos/tlv/CharTagMapBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/CharTagMapBuilderTest.java
@@ -1,0 +1,121 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2016 Alejandro P. Revilla
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.tlv;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ *
+ * @author Robert Demski <drdemsey@gmail.com>
+ */
+public class CharTagMapBuilderTest {
+
+    Exception thrown;
+
+    CharTagMapBuilder instance;
+
+    @BeforeEach
+    public void setUp() {
+        instance = new CharTagMapBuilder();
+    }
+
+    @Test
+    public void testBuildDefault() {
+        CharTagMap tm = instance.build();
+
+        tm.unpack("XY019The quick brown foxKV007Foo Bar");
+        assertEquals("The quick brown fox", tm.getTagValue("XY"));
+        assertEquals("Foo Bar", tm.getTagValue("KV"));
+
+        String result = tm.pack();
+        tm.clear();
+        tm.unpack(result);
+        assertEquals("The quick brown fox", tm.getTagValue("XY"));
+        assertEquals("Foo Bar", tm.getTagValue("KV"));
+    }
+
+    @Test
+    public void testBuild() {
+        CharTagMap tm = instance.withTagSize(3)
+                .withLengthSize(2)
+                .build();
+
+        tm.unpack("XYZ19The quick brown foxKV107Foo Bar");
+        assertEquals("The quick brown fox", tm.getTagValue("XYZ"));
+        assertEquals("Foo Bar", tm.getTagValue("KV1"));
+
+        String result = tm.pack();
+        tm.clear();
+        tm.unpack(result);
+        assertEquals("The quick brown fox", tm.getTagValue("XYZ"));
+        assertEquals("Foo Bar", tm.getTagValue("KV1"));
+    }
+
+    @Test
+    public void testBuildLongTagSize() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.withTagSize(5)
+                          .build()
+        );
+    }
+
+    @Test
+    public void testBuildZeroTagSize() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.withTagSize(0)
+                          .build()
+        );
+    }
+
+    @Test
+    public void testBuildNegativeTagSize() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.withTagSize(-1)
+                          .build()
+        );
+    }
+
+    @Test
+    public void testBuildLongLengthSize() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.withLengthSize(6)
+                          .build()
+        );
+    }
+
+    @Test
+    public void testBuildZeroLengthSize() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.withLengthSize(0)
+                          .build()
+        );
+    }
+
+    @Test
+    public void testBuildNegativeLengthSize() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.withLengthSize(-1)
+                          .build()
+        );
+    }
+
+}

--- a/jpos/src/test/java/org/jpos/tlv/CharTagMapBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/CharTagMapBuilderTest.java
@@ -71,6 +71,23 @@ public class CharTagMapBuilderTest {
     }
 
     @Test
+    public void testBuildSwapped() {
+        CharTagMap tm = instance
+                .withTagLengthSwap(true)
+                .build();
+
+        tm.unpack("019XYThe quick brown fox007KVFoo Bar");
+        assertEquals("The quick brown fox", tm.getTagValue("XY"));
+        assertEquals("Foo Bar", tm.getTagValue("KV"));
+
+        String result = tm.pack();
+        tm.clear();
+        tm.unpack(result);
+        assertEquals("The quick brown fox", tm.getTagValue("XY"));
+        assertEquals("Foo Bar", tm.getTagValue("KV"));
+    }
+
+    @Test
     public void testBuildLongTagSize() {
         thrown = assertThrows(IllegalArgumentException.class,
             () -> instance.withTagSize(5)

--- a/jpos/src/test/java/org/jpos/tlv/CharTagMapTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/CharTagMapTest.java
@@ -1,0 +1,181 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2016 Alejandro P. Revilla
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.tlv;
+
+import org.jpos.iso.ISOUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the CharTagMap class.
+ *
+ * @author Robert Demski <drdemsey@gmail.com>
+ */
+public class CharTagMapTest {
+
+    Exception thrown;
+
+    CharTagMap instance;
+
+    @BeforeEach
+    public void setUp() {
+        instance = CharTagMap.getInstance();
+    }
+
+    @Test
+    public void testCreateTLV() {
+        CharTag tag = instance.createTLV("X7", "test");
+
+        assertAll(
+            () -> assertEquals("X7", tag.getTagId()),
+            () -> assertEquals("test", tag.getValue()),
+            () -> assertNull(instance.getTagValue("X7")),
+            () -> assertNull(instance.get("X7"))
+        );
+    }
+
+    @Test
+    public void testCreateTLVWithNullValue() {
+        CharTag tag = instance.createTLV("X7", null);
+
+        assertAll(
+            () -> assertEquals("X7", tag.getTagId()),
+            () -> assertNull(tag.getValue()),
+            () -> assertNull(instance.get("X7"))
+        );
+    }
+
+    @Test
+    public void testCreateTLVWithTagIdNull() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.createTLV(null, "test")
+        );
+        assertEquals("Tag identifier have to be specified", thrown.getMessage());
+    }
+
+    @Test
+    public void testCreateTLVWithTagIdInvalidSize() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.createTLV("XYZ", "test")
+        );
+        assertEquals("Invalid tag 'XYZ' size: expected 2, but got 3", thrown.getMessage());
+    }
+
+    @Test
+    public void testCreateTLVWithValueExceededMaxSize() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.createTLV("XY", ISOUtil.zeropad("", 1000))
+        );
+        assertEquals(
+            "The value size 1000 of the tag 'XY' has exceeded the maximum allowable value 999"
+            , thrown.getMessage()
+        );
+    }
+
+    @Test
+    public void testUnpackEmptyTag() {
+        instance.unpack("02000");
+
+        assertAll(
+            () -> assertEquals(1, instance.size()),
+            () -> assertEquals("02", instance.get("02").getTagId()),
+            () -> assertEquals("", instance.get("02").getValue())
+        );
+    }
+
+    @Test
+    public void testUnpackOneTag() {
+        instance.unpack("02008ValueXyZ");
+
+        assertAll(
+            () -> assertEquals(1, instance.size()),
+            () -> assertEquals("02", instance.get("02").getTagId()),
+            () -> assertEquals("ValueXyZ", instance.get("02").getValue())
+        );
+    }
+
+    @Test
+    public void testUnpackOneTagAndMissing() {
+        instance.unpack("02008ValueXyZ");
+
+        assertAll(
+            () -> assertEquals(1, instance.size()),
+            () -> assertEquals("02", instance.get("02").getTagId()),
+            () -> assertEquals("ValueXyZ", instance.get("02").getValue()),
+            () -> assertNull(instance.get("03"))
+        );
+    }
+
+    @Test
+    public void testUnpackTwoTag() {
+        instance.unpack("02008ValueXyZ03007ValueAb");
+
+        assertAll(
+            () -> assertEquals(2, instance.size()),
+            () -> assertEquals("02", instance.get("02").getTagId()),
+            () -> assertEquals("ValueXyZ", instance.get("02").getValue()),
+            () -> assertEquals("03", instance.get("03").getTagId()),
+            () -> assertEquals("ValueAb", instance.get("03").getValue())
+        );
+    }
+
+    @Test
+    public void testUnpackTwoTagReverted() {
+        instance.unpack("03007ValueAb02008ValueXyZ");
+
+        assertAll(
+            () -> assertEquals(2, instance.size()),
+            () -> assertEquals("02", instance.get("02").getTagId()),
+            () -> assertEquals("ValueXyZ", instance.get("02").getValue()),
+            () -> assertEquals("03", instance.get("03").getTagId()),
+            () -> assertEquals("ValueAb", instance.get("03").getValue())
+        );
+    }
+
+    @Test
+    public void testUnpackTwoTagShortTag() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.unpack("03008wartosc20")
+        );
+    }
+
+    @Test
+    public void testUnpackTwoTagShortLength() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.unpack("0400")
+        );
+    }
+
+    @Test
+    public void testUnpackRevertedTwoTagShortValue() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.unpack("04008wa")
+        );
+    }
+
+    @Test
+    public void testUnpackNull() {
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.unpack(null)
+        );
+    }
+
+}

--- a/jpos/src/test/java/org/jpos/tlv/CharTagTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/CharTagTest.java
@@ -1,0 +1,66 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2016 Alejandro P. Revilla
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.tlv;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for the CharTag class.
+ *
+ * @author Robert Demski <drdemsey@gmail.com>
+ */
+public class CharTagTest {
+
+    CharTag instance;
+    CharTagMap tagMap;
+
+    @BeforeEach
+    public void setUp() {
+        tagMap = CharTagMap.getInstance();
+        instance = tagMap.createTLV("02", "valueXYZ");
+    }
+
+    @Test
+    void testTag() {
+        assertEquals("02", instance.getTagId());
+        assertEquals("valueXYZ", instance.getValue());
+        assertEquals("02008valueXYZ", instance.getTLV());
+    }
+
+    @Test
+    void testTLVNullValue() {
+        instance = tagMap.createTLV("02", null);
+        assertEquals("02000", instance.getTLV());
+    }
+
+    @Test
+    void testToString() {
+        assertEquals("tag: 02, len: 8, value: valueXYZ", instance.toString());
+    }
+
+    @Test
+    void testToStringNullValue() {
+        instance = tagMap.createTLV("K7", null);
+        assertEquals("tag: K7, len: 0", instance.toString());
+    }
+
+}

--- a/jpos/src/test/resources/org/jpos/iso/packagers/ISO93TLVPackager.xml
+++ b/jpos/src/test/resources/org/jpos/iso/packagers/ISO93TLVPackager.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE isopackager SYSTEM "genericpackager.dtd">
+<!DOCTYPE isopackager PUBLIC
+        "-//jPOS/jPOS Generic Packager DTD 1.0//EN"
+        "http://jpos.org/dtd/generic-packager-1.0.dtd">
 
 <!-- ISO 8583:1993 (ASCII) field descriptions for GenericPackager -->
 
@@ -145,7 +147,7 @@
       length="999"
       name="Additional Data Private Use"
       class="org.jpos.iso.IFA_LLLCHAR"
-      emitBitmap="false"
+      tagSize="2" lenSize="2"
       tagMapper="org.jpos.iso.packager.TaggedFieldPackagerBaseTest$TagMapperImpl"
       packager="org.jpos.iso.packager.GenericTaggedFieldsPackager">
       <isofield
@@ -200,7 +202,7 @@
       length="999"
       name="Reserved National – 1 - Transaction Environment Data"
       class="org.jpos.iso.IFA_LLLCHAR"
-      emitBitmap="false"
+      tagSize="2" lenSize="3"
       tagMapper="org.jpos.iso.packager.TaggedFieldPackagerBaseTest$TagMapperImpl"
       packager="org.jpos.iso.packager.GenericTaggedFieldsPackager">
       <isofield


### PR DESCRIPTION
As mentoined in #248 and #252

When using the `GenericTaggedFieldsPackager` two new mandatory attributes have been introduced: `tagSize`, `lenSize` and optional `swapTagAndLen` _( `genericpackager.dtd` was updated)_

```xml
  <isofieldpackager
      id="62"
      length="999"
      name="Additional Data Private Use"
      class="org.jpos.iso.IFA_LLLCHAR"
      tagMapper="org.jpos.iso.packager.TTDecimalTagMapper"
      tagSize="2", lenSize="2"
      packager="org.jpos.iso.packager.GenericTaggedFieldsPackager">
      <isofield
          id="1"
          length="29"
          name="Some ascii value 1"
          class="org.jpos.iso.IFA_TTLLCHAR"/>
      <isofield
          id="2"
          length="12"
          name="Some binary value 2"
          class="org.jpos.iso.IFA_TTLLBINARY"/>
      <isofield
          id="92"
          length="8"
          name="Some ascii value 93"
          class="org.jpos.iso.IFA_TTLLCHAR"/>
  </isofieldpackager>
```
**Defining subfields in `packager.xml` is not required** - new unknown tags are packed/unpacked as defined in `tagSize` and `lenSize` and **interpreted _(by design)_ as a character element** _(without strict length limit and description)_.

Excluded from handling unknown tags are:
 * without mapping in `TagMapper.getTagForField` or `TagMapper.getFieldNumberForTag`
 * at packing binary elements created as e.g. `ISOMsg.set(int, byte[])`.

Use of attribute `swapTagAndLen="true"` allow change order of processing elements from `TLV` to `LTV` mode.