### PR TITLE
Enable JSON Logging

### DIFF
--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     compile libraries.yaml;
     compile libraries.jacksonDatabind
 
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.5.3'
+    implementation 'org.json:json:20140107'
+
     testCompile libraries.commons_lang3
     testCompile libraries.hamcrest
     testCompile libraries.fest_assert

--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compile libraries.javassist
     compile libraries.hdrhistogram
     compile libraries.yaml;
+    compile libraries.jacksonDatabind
 
     testCompile libraries.commons_lang3
     testCompile libraries.hamcrest

--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     compile libraries.javassist
     compile libraries.hdrhistogram
     compile libraries.yaml;
-    compile libraries.jacksonDatabind
     compile libraries.json
 
     testCompile libraries.commons_lang3

--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -28,8 +28,7 @@ dependencies {
     compile libraries.hdrhistogram
     compile libraries.yaml;
     compile libraries.jacksonDatabind
-
-    implementation 'org.json:json:20140107'
+    compile libraries.json
 
     testCompile libraries.commons_lang3
     testCompile libraries.hamcrest

--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     compile libraries.yaml;
     compile libraries.jacksonDatabind
 
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.5.3'
     implementation 'org.json:json:20140107'
 
     testCompile libraries.commons_lang3

--- a/jpos/libraries.gradle
+++ b/jpos/libraries.gradle
@@ -26,7 +26,8 @@ ext {
         hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.11',
         yaml: "org.yaml:snakeyaml:1.25",
         jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.9.5',
-        jsonsimple: 'com.googlecode.json-simple:json-simple:1.1.1'    
+        jsonsimple: 'com.googlecode.json-simple:json-simple:1.1.1',
+        json: 'org.json:json:20140107'    
     ]
 }
 

--- a/jpos/libraries.gradle
+++ b/jpos/libraries.gradle
@@ -24,7 +24,9 @@ ext {
         slf4j_api: "org.slf4j:slf4j-api:1.7.28",
         slf4j_nop: "org.slf4j:slf4j-nop:1.7.28",
         hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.11',
-        yaml: "org.yaml:snakeyaml:1.25"
+        yaml: "org.yaml:snakeyaml:1.25",
+        jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.9.5',
+        jsonsimple: 'com.googlecode.json-simple:json-simple:1.1.1'    
     ]
 }
 

--- a/jpos/libraries.gradle
+++ b/jpos/libraries.gradle
@@ -25,9 +25,7 @@ ext {
         slf4j_nop: "org.slf4j:slf4j-nop:1.7.28",
         hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.11',
         yaml: "org.yaml:snakeyaml:1.25",
-        jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.9.5',
-        jsonsimple: 'com.googlecode.json-simple:json-simple:1.1.1',
-        json: 'org.json:json:20140107'    
+        json: 'org.json:json:20140107'
     ]
 }
 

--- a/jpos/src/main/java/org/jpos/util/DailyLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/DailyLogListener.java
@@ -38,6 +38,8 @@ import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static org.jpos.util.log.format.XML.XML_LABEL;
+
 /**
  * Rotates log daily and compress the previous log.
  * @author <a href="mailto:alcarraz@jpos.org">Andr&eacute;s Alcarraz</a>
@@ -161,7 +163,7 @@ public class DailyLogListener extends RotateLogListener{
             compress(dest);
         };
 
-        setBaseLogFormat(LogFormatFactory.getLogFormat(cfg.get("format","xml")));
+        setBaseLogFormat(LogFormatFactory.getLogFormat(cfg.get("format",XML_LABEL)));
 
         super.setConfiguration(cfg);
     }

--- a/jpos/src/main/java/org/jpos/util/DailyLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/DailyLogListener.java
@@ -163,8 +163,6 @@ public class DailyLogListener extends RotateLogListener{
             compress(dest);
         };
 
-        setBaseLogFormat(LogFormatFactory.getLogFormat(cfg.get("format",XML_LABEL)));
-
         super.setConfiguration(cfg);
     }
 

--- a/jpos/src/main/java/org/jpos/util/DailyLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/DailyLogListener.java
@@ -20,6 +20,7 @@ package org.jpos.util;
 
 import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
+import org.jpos.util.log.format.LogFormatFactory;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -159,6 +160,8 @@ public class DailyLogListener extends RotateLogListener{
             setLastDate(getDateFmt().format(new Date()));
             compress(dest);
         };
+
+        setBaseLogFormat(LogFormatFactory.getLogFormat(cfg.get("format","xml")));
 
         super.setConfiguration(cfg);
     }

--- a/jpos/src/main/java/org/jpos/util/ISOLogUtil.java
+++ b/jpos/src/main/java/org/jpos/util/ISOLogUtil.java
@@ -1,0 +1,31 @@
+package org.jpos.util;
+
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOField;
+import org.jpos.iso.ISOMsg;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+public class ISOLogUtil {
+    public static final String MTI = "MTI";
+
+    public static Map<String, Object> getMap(ISOMsg isoMsg) throws ISOException
+    {
+        Map<String, Object> mapz = new TreeMap<>();
+        Map<Integer, ISOField> fields = isoMsg.getChildren();
+
+        mapz.put(MTI, isoMsg.getMTI());
+        for (Map.Entry<Integer, ISOField> entry : fields.entrySet())
+        {
+            if (entry.getKey() >= 1)
+            {
+                mapz.put("de" + entry.getKey(), isoMsg.getString(entry.getKey()));
+            }
+
+        }
+
+        return mapz;
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/util/LogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/LogEvent.java
@@ -85,7 +85,7 @@ public class LogEvent {
         payLoad.add (msg);
     }
     public void addMessage (String tagname, String message) {
-        payLoad.add ("<"+tagname+">"+message+"</"+tagname+">");
+        payLoad.add (baseLogEvent.addMessage(tagname,message));
     }
     public LogSource getSource() {
         return source;

--- a/jpos/src/main/java/org/jpos/util/RotateLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/RotateLogListener.java
@@ -154,11 +154,11 @@ public class RotateLogListener extends SimpleLogListener
             f.close();
         f = new FileOutputStream (logName, true);
         setPrintStream (new PrintStream(f));
-        p.println ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-        p.println ("<logger class=\"" + getClass().getName() + "\">");
+        //p.println ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        //p.println ("<logger class=\"" + getClass().getName() + "\">");
     }
     protected synchronized void closeLogFile() throws IOException {
-        p.println ("</logger>");
+        //p.println ("</logger>");
         if (f != null)
             f.close();
         f = null;

--- a/jpos/src/main/java/org/jpos/util/RotateLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/RotateLogListener.java
@@ -153,6 +153,8 @@ public class RotateLogListener extends SimpleLogListener
             };
         }
 
+        setBaseLogFormat(LogFormatFactory.getLogFormat(cfg.get("format",XML_LABEL)));
+
         runPostConfiguration();
     }
 

--- a/jpos/src/main/java/org/jpos/util/RotateLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/RotateLogListener.java
@@ -172,7 +172,7 @@ public class RotateLogListener extends SimpleLogListener
             f.close();
         f = new FileOutputStream (logName, true);
         setPrintStream (new PrintStream(f));
-        baseLogFormat.openLogFile(p);
+        baseLogFormat.openLogFile(p,getClass().getName());
     }
     protected synchronized void closeLogFile() throws IOException {
         baseLogFormat.closeLogFile(p);

--- a/jpos/src/main/java/org/jpos/util/RotateLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/RotateLogListener.java
@@ -21,6 +21,8 @@ package org.jpos.util;
 import org.jpos.core.Configurable;
 import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
+import org.jpos.util.log.format.BaseLogFormat;
+import org.jpos.util.log.format.LogFormatFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -53,12 +55,22 @@ public class RotateLogListener extends SimpleLogListener
     Rotate rotate;
     public static final int CHECK_INTERVAL = 100;
     public static final long DEFAULT_MAXSIZE = 10000000;
+    private BaseLogFormat baseLogFormat;
 
     ScheduleTimer timer = null;
     RotationAlgo rotationAlgo = null;
 
+    protected BaseLogFormat getBaseLogFormat() {
+        return baseLogFormat;
+    }
+
+    protected void setBaseLogFormat(BaseLogFormat baseLogFormat) {
+        this.baseLogFormat = baseLogFormat;
+    }
+
     public RotateLogListener () {
         super();
+        setBaseLogFormat(LogFormatFactory.getLogFormat("xml"));
     }
 
    /**
@@ -154,11 +166,10 @@ public class RotateLogListener extends SimpleLogListener
             f.close();
         f = new FileOutputStream (logName, true);
         setPrintStream (new PrintStream(f));
-        //p.println ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-        //p.println ("<logger class=\"" + getClass().getName() + "\">");
+        baseLogFormat.openLogFile(p);
     }
     protected synchronized void closeLogFile() throws IOException {
-        //p.println ("</logger>");
+        baseLogFormat.closeLogFile(p);
         if (f != null)
             f.close();
         f = null;
@@ -182,9 +193,7 @@ public class RotateLogListener extends SimpleLogListener
 
     protected synchronized void logDebug (String msg) {
         if (p != null) {
-            p.println ("<log realm=\"rotate-log-listener\" at=\""+new Date().toString() +"\">");
-            p.println ("   "+msg);
-            p.println ("</log>");
+           baseLogFormat.logDebug(p,msg);
         }
     }
     protected void checkSize() {

--- a/jpos/src/main/java/org/jpos/util/RotateLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/RotateLogListener.java
@@ -21,6 +21,7 @@ package org.jpos.util;
 import org.jpos.core.Configurable;
 import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
+import org.jpos.util.log.event.LogEventFactory;
 import org.jpos.util.log.format.BaseLogFormat;
 import org.jpos.util.log.format.LogFormatFactory;
 
@@ -33,6 +34,8 @@ import java.net.UnknownHostException;
 import java.util.Date;
 import java.util.Timer;
 import java.util.TimerTask;
+
+import static org.jpos.util.log.format.XML.XML_LABEL;
 
 /**
  * Rotates logs
@@ -70,7 +73,7 @@ public class RotateLogListener extends SimpleLogListener
 
     public RotateLogListener () {
         super();
-        setBaseLogFormat(LogFormatFactory.getLogFormat("xml"));
+        setBaseLogFormat(LogFormatFactory.getLogFormat(XML_LABEL));
     }
 
    /**
@@ -159,6 +162,7 @@ public class RotateLogListener extends SimpleLogListener
             msgCount = 0;
         }
 
+        ev.setBaseLogEvent(LogEventFactory.getLogEvent(baseLogFormat.getType()));
         return super.log (ev);
     }
     protected synchronized void openLogFile() throws IOException {

--- a/jpos/src/main/java/org/jpos/util/SimpleLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/SimpleLogListener.java
@@ -18,16 +18,7 @@
 
 package org.jpos.util;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import java.io.PrintStream;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 
 /**
  * @author <a href="mailto:apr@cs.com.uy">Alejandro P. Revilla</a>
@@ -58,69 +49,6 @@ public class SimpleLogListener implements LogListener {
     public synchronized LogEvent log (LogEvent ev) {
         if (p != null) {
             ev.dump (p, "");
-            /*try {
-                ev = printJsonLog(ev);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }*/
-            p.flush();
-        }
-        return ev;
-    }
-
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
-    private LogEvent printJsonLog(LogEvent ev) throws Exception{
-        if (p != null) {
-            JsonNode tag = JsonNodeFactory.instance.objectNode();
-
-            JsonNode header = JsonNodeFactory.instance.objectNode();
-            JsonNode log = JsonNodeFactory.instance.objectNode();
-
-            ObjectNode headerNode = ((ObjectNode) header)
-                    .put("id", 2016)
-                    .put("realm", ev.getRealm())
-                    .put("at", LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()).format(formatter));
-            headerNode.set(ev.getTag(),tag);
-
-            ObjectNode logNode = ((ObjectNode) log);
-            logNode.set("log",header);
-
-            /*synchronized (ev.getPayLoad()) {
-                for(Object o : ev.getPayLoad()) {
-                    if (o instanceof SQLException) {
-                        log = log.append("error", ConsoleLogUtil.processSQLException((SQLException)o));
-                    }else if (o instanceof Throwable) {
-                        log = log.append("error", ConsoleLogUtil.processThrowable((Throwable)o));
-                    }else if (o instanceof Object[]) {
-                        log = log.append("message", ConsoleLogUtil.processObjectArray((Object[])o));
-                    }else if (o instanceof Element) {
-                        try {
-                            log = log.append("message", ConsoleLogUtil.processXML((Element)o));
-                        } catch (JSONException ex) {
-                            System.err.println("{\"log-name\":\"log-error\",\"realm\":\"log\",\"tag\":\"error\"," +
-                                    "\"error\":[{\"message\":\"XML log cannot be converted into JSON, (\"" +
-                                    ex.getMessage() + ") happened," +
-                                    "\"stack-trace\":"+ConsoleLogUtil.parseStackTrace(ex.getStackTrace()).toString()+"}]}");
-                        }
-                    }else if(o instanceof ISOMsg){
-                        try{
-                            log = log.append("message", ISOLogUtil.getJSON((ISOMsg) o));
-                        }catch(Exception ex){
-                            System.err.println("{\"log-name\":\"log-error\",\"realm\":\"log\",\"tag\":\"error\"," +
-                                    "\"error\":[{\"message\":\"ISOMsg log cannot be converted into JSON, (\"" +
-                                    ex.getMessage() + ") happened," +
-                                    "\"stack-trace\":"+ConsoleLogUtil.parseStackTrace(ex.getStackTrace()).toString()+"}]}");
-                        }
-
-                    }else if(o!=null) {
-                        log = log.append("message", o.toString());
-                    }else {
-                        log = log.append("message", "null");
-                    }
-                }
-            }*/
-
-            p.println(new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(log));
             p.flush();
         }
         return ev;

--- a/jpos/src/main/java/org/jpos/util/SimpleLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/SimpleLogListener.java
@@ -18,7 +18,16 @@
 
 package org.jpos.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.PrintStream;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 /**
  * @author <a href="mailto:apr@cs.com.uy">Alejandro P. Revilla</a>
@@ -49,9 +58,73 @@ public class SimpleLogListener implements LogListener {
     public synchronized LogEvent log (LogEvent ev) {
         if (p != null) {
             ev.dump (p, "");
+            /*try {
+                ev = printJsonLog(ev);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }*/
             p.flush();
         }
         return ev;
     }
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    private LogEvent printJsonLog(LogEvent ev) throws Exception{
+        if (p != null) {
+            JsonNode tag = JsonNodeFactory.instance.objectNode();
+
+            JsonNode header = JsonNodeFactory.instance.objectNode();
+            JsonNode log = JsonNodeFactory.instance.objectNode();
+
+            ObjectNode headerNode = ((ObjectNode) header)
+                    .put("id", 2016)
+                    .put("realm", ev.getRealm())
+                    .put("at", LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()).format(formatter));
+            headerNode.set(ev.getTag(),tag);
+
+            ObjectNode logNode = ((ObjectNode) log);
+            logNode.set("log",header);
+
+            /*synchronized (ev.getPayLoad()) {
+                for(Object o : ev.getPayLoad()) {
+                    if (o instanceof SQLException) {
+                        log = log.append("error", ConsoleLogUtil.processSQLException((SQLException)o));
+                    }else if (o instanceof Throwable) {
+                        log = log.append("error", ConsoleLogUtil.processThrowable((Throwable)o));
+                    }else if (o instanceof Object[]) {
+                        log = log.append("message", ConsoleLogUtil.processObjectArray((Object[])o));
+                    }else if (o instanceof Element) {
+                        try {
+                            log = log.append("message", ConsoleLogUtil.processXML((Element)o));
+                        } catch (JSONException ex) {
+                            System.err.println("{\"log-name\":\"log-error\",\"realm\":\"log\",\"tag\":\"error\"," +
+                                    "\"error\":[{\"message\":\"XML log cannot be converted into JSON, (\"" +
+                                    ex.getMessage() + ") happened," +
+                                    "\"stack-trace\":"+ConsoleLogUtil.parseStackTrace(ex.getStackTrace()).toString()+"}]}");
+                        }
+                    }else if(o instanceof ISOMsg){
+                        try{
+                            log = log.append("message", ISOLogUtil.getJSON((ISOMsg) o));
+                        }catch(Exception ex){
+                            System.err.println("{\"log-name\":\"log-error\",\"realm\":\"log\",\"tag\":\"error\"," +
+                                    "\"error\":[{\"message\":\"ISOMsg log cannot be converted into JSON, (\"" +
+                                    ex.getMessage() + ") happened," +
+                                    "\"stack-trace\":"+ConsoleLogUtil.parseStackTrace(ex.getStackTrace()).toString()+"}]}");
+                        }
+
+                    }else if(o!=null) {
+                        log = log.append("message", o.toString());
+                    }else {
+                        log = log.append("message", "null");
+                    }
+                }
+            }*/
+
+            p.println(new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(log));
+            p.flush();
+        }
+        return ev;
+    }
+
 }
 

--- a/jpos/src/main/java/org/jpos/util/log/event/BaseLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/BaseLogEvent.java
@@ -11,4 +11,5 @@ public interface BaseLogEvent {
     String dumpHeader(PrintStream p, String indent, String realm, Instant dumpedAt, Instant createdAt, boolean noArmor);
     void dumpTrailer (PrintStream p, String indent, boolean noArmor);
     void dump (PrintStream p, String outer,String realm, Instant dumpedAt, Instant createdAt, List<Object> payLoad, boolean noArmor, String tag);
+    String addMessage(String tagname, String message);
 }

--- a/jpos/src/main/java/org/jpos/util/log/event/BaseLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/BaseLogEvent.java
@@ -1,0 +1,14 @@
+package org.jpos.util.log.event;
+
+import java.io.PrintStream;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Created by erlangga on 2019-10-12.
+ */
+public interface BaseLogEvent {
+    String dumpHeader(PrintStream p, String indent, String realm, Instant dumpedAt, Instant createdAt, boolean noArmor);
+    void dumpTrailer (PrintStream p, String indent, boolean noArmor);
+    void dump (PrintStream p, String outer,String realm, Instant dumpedAt, Instant createdAt, List<Object> payLoad, boolean noArmor, String tag);
+}

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -23,8 +23,6 @@ import java.util.stream.Stream;
  */
 public class JSONLogEvent implements BaseLogEvent {
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
-
     @Override
     public String dumpHeader(PrintStream p, String indent, String realm, Instant dumpedAt, Instant createdAt, boolean noArmor) {
         if (noArmor) {

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -93,6 +93,7 @@ public class JSONLogEvent implements BaseLogEvent {
                         } else if (o instanceof SQLException) {
                             p.print("SQLException");
                         } else if (o instanceof Throwable) {
+                            // TODO: Fetch n lines
                             p.print("{ \"exception\" : { \"name\":\"" + ((Throwable) o).getMessage()+"\",");
                             p.print("\"stackTrace\":\"");
                             p.print(Arrays.toString(((Throwable)o).getStackTrace()));
@@ -106,10 +107,6 @@ public class JSONLogEvent implements BaseLogEvent {
                             p.print("Element");
                         } else if (o != null) {
                             if(stringBuilder.length()==0){
-                                /*
-                                    for handling
-                                    "connect":"Try 0 127.0.0.1:6990  Connection refused (Connection refused)Unable to connect"}}
-                                 */
                                 isOpenQuote = true;
                                 stringBuilder.append("\"");
                             }

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -55,7 +55,7 @@ public class JSONLogEvent implements BaseLogEvent {
     @Override
     public void dumpTrailer(PrintStream p, String indent, boolean noArmor) {
         if (!noArmor) {
-            p.print ("\n}\n");
+            p.print (indent+"\n}\n");
         }
     }
 

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -23,9 +23,10 @@ import java.util.stream.Stream;
  */
 public class JSONLogEvent implements BaseLogEvent {
 
-    public static final String XML_TAG_PATTERN = "(?s).*(<(\\w+)[^>]*>.*</\\2>|<(\\w+)[^>]*/>).*";
+    private static final String XML_TAG_PATTERN = "(?s).*(<(\\w+)[^>]*>.*</\\2>|<(\\w+)[^>]*/>).*";
     private static final String STACK_TRACE_TAG_PATTERN = "(^\\d+\\) .+)|(^.+Exception: .+)|(^\\s+at .+)|(^\\s+... \\d+ more)|(^\\s*Caused by:.+)";
-    public static final Pattern STACK_TRACE_REGEX = Pattern.compile(STACK_TRACE_TAG_PATTERN, Pattern.MULTILINE);
+
+    private static final Pattern STACK_TRACE_REGEX = Pattern.compile(STACK_TRACE_TAG_PATTERN, Pattern.MULTILINE);
 
     @Override
     public String dumpHeader(PrintStream p, String indent, String realm, Instant dumpedAt, Instant createdAt, boolean noArmor) {

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -1,7 +1,6 @@
 package org.jpos.util.log.event;
 
 import org.jpos.util.Loggeable;
-import org.json.JSONObject;
 import org.json.XML;
 
 import java.io.ByteArrayOutputStream;
@@ -12,11 +11,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Created by erlangga on 2019-10-12.
@@ -175,35 +171,24 @@ public class JSONLogEvent implements BaseLogEvent {
     }
 
     private String convertXmlToJson(String xmlString) {
-        JSONObject jsonObject = XML.toJSONObject(xmlString);
-        Iterator<String> keys = jsonObject.keys();
-        while(keys.hasNext()) {
-            String key = keys.next();
-            if(jsonObject.get(key) instanceof String){
-                String str = jsonObject.getString(key);
-                if(str.isEmpty()){
-                    return null;
-                }
-            }
-        }
-        return jsonObject.toString(4);
+        return XML.toJSONObject(xmlString).toString(4);
     }
 
     private String extrapolateStackTrace(Exception ex, String indent) {
         Throwable e = ex;
-        String trace ="\""+e.toString() + "\",\n"+indent;
+        StringBuilder stringBuilder = new StringBuilder("\""+e.toString() + "\",\n"+indent);
         for (StackTraceElement e1 : e.getStackTrace()) {
-            trace += "   "+"\"at " + e1.toString() + "\",\n"+indent;
+            stringBuilder.append("   "+"\"at " + e1.toString() + "\",\n"+indent);
         }
         while (e.getCause() != null) {
             e = e.getCause();
-            trace += "\"Cause by: " + e.toString() + "\",\n"+indent;
+            stringBuilder.append("\"Cause by: " + e.toString() + "\",\n"+indent);
             for (StackTraceElement e1 : e.getStackTrace()) {
-                trace += "   "+"\"at " + e1.toString() + "\",\n"+indent;
+                stringBuilder.append("   "+"\"at " + e1.toString() + "\",\n"+indent);
             }
         }
 
-        trace = trace.trim();
+        String trace = stringBuilder.toString().trim();
         return trace.substring(0,trace.length()-1);
     }
 

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -88,10 +88,7 @@ public class JSONLogEvent implements BaseLogEvent {
                             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                             try (PrintStream ps = new PrintStream(baos, true)) {
                                 ((Loggeable) o).dump(ps, "");
-                                String json = convertXmlToJson(new String(baos.toByteArray(), StandardCharsets.UTF_8));
-                                if(json!=null){
-                                    p.print(json);
-                                }
+                                stringBuilder = new StringBuilder(new String(baos.toByteArray(), StandardCharsets.UTF_8));
                             }
                         } else if (o instanceof SQLException) {
                             SQLException e = (SQLException) o;
@@ -140,7 +137,6 @@ public class JSONLogEvent implements BaseLogEvent {
                                 stringBuilder = new StringBuilder();
                                 stringBuilder.append("\"");
                             }
-
                             stringBuilder.append(data);
                         }
                     }

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -194,9 +194,7 @@ public class JSONLogEvent implements BaseLogEvent {
                 }
             }
         }
-
-        String json = jsonObject.toString();
-        return json;
+        return jsonObject.toString(4);
     }
 
     private String indent(int n, String indent, char symbol) {

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -76,8 +76,6 @@ public class JSONLogEvent implements BaseLogEvent {
                             }else {
                                 stringBuilder.append("\""+o.toString()+" ");
                             }
-                        } else {
-                            stringBuilder.append("null"+ " ");
                         }
                     }
                     p.print(stringBuilder.toString().trim());

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -1,0 +1,55 @@
+package org.jpos.util.log.event;
+
+import java.io.PrintStream;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Created by erlangga on 2019-10-12.
+ */
+public class JSONLogEvent implements BaseLogEvent {
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+
+    @Override
+    public String dumpHeader(PrintStream p, String indent, String realm, Instant dumpedAt, Instant createdAt, boolean noArmor) {
+        if (noArmor) {
+            p.println("");
+        } else {
+            if (dumpedAt == null)
+                dumpedAt = Instant.now();
+
+            StringBuilder sb = new StringBuilder(indent);
+            sb.append ("\"log\":{\n");
+            sb.append ("\"realm\":"+ "\""+realm+"\",\n");
+            sb.append("\"at=\"");
+            sb.append("\""+LocalDateTime.ofInstant(dumpedAt, ZoneId.systemDefault())+"\"\n");
+
+            /*
+            long elapsed = Duration.between(createdAt, dumpedAt).toMillis();
+            if (elapsed > 0) {
+                sb.append (" lifespan=\"");
+                sb.append (elapsed);
+                sb.append ("ms\"");
+            }
+            */
+
+            p.println (sb.toString());
+        }
+        return indent + "  ";
+    }
+
+    @Override
+    public void dumpTrailer(PrintStream p, String indent, boolean noArmor) {
+        if (!noArmor)
+            p.println (indent + "}");
+    }
+
+    @Override
+    public void dump(PrintStream p, String outer, String realm, Instant dumpedAt, Instant createdAt, List<Object> payLoad, boolean noArmor, String tag) {
+
+    }
+}

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -5,9 +5,7 @@ import org.jpos.util.Loggeable;
 import org.json.JSONObject;
 import org.json.XML;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -15,6 +13,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -62,7 +61,7 @@ public class JSONLogEvent implements BaseLogEvent {
     @Override
     public void dump(PrintStream p, String outer, String realm, Instant dumpedAt, Instant createdAt, List<Object> payLoad, boolean noArmor, String tag) {
         try{
-            String indent = dumpHeader (p, outer, realm,dumpedAt,createdAt, noArmor);
+            dumpHeader (p, outer, realm,dumpedAt,createdAt, noArmor);
             if (payLoad.isEmpty()) {
                 if (tag != null)
                     p.print (", \"" + tag + "\":{}");
@@ -96,7 +95,7 @@ public class JSONLogEvent implements BaseLogEvent {
                         } else if (o instanceof Throwable) {
                             p.print("{ \"exception\" : { \"name\":\"" + ((Throwable) o).getMessage()+"\",");
                             p.print("\"stackTrace\":\"");
-                            ((Throwable) o).printStackTrace(p);
+                            p.print(Arrays.toString(((Throwable)o).getStackTrace()));
                             p.print("\"}");
 
                             isClosedBracket = true;

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -104,8 +104,8 @@ public class JSONLogEvent implements BaseLogEvent {
                             p.print(indent+"\"sqlexception\":\"" + e.getMessage()+"\",\n");
                             p.print(indent+"\"sqlstate\":\""+ e.getSQLState()+"\",\n");
                             p.print(indent+"\"vendorerror\":\""+ e.getErrorCode()+"\",\n");
-                            p.print(indent+"\"stacktrace\":");
-                            p.print(getCurrentStackTraceString(((Throwable)o).getStackTrace(),indent)+"\n");
+                            p.print(indent+"\"stacktrace\": [");
+                            p.print(extrapolateStackTrace((Exception) o,indent)+"]\n");
                             p.print(indent+"}");
 
                             isClosedBracket = true;
@@ -118,8 +118,8 @@ public class JSONLogEvent implements BaseLogEvent {
 
                             indent = indent(2,indent,'+');
                             p.print(indent+"\"name\":\"" + ((Throwable) o).getMessage()+"\",\n");
-                            p.print(indent+"\"stacktrace\": [ ");
-                            p.print(extrapolateStackTrace((Exception) o,indent)+" ]\n");
+                            p.print(indent+"\"stacktrace\": [");
+                            p.print(extrapolateStackTrace((Exception) o,indent)+"]\n");
                             p.print(indent+"}");
 
                             isClosedBracket = true;
@@ -201,13 +201,13 @@ public class JSONLogEvent implements BaseLogEvent {
         Throwable e = ex;
         String trace ="\""+e.toString() + "\",\n"+indent;
         for (StackTraceElement e1 : e.getStackTrace()) {
-            trace += "\"at " + e1.toString() + "\",\n"+indent;
+            trace += "   "+"\"at " + e1.toString() + "\",\n"+indent;
         }
         while (e.getCause() != null) {
             e = e.getCause();
             trace += "\"Cause by: " + e.toString() + "\",\n"+indent;
             for (StackTraceElement e1 : e.getStackTrace()) {
-                trace += "\"at " + e1.toString() + "\",\n"+indent;
+                trace += "   "+"\"at " + e1.toString() + "\",\n"+indent;
             }
         }
 

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -13,9 +13,10 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Created by erlangga on 2019-10-12.
@@ -93,17 +94,17 @@ public class JSONLogEvent implements BaseLogEvent {
                             p.print("{ \"exception\" : { \"SQLException\":\"" + e.getMessage()+"\",");
                             p.print("\"SQLState\":\""+ e.getSQLState()+"\",");
                             p.print("\"VendorError\":\""+ e.getErrorCode()+"\",");
-                            p.print("\"stackTrace\":\"");
-                            p.print(Arrays.toString(((Throwable)o).getStackTrace()));
-                            p.print("\"}");
+                            p.print("\"stackTrace\":");
+                            p.print(getCurrentStackTraceString(((Throwable)o).getStackTrace()));
+                            p.print("}");
 
                             isClosedBracket = true;
                             isExceptionOccured = true;
                         } else if (o instanceof Throwable) {
                             p.print("{ \"exception\" : { \"name\":\"" + ((Throwable) o).getMessage()+"\",");
-                            p.print("\"stackTrace\":\"");
-                            p.print(Arrays.toString(((Throwable)o).getStackTrace()));
-                            p.print("\"}");
+                            p.print("\"stackTrace\":");
+                            p.print(getCurrentStackTraceString(((Throwable)o).getStackTrace()));
+                            p.print("}");
 
                             isClosedBracket = true;
                             isExceptionOccured = true;
@@ -148,6 +149,10 @@ public class JSONLogEvent implements BaseLogEvent {
                 "\"" + message + "\"" +
                 "}";
         return json;
+    }
+
+    private String getCurrentStackTraceString(StackTraceElement[] stackTrace){
+        return Stream.of(stackTrace).map((a) -> "\"" + a.toString() + "\"").collect(Collectors.joining(",\n","[", "]"));
     }
 
     private String convertXmlToJson(String xmlString) {

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -23,9 +23,9 @@ import java.util.stream.Stream;
  */
 public class JSONLogEvent implements BaseLogEvent {
 
-    private static final String XML_TAG_PATTERN = "(?s).*(<(\\w+)[^>]*>.*</\\2>|<(\\w+)[^>]*/>).*";
-    private static final String STACK_TRACE_TAG_PATTERN = "(?m)^.*?Exception.*(?:\\R+^\\s*at .*)+";
-    private static final Pattern STACK_TRACE_REGEX = Pattern.compile(STACK_TRACE_TAG_PATTERN, Pattern.MULTILINE);
+    public static final String XML_TAG_PATTERN = "(?s).*(<(\\w+)[^>]*>.*</\\2>|<(\\w+)[^>]*/>).*";
+    private static final String STACK_TRACE_TAG_PATTERN = "(^\\d+\\) .+)|(^.+Exception: .+)|(^\\s+at .+)|(^\\s+... \\d+ more)|(^\\s*Caused by:.+)";
+    public static final Pattern STACK_TRACE_REGEX = Pattern.compile(STACK_TRACE_TAG_PATTERN, Pattern.MULTILINE);
 
     @Override
     public String dumpHeader(PrintStream p, String indent, String realm, Instant dumpedAt, Instant createdAt, boolean noArmor) {

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -89,7 +89,16 @@ public class JSONLogEvent implements BaseLogEvent {
                                 }
                             }
                         } else if (o instanceof SQLException) {
-                            p.print("SQLException");
+                            SQLException e = (SQLException) o;
+                            p.print("{ \"exception\" : { \"SQLException\":\"" + e.getMessage()+"\",");
+                            p.print("\"SQLState\":\""+ e.getSQLState()+"\",");
+                            p.print("\"VendorError\":\""+ e.getErrorCode()+"\",");
+                            p.print("\"stackTrace\":\"");
+                            p.print(Arrays.toString(((Throwable)o).getStackTrace()));
+                            p.print("\"}");
+
+                            isClosedBracket = true;
+                            isExceptionOccured = true;
                         } else if (o instanceof Throwable) {
                             p.print("{ \"exception\" : { \"name\":\"" + ((Throwable) o).getMessage()+"\",");
                             p.print("\"stackTrace\":\"");

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -81,14 +81,12 @@ public class JSONLogEvent implements BaseLogEvent {
                     for (Object o : payLoad) {
                         if (o instanceof Loggeable) {
                             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                            try (PrintStream ps = new PrintStream(baos, true, "UTF-8")) {
+                            try (PrintStream ps = new PrintStream(baos, true)) {
                                 ((Loggeable) o).dump(ps, "");
                                 String json = convertXmlToJson(new String(baos.toByteArray(), StandardCharsets.UTF_8));
                                 if(json!=null){
                                     p.print(json);
                                 }
-                            } catch (UnsupportedEncodingException e) {
-                                e.printStackTrace();
                             }
                         } else if (o instanceof SQLException) {
                             p.print("SQLException");

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -65,19 +65,23 @@ public class JSONLogEvent implements BaseLogEvent {
 
                 synchronized (payLoad) {
                     StringBuilder stringBuilder = null;
-                    if(!payLoad.isEmpty()){
-                        p.print("\"");
-                        stringBuilder = new StringBuilder();
-                    }
+                    stringBuilder = new StringBuilder();
+                    boolean isJson = false;
                     for (Object o : payLoad) {
                         if (o != null) {
-                            stringBuilder.append(o.toString()+" ");
+                            String value = o.toString();
+                            if(value.startsWith("{")){
+                                isJson = true;
+                                stringBuilder.append(o.toString()+" ");
+                            }else {
+                                stringBuilder.append("\""+o.toString()+" ");
+                            }
                         } else {
                             stringBuilder.append("null"+ " ");
                         }
                     }
                     p.print(stringBuilder.toString().trim());
-                    if(!payLoad.isEmpty()){
+                    if(!payLoad.isEmpty() && !isJson){
                         p.println("\"");
                     }
                 }
@@ -86,5 +90,14 @@ public class JSONLogEvent implements BaseLogEvent {
             dumpTrailer(p,outer,noArmor);
         }
 
+    }
+
+    @Override
+    public String addMessage(String tagname, String message) {
+        String json = "{\n" +
+                "\"" + tagname + "\":" +
+                "\"" + message + "\"\n" +
+                "}";
+        return json;
     }
 }

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -93,7 +93,6 @@ public class JSONLogEvent implements BaseLogEvent {
                         } else if (o instanceof SQLException) {
                             p.print("SQLException");
                         } else if (o instanceof Throwable) {
-                            // TODO: Fetch n lines
                             p.print("{ \"exception\" : { \"name\":\"" + ((Throwable) o).getMessage()+"\",");
                             p.print("\"stackTrace\":\"");
                             p.print(Arrays.toString(((Throwable)o).getStackTrace()));

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -33,9 +33,9 @@ public class JSONLogEvent implements BaseLogEvent {
 
             StringBuilder sb = new StringBuilder();
             sb.append("{\n");
-            indent+=indent(2,indent,'+');
+            indent+=indent(indent,'+');
             sb.append(indent+"\"log\": {\n");
-            indent = indent(2,indent,'+');
+            indent = indent(indent,'+');
             sb.append(indent+"\"realm\" : "+ "\""+realm+"\",\n");
             sb.append(indent+"\"at\" : ");
             sb.append("\""+LocalDateTime.ofInstant(dumpedAt, ZoneId.systemDefault())+"\"");
@@ -89,11 +89,10 @@ public class JSONLogEvent implements BaseLogEvent {
                         } else if (o instanceof SQLException) {
                             SQLException e = (SQLException) o;
                             p.print("{\n");
-
-                            indent = indent(2,indent,'+');
+                            indent = indent(indent,'+');
                             p.print(indent+"\"exception\" : { \n");
 
-                            indent = indent(2,indent,'+');
+                            indent = indent(indent,'+');
                             p.print(indent+"\"sqlexception\":\"" + e.getMessage()+"\",\n");
                             p.print(indent+"\"sqlstate\":\""+ e.getSQLState()+"\",\n");
                             p.print(indent+"\"vendorerror\":\""+ e.getErrorCode()+"\",\n");
@@ -106,10 +105,10 @@ public class JSONLogEvent implements BaseLogEvent {
                         } else if (o instanceof Throwable) {
                             p.print("{\n");
 
-                            indent = indent(2,indent,'+');
+                            indent = indent(indent,'+');
                             p.print(indent+"\"exception\" : {\n");
 
-                            indent = indent(2,indent,'+');
+                            indent = indent(indent,'+');
                             p.print(indent+"\"name\":\"" + ((Throwable) o).getMessage()+"\",\n");
                             p.print(indent+"\"stacktrace\": [");
                             p.print(extrapolateStackTrace((Exception) o,indent)+"]\n");
@@ -150,13 +149,13 @@ public class JSONLogEvent implements BaseLogEvent {
                         }
                     }
                     if(isClosedBracket){
-                        indent = indent(2,indent,'-');
+                        indent = indent(indent,'-');
                         p.print("\n"+indent+"}");
                     }
                 }
             }
         } finally {
-            p.print("\n"+indent(2,indent,'-')+"}");
+            p.print("\n"+indent(indent,'-')+"}");
             dumpTrailer(p,outer,noArmor);
         }
     }
@@ -173,7 +172,7 @@ public class JSONLogEvent implements BaseLogEvent {
     private String convertXmlToJson(String xmlString) {
         return XML.toJSONObject(xmlString).toString(4);
     }
-
+    
     private String extrapolateStackTrace(Exception ex, String indent) {
         Throwable e = ex;
         StringBuilder stringBuilder = new StringBuilder("\""+e.toString() + "\",\n"+indent);
@@ -192,20 +191,12 @@ public class JSONLogEvent implements BaseLogEvent {
         return trace.substring(0,trace.length()-1);
     }
 
-    private String indent(int n, String indent, char symbol) {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (symbol == '+') {
-            stringBuilder.append(indent);
-            for (int i = 0; i < n; i++) {
-                stringBuilder.append(" ");
-            }
-            return stringBuilder.toString();
+    private String indent(String indent, char symbol) {
+        if(symbol=='+'){
+            indent = indent+ "  ";
+        }else if(symbol=='-'){
+            indent = indent.substring(0,2);
         }
-
-        int length = indent.length();
-        for (int i = 0; i < (length-n); i++) {
-            stringBuilder.append(" ");
-        }
-        return stringBuilder.toString();
+        return indent;
     }
 }

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -118,8 +118,8 @@ public class JSONLogEvent implements BaseLogEvent {
 
                             indent = indent(2,indent,'+');
                             p.print(indent+"\"name\":\"" + ((Throwable) o).getMessage()+"\",\n");
-                            p.print(indent+"\"stacktrace\":");
-                            p.print(getCurrentStackTraceString(((Throwable)o).getStackTrace(),indent)+"\n");
+                            p.print(indent+"\"stacktrace\": [ ");
+                            p.print(extrapolateStackTrace((Exception) o,indent)+" ]\n");
                             p.print(indent+"}");
 
                             isClosedBracket = true;
@@ -195,6 +195,24 @@ public class JSONLogEvent implements BaseLogEvent {
             }
         }
         return jsonObject.toString(4);
+    }
+
+    private String extrapolateStackTrace(Exception ex, String indent) {
+        Throwable e = ex;
+        String trace ="\""+e.toString() + "\",\n"+indent;
+        for (StackTraceElement e1 : e.getStackTrace()) {
+            trace += "\"at " + e1.toString() + "\",\n"+indent;
+        }
+        while (e.getCause() != null) {
+            e = e.getCause();
+            trace += "\"Cause by: " + e.toString() + "\",\n"+indent;
+            for (StackTraceElement e1 : e.getStackTrace()) {
+                trace += "\"at " + e1.toString() + "\",\n"+indent;
+            }
+        }
+
+        trace = trace.trim();
+        return trace.substring(0,trace.length()-1);
     }
 
     private String indent(int n, String indent, char symbol) {

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -108,13 +108,13 @@ public class JSONLogEvent implements BaseLogEvent {
                             isExceptionOccured = true;
                         } else if (o instanceof Object[]) {
                             Object[] oa = (Object[]) o;
-                            p.print("\"[");
+                            p.print("[");
                             for (int j = 0; j < oa.length; j++) {
                                 if (j > 0)
                                     p.print(",");
-                                p.print(oa[j].toString());
+                                p.print("\""+oa[j].toString()+"\"");
                             }
-                            p.print("]\"");
+                            p.print("]");
                         } else if (o != null) {
                             if(stringBuilder.length()==0){
                                 isOpenQuote = true;

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -41,7 +41,7 @@ public class JSONLogEvent implements BaseLogEvent {
 
             p.print(sb.toString());
         }
-        return indent + " ";
+        return indent;
     }
 
     @Override
@@ -58,22 +58,26 @@ public class JSONLogEvent implements BaseLogEvent {
                 if (tag != null)
                     p.println (indent + ",\n  \"" + tag + "\":{}");
             }else {
-                String newIndent;
                 if (tag != null) {
                     if (!tag.isEmpty())
-                        p.println (indent + "{" + tag);
-                    newIndent = indent + "  ";
+                        p.print (indent + ",\n  \"" + tag+"\" : ");
                 }else
-                    newIndent = "";
                 synchronized (payLoad) {
+                    StringBuilder stringBuilder = null;
+                    if(!payLoad.isEmpty()){
+                        p.print("\"");
+                        stringBuilder = new StringBuilder();
+                    }
                     for (Object o : payLoad) {
-                        if (o instanceof Loggeable)
-                            ((Loggeable) o).dump(p, newIndent);
-                        else if (o != null) {
-                            p.println(newIndent + o.toString());
+                        if (o != null) {
+                            stringBuilder.append(o.toString()+" ");
                         } else {
-                            p.println(newIndent + "null");
+                            stringBuilder.append("null"+ " ");
                         }
+                    }
+                    p.print(stringBuilder.toString().trim());
+                    if(!payLoad.isEmpty()){
+                        p.println("\"");
                     }
                 }
                 if (tag != null && !tag.isEmpty())

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -60,8 +60,9 @@ public class JSONLogEvent implements BaseLogEvent {
             }else {
                 if (tag != null) {
                     if (!tag.isEmpty())
-                        p.print (indent + ",\n  \"" + tag+"\" : ");
-                }else
+                        p.print (indent + ",\n  \"" + tag+"\":");
+                }
+
                 synchronized (payLoad) {
                     StringBuilder stringBuilder = null;
                     if(!payLoad.isEmpty()){
@@ -80,8 +81,6 @@ public class JSONLogEvent implements BaseLogEvent {
                         p.println("\"");
                     }
                 }
-                if (tag != null && !tag.isEmpty())
-                    p.println (indent + "}");
             }
         }finally {
             dumpTrailer(p,outer,noArmor);

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -1,6 +1,11 @@
 package org.jpos.util.log.event;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
 import java.io.PrintStream;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -25,19 +30,19 @@ public class JSONLogEvent implements BaseLogEvent {
             StringBuilder sb = new StringBuilder(indent);
             sb.append ("\"log\":{\n");
             sb.append ("\"realm\":"+ "\""+realm+"\",\n");
-            sb.append("\"at=\"");
-            sb.append("\""+LocalDateTime.ofInstant(dumpedAt, ZoneId.systemDefault())+"\"\n");
+            sb.append("\"at\":");
+            sb.append("\""+LocalDateTime.ofInstant(dumpedAt, ZoneId.systemDefault())+"\"");
 
-            /*
             long elapsed = Duration.between(createdAt, dumpedAt).toMillis();
             if (elapsed > 0) {
-                sb.append (" lifespan=\"");
+                sb.append(",\n");
+                sb.append ("\"lifespan\":\"");
                 sb.append (elapsed);
                 sb.append ("ms\"");
             }
-            */
 
-            p.println (sb.toString());
+            sb.append ("\n}");
+            p.print(sb.toString());
         }
         return indent + "  ";
     }
@@ -50,6 +55,12 @@ public class JSONLogEvent implements BaseLogEvent {
 
     @Override
     public void dump(PrintStream p, String outer, String realm, Instant dumpedAt, Instant createdAt, List<Object> payLoad, boolean noArmor, String tag) {
+        try{
+            String indent = dumpHeader (p, outer, realm,dumpedAt,createdAt, noArmor);
+            p.println(indent);
+        }finally {
+            dumpTrailer(p,outer,noArmor);
+        }
 
     }
 }

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -59,7 +59,7 @@ public class JSONLogEvent implements BaseLogEvent {
     @Override
     public void dumpTrailer(PrintStream p, String indent, boolean noArmor) {
         if (!noArmor) {
-            p.print ("\n}");
+            p.print ("\n}\n");
         }
     }
 

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -1,11 +1,11 @@
 package org.jpos.util.log.event;
 
-import org.jdom2.Element;
 import org.jpos.util.Loggeable;
 import org.json.JSONObject;
 import org.json.XML;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -108,9 +108,14 @@ public class JSONLogEvent implements BaseLogEvent {
                             isClosedBracket = true;
                             isExceptionOccured = true;
                         } else if (o instanceof Object[]) {
-                            p.print("Object[]");
-                        } else if (o instanceof Element) {
-                            p.print("Element");
+                            Object[] oa = (Object[]) o;
+                            p.print("\"[");
+                            for (int j = 0; j < oa.length; j++) {
+                                if (j > 0)
+                                    p.print(",");
+                                p.print(oa[j].toString());
+                            }
+                            p.print("]\"");
                         } else if (o != null) {
                             if(stringBuilder.length()==0){
                                 isOpenQuote = true;

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -178,10 +178,6 @@ public class JSONLogEvent implements BaseLogEvent {
         return json;
     }
 
-    private String getCurrentStackTraceString(StackTraceElement[] stackTrace, String indent){
-        return Stream.of(stackTrace).map((a) -> "\"" + a.toString() + "\"").collect(Collectors.joining(",\n"+indent,"[", "]"));
-    }
-
     private String convertXmlToJson(String xmlString) {
         JSONObject jsonObject = XML.toJSONObject(xmlString);
         Iterator<String> keys = jsonObject.keys();

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -95,12 +95,18 @@ public class JSONLogEvent implements BaseLogEvent {
                             }
                         } else if (o instanceof SQLException) {
                             SQLException e = (SQLException) o;
-                            p.print("{ \"exception\" : { \"SQLException\":\"" + e.getMessage()+"\",");
-                            p.print("\"SQLState\":\""+ e.getSQLState()+"\",");
-                            p.print("\"VendorError\":\""+ e.getErrorCode()+"\",");
-                            p.print("\"stackTrace\":");
-                            p.print(getCurrentStackTraceString(((Throwable)o).getStackTrace(),indent));
-                            p.print("}");
+                            p.print("{\n");
+
+                            indent = indent(2,indent,'+');
+                            p.print(indent+"\"exception\" : { \n");
+
+                            indent = indent(2,indent,'+');
+                            p.print(indent+"\"sqlexception\":\"" + e.getMessage()+"\",\n");
+                            p.print(indent+"\"sqlstate\":\""+ e.getSQLState()+"\",\n");
+                            p.print(indent+"\"vendorerror\":\""+ e.getErrorCode()+"\",\n");
+                            p.print(indent+"\"stacktrace\":");
+                            p.print(getCurrentStackTraceString(((Throwable)o).getStackTrace(),indent)+"\n");
+                            p.print(indent+"}");
 
                             isClosedBracket = true;
                             isExceptionOccured = true;
@@ -112,7 +118,7 @@ public class JSONLogEvent implements BaseLogEvent {
 
                             indent = indent(2,indent,'+');
                             p.print(indent+"\"name\":\"" + ((Throwable) o).getMessage()+"\",\n");
-                            p.print(indent+"\"stackTrace\":");
+                            p.print(indent+"\"stacktrace\":");
                             p.print(getCurrentStackTraceString(((Throwable)o).getStackTrace(),indent)+"\n");
                             p.print(indent+"}");
 

--- a/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/JSONLogEvent.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 public class JSONLogEvent implements BaseLogEvent {
 
     private static final String XML_TAG_PATTERN = "(?s).*(<(\\w+)[^>]*>.*</\\2>|<(\\w+)[^>]*/>).*";
-    private static final String STACK_TRACE_TAG_PATTERN = "(^\\d+\\) .+)|(^.+Exception: .+)|(^\\s+at .+)|(^\\s+... \\d+ more)|(^\\s*Caused by:.+)";
+    private static final String STACK_TRACE_TAG_PATTERN = "(?m)^.*?Exception.*(?:\\R+^\\s*at .*)+";
     private static final Pattern STACK_TRACE_REGEX = Pattern.compile(STACK_TRACE_TAG_PATTERN, Pattern.MULTILINE);
 
     @Override

--- a/jpos/src/main/java/org/jpos/util/log/event/LogEventFactory.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/LogEventFactory.java
@@ -1,0 +1,15 @@
+package org.jpos.util.log.event;
+
+import static org.jpos.util.log.format.JSON.JSON_LABEL;
+
+/**
+ * Created by erlangga on 2019-10-12.
+ */
+public class LogEventFactory {
+    public static BaseLogEvent getLogEvent(String format){
+        if(JSON_LABEL.equals(format)){
+            return null;
+        }
+        return new XMLLogEvent();
+    }
+}

--- a/jpos/src/main/java/org/jpos/util/log/event/LogEventFactory.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/LogEventFactory.java
@@ -8,7 +8,7 @@ import static org.jpos.util.log.format.JSON.JSON_LABEL;
 public class LogEventFactory {
     public static BaseLogEvent getLogEvent(String format){
         if(JSON_LABEL.equals(format)){
-            return null;
+            return new JSONLogEvent();
         }
         return new XMLLogEvent();
     }

--- a/jpos/src/main/java/org/jpos/util/log/event/XMLLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/XMLLogEvent.java
@@ -1,0 +1,125 @@
+package org.jpos.util.log.event;
+
+import org.jdom2.Element;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.jpos.util.Loggeable;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+/**
+ * Created by erlangga on 2019-10-12.
+ */
+public class XMLLogEvent implements BaseLogEvent {
+
+    @Override
+    public String dumpHeader(PrintStream p, String indent, String realm, Instant dumpedAt, Instant createdAt, boolean noArmor) {
+        if (noArmor) {
+            p.println("");
+        } else {
+            if (dumpedAt == null)
+                dumpedAt = Instant.now();
+            StringBuilder sb = new StringBuilder(indent);
+            sb.append ("<log realm=\"");
+            sb.append (realm);
+            sb.append("\" at=\"");
+            sb.append(LocalDateTime.ofInstant(dumpedAt, ZoneId.systemDefault()));
+            sb.append ('"');
+            long elapsed = Duration.between(createdAt, dumpedAt).toMillis();
+            if (elapsed > 0) {
+                sb.append (" lifespan=\"");
+                sb.append (elapsed);
+                sb.append ("ms\"");
+            }
+            sb.append ('>');
+            p.println (sb.toString());
+        }
+        return indent + "  ";
+    }
+
+    @Override
+    public void dumpTrailer(PrintStream p, String indent, boolean noArmor) {
+        if (!noArmor)
+            p.println (indent + "</log>");
+    }
+
+    @Override
+    public void dump(PrintStream p, String outer, String realm, Instant dumpedAt, Instant createdAt, List<Object> payLoad, boolean noArmor, String tag) {
+        try {
+            String indent = dumpHeader (p, outer, realm,dumpedAt,createdAt, noArmor);
+            if (payLoad.isEmpty()) {
+                if (tag != null)
+                    p.println (indent + "<" + tag + "/>");
+            }
+            else {
+                String newIndent;
+                if (tag != null) {
+                    if (!tag.isEmpty())
+                        p.println (indent + "<" + tag + ">");
+                    newIndent = indent + "  ";
+                }
+                else
+                    newIndent = "";
+                synchronized (payLoad) {
+                    for (Object o : payLoad) {
+                        if (o instanceof Loggeable)
+                            ((Loggeable) o).dump(p, newIndent);
+                        else if (o instanceof SQLException) {
+                            SQLException e = (SQLException) o;
+                            p.println(newIndent + "<SQLException>"
+                                    + e.getMessage() + "</SQLException>");
+                            p.println(newIndent + "<SQLState>"
+                                    + e.getSQLState() + "</SQLState>");
+                            p.println(newIndent + "<VendorError>"
+                                    + e.getErrorCode() + "</VendorError>");
+                            ((Throwable) o).printStackTrace(p);
+                        } else if (o instanceof Throwable) {
+                            p.println(newIndent + "<exception name=\""
+                                    + ((Throwable) o).getMessage() + "\">");
+                            p.print(newIndent);
+                            ((Throwable) o).printStackTrace(p);
+                            p.println(newIndent + "</exception>");
+                        } else if (o instanceof Object[]) {
+                            Object[] oa = (Object[]) o;
+                            p.print(newIndent + "[");
+                            for (int j = 0; j < oa.length; j++) {
+                                if (j > 0)
+                                    p.print(",");
+                                p.print(oa[j].toString());
+                            }
+                            p.println("]");
+                        } else if (o instanceof Element) {
+                            p.println("");
+                            XMLOutputter out = new XMLOutputter(Format.getPrettyFormat());
+                            out.getFormat().setLineSeparator("\n");
+                            try {
+                                out.output((Element) o, p);
+                            } catch (IOException ex) {
+                                ex.printStackTrace(p);
+                            }
+                            p.println("");
+                        } else if (o != null) {
+                            p.println(newIndent + o.toString());
+                        } else {
+                            p.println(newIndent + "null");
+                        }
+                    }
+                }
+                if (tag != null && !tag.isEmpty())
+                    p.println (indent + "</" + tag + ">");
+            }
+        } catch (Throwable t) {
+            t.printStackTrace(p);
+
+        } finally {
+            dumpTrailer (p, outer, noArmor);
+        }
+    }
+}

--- a/jpos/src/main/java/org/jpos/util/log/event/XMLLogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/log/event/XMLLogEvent.java
@@ -122,4 +122,9 @@ public class XMLLogEvent implements BaseLogEvent {
             dumpTrailer (p, outer, noArmor);
         }
     }
+
+    @Override
+    public String addMessage(String tagname, String message) {
+        return "<"+tagname+">"+message+"</"+tagname+">";
+    }
 }

--- a/jpos/src/main/java/org/jpos/util/log/format/BaseLogFormat.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/BaseLogFormat.java
@@ -1,0 +1,12 @@
+package org.jpos.util.log.format;
+
+import java.io.PrintStream;
+
+/**
+ * Created by erlangga on 2019-10-12.
+ */
+public interface BaseLogFormat {
+    void openLogFile(PrintStream p);
+    void closeLogFile(PrintStream p);
+    void logDebug(PrintStream p, String message);
+}

--- a/jpos/src/main/java/org/jpos/util/log/format/BaseLogFormat.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/BaseLogFormat.java
@@ -6,7 +6,7 @@ import java.io.PrintStream;
  * Created by erlangga on 2019-10-12.
  */
 public interface BaseLogFormat {
-    void openLogFile(PrintStream p);
+    void openLogFile(PrintStream p, String className);
     void closeLogFile(PrintStream p);
     void logDebug(PrintStream p, String message);
     String getType();

--- a/jpos/src/main/java/org/jpos/util/log/format/BaseLogFormat.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/BaseLogFormat.java
@@ -9,4 +9,5 @@ public interface BaseLogFormat {
     void openLogFile(PrintStream p);
     void closeLogFile(PrintStream p);
     void logDebug(PrintStream p, String message);
+    String getType();
 }

--- a/jpos/src/main/java/org/jpos/util/log/format/JSON.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/JSON.java
@@ -12,12 +12,12 @@ public class JSON implements BaseLogFormat {
 
     @Override
     public void openLogFile(PrintStream p) {
-        p.println ("{");
+        //p.println ("{");
     }
 
     @Override
     public void closeLogFile(PrintStream p) {
-        p.println ("}");
+        //p.println ("}");
     }
 
     @Override

--- a/jpos/src/main/java/org/jpos/util/log/format/JSON.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/JSON.java
@@ -1,0 +1,31 @@
+package org.jpos.util.log.format;
+
+import java.io.PrintStream;
+
+/**
+ * Created by erlangga on 2019-10-12.
+ */
+public class JSON implements BaseLogFormat {
+
+    public static final String JSON_LABEL = "json";
+
+    @Override
+    public void openLogFile(PrintStream p) {
+
+    }
+
+    @Override
+    public void closeLogFile(PrintStream p) {
+
+    }
+
+    @Override
+    public void logDebug(PrintStream p, String message) {
+        // TODO
+    }
+
+    @Override
+    public String getType() {
+        return JSON_LABEL;
+    }
+}

--- a/jpos/src/main/java/org/jpos/util/log/format/JSON.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/JSON.java
@@ -11,7 +11,7 @@ public class JSON implements BaseLogFormat {
     public static final String JSON_LABEL = "json";
 
     @Override
-    public void openLogFile(PrintStream p) {
+    public void openLogFile(PrintStream p,String className) {
     }
 
     @Override

--- a/jpos/src/main/java/org/jpos/util/log/format/JSON.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/JSON.java
@@ -1,6 +1,7 @@
 package org.jpos.util.log.format;
 
 import java.io.PrintStream;
+import java.util.Date;
 
 /**
  * Created by erlangga on 2019-10-12.
@@ -21,7 +22,13 @@ public class JSON implements BaseLogFormat {
 
     @Override
     public void logDebug(PrintStream p, String message) {
-        // TODO
+        p.println("{");
+        p.println("\"log\" : {");
+        p.println("\"realm\" : \"rotate-log-listener\",");
+        p.println("\"at\" : \""+ new Date().toString() +"\",");
+        p.println("\"message\" : \""+ message +"\"");
+        p.println ("}");
+        p.println("}");
     }
 
     @Override

--- a/jpos/src/main/java/org/jpos/util/log/format/JSON.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/JSON.java
@@ -12,12 +12,10 @@ public class JSON implements BaseLogFormat {
 
     @Override
     public void openLogFile(PrintStream p) {
-        //p.println ("{");
     }
 
     @Override
     public void closeLogFile(PrintStream p) {
-        //p.println ("}");
     }
 
     @Override

--- a/jpos/src/main/java/org/jpos/util/log/format/JSON.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/JSON.java
@@ -11,12 +11,12 @@ public class JSON implements BaseLogFormat {
 
     @Override
     public void openLogFile(PrintStream p) {
-
+        p.println ("{");
     }
 
     @Override
     public void closeLogFile(PrintStream p) {
-
+        p.println ("}");
     }
 
     @Override

--- a/jpos/src/main/java/org/jpos/util/log/format/JSON.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/JSON.java
@@ -22,10 +22,10 @@ public class JSON implements BaseLogFormat {
     public void logDebug(PrintStream p, String message) {
         p.println("{");
         p.println("\"log\" : {");
-        p.println("\"realm\" : \"rotate-log-listener\",");
-        p.println("\"at\" : \""+ new Date().toString() +"\",");
-        p.println("\"message\" : \""+ message +"\"");
-        p.println ("}");
+        p.println("     \"realm\" : \"rotate-log-listener\",");
+        p.println("     \"at\" : \""+ new Date().toString() +"\",");
+        p.println("     \"message\" : \""+ message +"\"");
+        p.println("   }");
         p.println("}");
     }
 

--- a/jpos/src/main/java/org/jpos/util/log/format/LogFormatFactory.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/LogFormatFactory.java
@@ -1,15 +1,15 @@
 package org.jpos.util.log.format;
 
+import static org.jpos.util.log.format.JSON.JSON_LABEL;
+
 /**
  * Created by erlangga on 2019-10-12.
  */
 public class LogFormatFactory {
     public static BaseLogFormat getLogFormat(String format){
-        if(format.equals("xml")){
-            return new XML();
-        }else if(format.equals("json")){
-
+        if(JSON_LABEL.equals(format)){
+            return new JSON();
         }
-        return null;
+        return new XML();
     }
 }

--- a/jpos/src/main/java/org/jpos/util/log/format/LogFormatFactory.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/LogFormatFactory.java
@@ -1,0 +1,15 @@
+package org.jpos.util.log.format;
+
+/**
+ * Created by erlangga on 2019-10-12.
+ */
+public class LogFormatFactory {
+    public static BaseLogFormat getLogFormat(String format){
+        if(format.equals("xml")){
+            return new XML();
+        }else if(format.equals("json")){
+
+        }
+        return null;
+    }
+}

--- a/jpos/src/main/java/org/jpos/util/log/format/XML.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/XML.java
@@ -11,9 +11,9 @@ public class XML implements BaseLogFormat {
     public static final String XML_LABEL = "xml";
 
     @Override
-    public void openLogFile(PrintStream p) {
+    public void openLogFile(PrintStream p, String className) {
         p.println ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-        p.println ("<logger class=\"" + getClass().getName() + "\">");
+        p.println ("<logger class=\"" + className + "\">");
     }
 
     @Override

--- a/jpos/src/main/java/org/jpos/util/log/format/XML.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/XML.java
@@ -7,6 +7,9 @@ import java.util.Date;
  * Created by erlangga on 2019-10-12.
  */
 public class XML implements BaseLogFormat {
+
+    public static final String XML_LABEL = "xml";
+
     @Override
     public void openLogFile(PrintStream p) {
         p.println ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
@@ -23,5 +26,10 @@ public class XML implements BaseLogFormat {
         p.println ("<log realm=\"rotate-log-listener\" at=\""+new Date().toString() +"\">");
         p.println ("   "+msg);
         p.println ("</log>");
+    }
+
+    @Override
+    public String getType() {
+        return XML_LABEL;
     }
 }

--- a/jpos/src/main/java/org/jpos/util/log/format/XML.java
+++ b/jpos/src/main/java/org/jpos/util/log/format/XML.java
@@ -1,0 +1,27 @@
+package org.jpos.util.log.format;
+
+import java.io.PrintStream;
+import java.util.Date;
+
+/**
+ * Created by erlangga on 2019-10-12.
+ */
+public class XML implements BaseLogFormat {
+    @Override
+    public void openLogFile(PrintStream p) {
+        p.println ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        p.println ("<logger class=\"" + getClass().getName() + "\">");
+    }
+
+    @Override
+    public void closeLogFile(PrintStream p) {
+        p.println ("</logger>");
+    }
+
+    @Override
+    public void logDebug(PrintStream p, String msg){
+        p.println ("<log realm=\"rotate-log-listener\" at=\""+new Date().toString() +"\">");
+        p.println ("   "+msg);
+        p.println ("</log>");
+    }
+}

--- a/jpos/src/test/java/org/jpos/util/DailyLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/DailyLogListenerTest.java
@@ -457,8 +457,8 @@ public class DailyLogListenerTest {
 
     @AfterEach
     public void cleanupLogRotateAbortsTestDir() {
-        File f = logRotationTestDirectory.getDirectory();
-        System.out.println(">>> " + f.getAbsolutePath());
-        //logRotationTestDirectory.delete();
+        //File file = logRotationTestDirectory.getDirectory();
+        //System.out.println(">>>> "+file.getAbsolutePath());
+        logRotationTestDirectory.delete();
     }
 }

--- a/jpos/src/test/java/org/jpos/util/DailyLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/DailyLogListenerTest.java
@@ -457,6 +457,8 @@ public class DailyLogListenerTest {
 
     @AfterEach
     public void cleanupLogRotateAbortsTestDir() {
-        logRotationTestDirectory.delete();
+        File f = logRotationTestDirectory.getDirectory();
+        System.out.println(">>> " + f.getAbsolutePath());
+        //logRotationTestDirectory.delete();
     }
 }

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -151,7 +151,7 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -189,6 +189,45 @@ public class JsonRotateListenerTest {
     }
 
     @Test
+    public void testAddMessageLoggeableAndData() throws ConfigurationException, IOException {
+        SimpleMsg simpleMsg = new SimpleMsg(null,null){
+            @Override
+            public void dump(PrintStream p, String indent) {
+                p.println(XML_SOURCE);
+            }
+        };
+
+        String error = "<ERROR>java.io.IOException: unexpected exception\n" +
+                "\tat org.jpos.iso.BaseChannel.applyIncomingFilters(BaseChannel.java:971)\n" +
+                "\tat org.jpos.iso.BaseChannel.receive(BaseChannel.java:749)\n" +
+                "\tat org.jpos.iso.ISOServer$Session.run(ISOServer.java:344)\n" +
+                "\tat org.jpos.util.ThreadPool$PooledThread.run(ThreadPool.java:76)\n" +
+                "Caused by: java.lang.RuntimeException: Failed to Decrypt\n" +
+                "\tat org.jpos.iso.BaseChannel.applyOutgoingFilters(BaseChannel.java:956)\n" +
+                "\tat org.jpos.iso.BaseChannel.send(BaseChannel.java:592)\n" +
+                "\t... 8 more\n" +
+                "</ERROR>";
+
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent();
+        logEvent.addMessage(simpleMsg);
+        logEvent.addMessage(error);
+
+        listener.log(logEvent);
+
+        listener.logRotate();
+
+        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        System.out.print(archivedLogFile1Contents);
+        assertTrue(isJSONValid(archivedLogFile1Contents));
+    }
+
+    @Test
     public void testAddMessageObjectArray() throws ConfigurationException, IOException {
         Properties configuration = new Properties();
         configuration.setProperty("format", JSON_LABEL);

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -184,7 +184,7 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -71,7 +71,7 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -87,11 +87,10 @@ public class JsonRotateListenerTest {
         logEvent.addMessage("Mux :Mux_200Echo Interval :10000");
         listener.log(logEvent);
 
-        // when: a rotation is executed
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -108,11 +107,10 @@ public class JsonRotateListenerTest {
 
         listener.log(logEvent);
 
-        // when: a rotation is executed
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -133,7 +131,7 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -214,6 +214,31 @@ public class JsonRotateListenerTest {
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
+    @Test
+    public void testAddMessageObjectArray() throws ConfigurationException, IOException {
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        Object[] array = new Object[3];
+        array[0] = "1";
+        array[1] = "2";
+        array[2] = "3";
+
+        LogEvent logEvent = new LogEvent("array");
+        logEvent.addMessage(array);
+        listener.log(logEvent);
+
+        // when: a rotation is executed
+        listener.logRotate();
+
+        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        System.out.print(">>> " + archivedLogFile1Contents);
+        assertTrue(isJSONValid(archivedLogFile1Contents));
+    }
+
     private boolean isJSONValid(String test) {
         try {
             new JSONObject(test);

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -167,8 +167,6 @@ public class JsonRotateListenerTest {
         try {
             new JSONObject(test);
         } catch (JSONException ex) {
-            // edited, to include @Arthur's comment
-            // e.g. in case JSONArray is valid as well...
             try {
                 new JSONArray(test);
             } catch (JSONException ex1) {

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -293,6 +293,33 @@ public class JsonRotateListenerTest {
     }
 
     @Test
+    public void testAddMessageUnpack2() throws ConfigurationException, IOException {
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent("unpack");
+        logEvent.addMessage("08002020010000870008450000000282062030303030303233350046DF9003084341383836363832DF900405312E302E35DF90080B3030303031363636363635DF90170630303030303601297B22706F705F6964223A2232626332633035332D366261652D343564642D616630352D666565363932663266353730222C2273617564616761725F6964223A2247373035353633363431222C227472616E73616374696F6E5F6964223A2232376365303534662D70732D6E766E642D396238322D4B626F623237494C313932227D0010FFFF98010003388003A00190600070000002003020458020E5901C00000000000002200000000158120901062000376019002000008773D2204120845151023500003030303030323335303035303030373530333432202020474F4B414E4120544550414E204A616B617274612053656C61744A414B494420202020202020202000154130303030303030303030303633330010FFFF98010003388003A003606195A424FD3AF33C000630303030303300154A414B415254412053454C4154414E000730303030303131");
+        logEvent.addMessage("<bitmap>{3, 11, 24, 41, 46, 47, 48, 61}</bitmap>");
+        logEvent.addMessage("<unpack fld=\"3\" packager=\"org.jpos.iso.IFB_NUMERIC\">");
+        logEvent.addMessage("<value>450000</value>");
+        logEvent.addMessage("</unpack>");
+        logEvent.addMessage("<unpack fld=\"46\" packager=\"org.jpos.iso.IFB_LLLBINARY\">");
+        logEvent.addMessage("<value type='binary'>DF9003084341383836363832DF900405312E302E35DF90080B3030303031363636363635DF901706303030303036</value>");
+        logEvent.addMessage("</unpack>");
+
+        listener.log(logEvent);
+
+        listener.logRotate();
+
+        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        System.out.print(">>> " + archivedLogFile1Contents);
+        assertTrue(isJSONValid(archivedLogFile1Contents));
+    }
+
+    @Test
     public void testAddMessageStackTrace() throws ConfigurationException, IOException {
         String stackTrace = "java.security.spec.InvalidKeySpecException: java.security.InvalidKeyException: IOException: Detect premature EOF\n" +
                 "\tat sun.security.rsa.RSAKeyFactory.engineGeneratePublic(RSAKeyFactory.java:205)\n" +

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -205,11 +205,10 @@ public class JsonRotateListenerTest {
         logEvent.addMessage(array);
         listener.log(logEvent);
 
-        // when: a rotation is executed
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -220,26 +219,8 @@ public class JsonRotateListenerTest {
                 "    <unpack fld=\"3\" packager=\"org.jpos.iso.IFB_NUMERIC\">\n" +
                 "      <value>450000</value>\n" +
                 "    </unpack>\n" +
-                "    <unpack fld=\"11\" packager=\"org.jpos.iso.IFB_NUMERIC\">\n" +
-                "      <value>000282</value>\n" +
-                "    </unpack>\n" +
-                "    <unpack fld=\"24\" packager=\"org.jpos.iso.IFB_NUMERIC\">\n" +
-                "      <value>620</value>\n" +
-                "    </unpack>\n" +
-                "    <unpack fld=\"41\" packager=\"org.jpos.iso.IF_CHAR\">\n" +
-                "      <value>00000235</value>\n" +
-                "    </unpack>\n" +
                 "    <unpack fld=\"46\" packager=\"org.jpos.iso.IFB_LLLBINARY\">\n" +
                 "      <value type='binary'>DF9003084341383836363832DF900405312E302E35DF90080B3030303031363636363635DF901706303030303036</value>\n" +
-                "    </unpack>\n" +
-                "    <unpack fld=\"47\" packager=\"org.jpos.iso.IFB_LLLBINARY\">\n" +
-                "      <value type='binary'>7B22706F705F6964223A2232626332633035332D366261652D343564642D616630352D666565363932663266353730222C2273617564616761725F6964223A2247373035353633363431222C227472616E73616374696F6E5F6964223A2232376365303534662D70732D6E766E642D396238322D4B626F623237494C313932227D</value>\n" +
-                "    </unpack>\n" +
-                "    <unpack fld=\"48\" packager=\"org.jpos.iso.IFB_LLLBINARY\">\n" +
-                "      <value type='binary'>FFFF98010003388003A0</value>\n" +
-                "    </unpack>\n" +
-                "    <unpack fld=\"61\" packager=\"org.jpos.iso.IFB_LLLBINARY\">\n" +
-                "      <value type='binary'>600070000002003038458020E5901C000000000000002283099933001558200958120901062000376019002000008773D2204120845151023500003030303030323335303035303030373530333432202020474F4B414E4120544550414E204A616B617274612053656C61744A414B494420202020202020202000154130303030303030303030303633330010FFFF98010003388003A003606195A424FD3AF33C000631303030313100154A414B415254412053454C4154414E0006313030303132</value>\n" +
                 "    </unpack>";
 
         Pattern regex = Pattern.compile(XML_TAG_PATTERN);
@@ -260,7 +241,7 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -287,7 +268,7 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -344,7 +325,7 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -367,7 +348,7 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -398,7 +379,7 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
+        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -34,13 +34,9 @@ public class JsonRotateListenerTest {
             "              <header>49534F303036303030303636</header>\n" +
             "              <field id=\"0\" value=\"0800\"/>\n" +
             "              <field id=\"3\" value=\"990000\"/>\n" +
-            "              <field id=\"7\" value=\"1019150454\"/>\n" +
-            "              <field id=\"11\" value=\"000000\"/>\n" +
-            "              <field id=\"70\" value=\"301\"/>\n" +
+            "              <field id=\"7\" value=\"111111\"/>\n" +
             "            </isomsg>";
     private static final String XML_TAG_PATTERN = "(?s).*(<(\\w+)[^>]*>.*</\\2>|<(\\w+)[^>]*/>).*";
-    private static final String STACK_TRACE_TAG_PATTERN = "(^\\d+\\) .+)|(^.+Exception: .+)|(^\\s+at .+)|(^\\s+... \\d+ more)|(^\\s*Caused by:.+)";
-    private static final Pattern STACK_TRACE_REGEX = Pattern.compile(STACK_TRACE_TAG_PATTERN, Pattern.MULTILINE);
 
     private static final String JSON_TAG_PATTERN = "\\{(?:[^{}]|(\\{(?:[^{}]|(\\{[^{}]*\\}))*\\}))*\\}";
     private static final Pattern JSON_REGEX = Pattern.compile(JSON_TAG_PATTERN);
@@ -67,11 +63,9 @@ public class JsonRotateListenerTest {
         logEvent.addMessage("Unable to connect");
         listener.log(logEvent);
 
-        // when: a rotation is executed
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -90,7 +84,6 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -110,7 +103,6 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -131,7 +123,6 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -151,7 +142,6 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -184,7 +174,6 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -199,11 +188,7 @@ public class JsonRotateListenerTest {
 
         String error = "<ERROR>java.io.IOException: unexpected exception\n" +
                 "\tat org.jpos.iso.BaseChannel.applyIncomingFilters(BaseChannel.java:971)\n" +
-                "\tat org.jpos.iso.BaseChannel.receive(BaseChannel.java:749)\n" +
-                "\tat org.jpos.iso.ISOServer$Session.run(ISOServer.java:344)\n" +
-                "\tat org.jpos.util.ThreadPool$PooledThread.run(ThreadPool.java:76)\n" +
-                "Caused by: java.lang.RuntimeException: Failed to Decrypt\n" +
-                "\tat org.jpos.iso.BaseChannel.applyOutgoingFilters(BaseChannel.java:956)\n" +
+                "Caused by: java.lang.RuntimeException: Failed to \n" +
                 "\tat org.jpos.iso.BaseChannel.send(BaseChannel.java:592)\n" +
                 "\t... 8 more\n" +
                 "</ERROR>";
@@ -223,7 +208,6 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -247,19 +231,18 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
     @Test
     public void testAddMessageUnpack() throws ConfigurationException, IOException {
-        String unpack = "08002020010000870008450000000282062030303030303233350046DF9003084341383836363832DF900405312E302E35DF90080B3030303031363636363635DF90170630303030303601297B22706F705F6964223A2232626332633035332D366261652D343564642D616630352D666565363932663266353730222C2273617564616761725F6964223A2247373035353633363431222C227472616E73616374696F6E5F6964223A2232376365303534662D70732D6E766E642D396238322D4B626F623237494C313932227D0010FFFF98010003388003A00194600070000002003038458020E5901C000000000000002283099933001558200958120901062000376019002000008773D2204120845151023500003030303030323335303035303030373530333432202020474F4B414E4120544550414E204A616B617274612053656C61744A414B494420202020202020202000154130303030303030303030303633330010FFFF98010003388003A003606195A424FD3AF33C000631303030313100154A414B415254412053454C4154414E0006313030303132\n" +
+        String unpack = "0800202\n" +
                 "    <bitmap>{3, 11, 24, 41, 46, 47, 48, 61}</bitmap>\n" +
                 "    <unpack fld=\"3\" packager=\"org.jpos.iso.IFB_NUMERIC\">\n" +
                 "      <value>450000</value>\n" +
                 "    </unpack>\n" +
                 "    <unpack fld=\"46\" packager=\"org.jpos.iso.IFB_LLLBINARY\">\n" +
-                "      <value type='binary'>DF9003084341383836363832DF900405312E302E35DF90080B3030303031363636363635DF901706303030303036</value>\n" +
+                "      <value type='binary'>DF900308</value>\n" +
                 "    </unpack>";
 
         Pattern regex = Pattern.compile(XML_TAG_PATTERN);
@@ -280,7 +263,6 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -293,13 +275,13 @@ public class JsonRotateListenerTest {
         RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
 
         LogEvent logEvent = new LogEvent("unpack");
-        logEvent.addMessage("08002020010000870008450000000282062030303030303233350046DF9003084341383836363832DF900405312E302E35DF90080B3030303031363636363635DF90170630303030303601297B22706F705F6964223A2232626332633035332D366261652D343564642D616630352D666565363932663266353730222C2273617564616761725F6964223A2247373035353633363431222C227472616E73616374696F6E5F6964223A2232376365303534662D70732D6E766E642D396238322D4B626F623237494C313932227D0010FFFF98010003388003A00190600070000002003020458020E5901C00000000000002200000000158120901062000376019002000008773D2204120845151023500003030303030323335303035303030373530333432202020474F4B414E4120544550414E204A616B617274612053656C61744A414B494420202020202020202000154130303030303030303030303633330010FFFF98010003388003A003606195A424FD3AF33C000630303030303300154A414B415254412053454C4154414E000730303030303131");
+        logEvent.addMessage("08002");
         logEvent.addMessage("<bitmap>{3, 11, 24, 41, 46, 47, 48, 61}</bitmap>");
         logEvent.addMessage("<unpack fld=\"3\" packager=\"org.jpos.iso.IFB_NUMERIC\">");
         logEvent.addMessage("<value>450000</value>");
         logEvent.addMessage("</unpack>");
         logEvent.addMessage("<unpack fld=\"46\" packager=\"org.jpos.iso.IFB_LLLBINARY\">");
-        logEvent.addMessage("<value type='binary'>DF9003084341383836363832DF900405312E302E35DF90080B3030303031363636363635DF901706303030303036</value>");
+        logEvent.addMessage("<value type='binary'>DF9003084</value>");
         logEvent.addMessage("</unpack>");
 
         listener.log(logEvent);
@@ -307,7 +289,6 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -339,17 +320,12 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(">>> " + archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
     @Test
     public void testAddMessageError() throws ConfigurationException, IOException {
-        String error = "com.exception.UnLogonException: UnLogon \tat org.jpos.q2.iso.QMUXCustom.request(QMUXCustom.java:93) \tat org.jpos.q2.iso.MUXPool.request(MUXPool.java:79) \tat com.ranggalabs.swc.Switcher.SessionManagerBean.access$000(SessionManagerBean.java:25) \tat com.ranggalabs.swc.Switcher.SessionManagerBean$1.run(SessionManagerBean.java:65) \tat java.lang.Thread.run(Thread.java:748) ";
-
-        Matcher regexMatcher = STACK_TRACE_REGEX.matcher(error);
-        assertTrue(regexMatcher.find());
-        assertTrue(STACK_TRACE_REGEX.matcher(error).find());
+        String error = "com.exception.UnLogException: UnLog \tat org.jpos.q2.iso.QMUXCustom.request(QMUXCustom.java:93) \tat org.jpos.q2.iso.MUXPool.request(MUXPool.java:79) \tat com.ranggalabs.swc.Switcher.SessionManagerBean.access$000(SessionManagerBean.java:25) \tat com.ranggalabs.swc.Switcher.SessionManagerBean$1.run(SessionManagerBean.java:65) \tat java.lang.Thread.run(Thread.java:748) ";
 
         Properties configuration = new Properties();
         configuration.setProperty("format", JSON_LABEL);
@@ -364,7 +340,6 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
@@ -377,7 +352,7 @@ public class JsonRotateListenerTest {
         RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
 
         LogEvent logEvent = new LogEvent("error");
-        logEvent.addMessage("com.ranggalabs.swc.exception.UnLogonException: UnLogon ");
+        logEvent.addMessage("com.ranggalabs.swc.exception.UnLogException: UnLog ");
         logEvent.addMessage("at org.jpos.q2.iso.QMUXCustom.request(QMUXCustom.java:93) ");
         logEvent.addMessage("at org.jpos.q2.iso.MUXPool.request(MUXPool.java:79) ");
         logEvent.addMessage("at com.ranggalabs.swc.Switcher.SessionManagerBean.sessionManaging(SessionManagerBean.java:80) ");
@@ -387,22 +362,15 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
     @Test
     public void testAddMessageStackTrace() throws ConfigurationException, IOException {
         String stackTrace = "java.security.spec.InvalidKeySpecException: java.security.InvalidKeyException: IOException: Detect premature EOF\n" +
-                "\tat sun.security.rsa.RSAKeyFactory.engineGeneratePublic(RSAKeyFactory.java:205)\n" +
-                "\tat java.security.KeyFactory.generatePublic(KeyFactory.java:334)\n" +
                 "\tat java.lang.Thread.run(Thread.java:748)\n" +
                 "Caused by: java.security.InvalidKeyException: IOException: Detect premature EOF\n" +
                 "\tat sun.security.x509.X509Key.decode(X509Key.java:398)\n" +
-                "\tat sun.security.x509.X509Key.decode(X509Key.java:403)\n" +
-                "\tat sun.security.rsa.RSAPublicKeyImpl.<init>(RSAPublicKeyImpl.java:86)\n" +
-                "\tat sun.security.rsa.RSAKeyFactory.generatePublic(RSAKeyFactory.java:298)\n" +
-                "\tat sun.security.rsa.RSAKeyFactory.engineGeneratePublic(RSAKeyFactory.java:201)\n" +
                 "\t... 9 more";
 
         Properties configuration = new Properties();
@@ -418,7 +386,6 @@ public class JsonRotateListenerTest {
         listener.logRotate();
 
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        System.out.print(archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -1,13 +1,12 @@
 package org.jpos.util;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.fest.assertions.Assert;
 import org.jpos.core.ConfigurationException;
 import org.jpos.core.SimpleConfiguration;
 import org.jpos.util.log.format.JSON;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.json.XML;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +15,8 @@ import java.util.Properties;
 
 import static org.jpos.util.LogFileTestUtils.getStringFromFile;
 import static org.jpos.util.log.format.JSON.JSON_LABEL;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Created by erlangga on 2019-10-19.
@@ -24,6 +24,16 @@ import static org.junit.jupiter.api.Assertions.*;
 public class JsonRotateListenerTest {
 
     private final LogRotationTestDirectory logRotationTestDirectory = new LogRotationTestDirectory();
+
+    private static final String XML_SOURCE = "<isomsg direction=\"outgoing\">\n" +
+            "              <!-- org.jpos.iso.packager.GenericPackager[cfg/packager/iso87ascii.XML_SOURCE] -->\n" +
+            "              <header>49534F303036303030303636</header>\n" +
+            "              <field id=\"0\" value=\"0800\"/>\n" +
+            "              <field id=\"3\" value=\"990000\"/>\n" +
+            "              <field id=\"7\" value=\"1019150454\"/>\n" +
+            "              <field id=\"11\" value=\"000000\"/>\n" +
+            "              <field id=\"70\" value=\"301\"/>\n" +
+            "            </isomsg>";
 
     @Test
     public void testJsonLogDebug(){
@@ -56,7 +66,6 @@ public class JsonRotateListenerTest {
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
         System.out.print(">>> " + archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
-        assertTrue(isJSONValidJackson(archivedLogFile1Contents));
     }
 
     /*
@@ -80,7 +89,6 @@ public class JsonRotateListenerTest {
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
         System.out.print(">>> " + archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
-        assertTrue(isJSONValidJackson(archivedLogFile1Contents));
     }
 
     /*
@@ -112,7 +120,6 @@ public class JsonRotateListenerTest {
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
         System.out.print(">>> " + archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
-        assertTrue(isJSONValidJackson(archivedLogFile1Contents));
     }
 
     /*
@@ -148,17 +155,12 @@ public class JsonRotateListenerTest {
         String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
         System.out.print(">>> " + archivedLogFile1Contents);
         assertTrue(isJSONValid(archivedLogFile1Contents));
-        assertTrue(isJSONValidJackson(archivedLogFile1Contents));
     }
 
-    private boolean isJSONValidJackson(String jsonInString ) {
-        try {
-            final ObjectMapper mapper = new ObjectMapper();
-            mapper.readTree(jsonInString);
-            return true;
-        } catch (IOException e) {
-            return false;
-        }
+    @Test
+    public void testParseXmlToJson(){
+        String json = XML.toJSONObject(XML_SOURCE).toString();
+        assertTrue(isJSONValid(json));
     }
 
     private boolean isJSONValid(String test) {

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -239,6 +239,52 @@ public class JsonRotateListenerTest {
         assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
+    @Test
+    public void testAddMessageUnpack() throws ConfigurationException, IOException {
+        String unpack = "08002020010000870008450000000282062030303030303233350046DF9003084341383836363832DF900405312E302E35DF90080B3030303031363636363635DF90170630303030303601297B22706F705F6964223A2232626332633035332D366261652D343564642D616630352D666565363932663266353730222C2273617564616761725F6964223A2247373035353633363431222C227472616E73616374696F6E5F6964223A2232376365303534662D70732D6E766E642D396238322D4B626F623237494C313932227D0010FFFF98010003388003A00194600070000002003038458020E5901C000000000000002283099933001558200958120901062000376019002000008773D2204120845151023500003030303030323335303035303030373530333432202020474F4B414E4120544550414E204A616B617274612053656C61744A414B494420202020202020202000154130303030303030303030303633330010FFFF98010003388003A003606195A424FD3AF33C000631303030313100154A414B415254412053454C4154414E0006313030303132\n" +
+                "    <bitmap>{3, 11, 24, 41, 46, 47, 48, 61}</bitmap>\n" +
+                "    <unpack fld=\"3\" packager=\"org.jpos.iso.IFB_NUMERIC\">\n" +
+                "      <value>450000</value>\n" +
+                "    </unpack>\n" +
+                "    <unpack fld=\"11\" packager=\"org.jpos.iso.IFB_NUMERIC\">\n" +
+                "      <value>000282</value>\n" +
+                "    </unpack>\n" +
+                "    <unpack fld=\"24\" packager=\"org.jpos.iso.IFB_NUMERIC\">\n" +
+                "      <value>620</value>\n" +
+                "    </unpack>\n" +
+                "    <unpack fld=\"41\" packager=\"org.jpos.iso.IF_CHAR\">\n" +
+                "      <value>00000235</value>\n" +
+                "    </unpack>\n" +
+                "    <unpack fld=\"46\" packager=\"org.jpos.iso.IFB_LLLBINARY\">\n" +
+                "      <value type='binary'>DF9003084341383836363832DF900405312E302E35DF90080B3030303031363636363635DF901706303030303036</value>\n" +
+                "    </unpack>\n" +
+                "    <unpack fld=\"47\" packager=\"org.jpos.iso.IFB_LLLBINARY\">\n" +
+                "      <value type='binary'>7B22706F705F6964223A2232626332633035332D366261652D343564642D616630352D666565363932663266353730222C2273617564616761725F6964223A2247373035353633363431222C227472616E73616374696F6E5F6964223A2232376365303534662D70732D6E766E642D396238322D4B626F623237494C313932227D</value>\n" +
+                "    </unpack>\n" +
+                "    <unpack fld=\"48\" packager=\"org.jpos.iso.IFB_LLLBINARY\">\n" +
+                "      <value type='binary'>FFFF98010003388003A0</value>\n" +
+                "    </unpack>\n" +
+                "    <unpack fld=\"61\" packager=\"org.jpos.iso.IFB_LLLBINARY\">\n" +
+                "      <value type='binary'>600070000002003038458020E5901C000000000000002283099933001558200958120901062000376019002000008773D2204120845151023500003030303030323335303035303030373530333432202020474F4B414E4120544550414E204A616B617274612053656C61744A414B494420202020202020202000154130303030303030303030303633330010FFFF98010003388003A003606195A424FD3AF33C000631303030313100154A414B415254412053454C4154414E0006313030303132</value>\n" +
+                "    </unpack>";
+
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent("unpack");
+        logEvent.addMessage(unpack);
+        listener.log(logEvent);
+
+        listener.logRotate();
+
+        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        System.out.print(">>> " + archivedLogFile1Contents);
+        assertTrue(isJSONValid(archivedLogFile1Contents));
+    }
+
     private boolean isJSONValid(String test) {
         try {
             new JSONObject(test);

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -83,6 +83,28 @@ public class JsonRotateListenerTest {
         assertTrue(isJSONValidJackson(archivedLogFile1Contents));
     }
 
+    @Test
+    public void testAddMessageThrowable() throws ConfigurationException, IOException {
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent("receive");
+        logEvent.addMessage(new IndexOutOfBoundsException());
+
+        listener.log(logEvent);
+
+        // when: a rotation is executed
+        listener.logRotate();
+
+        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        System.out.print(">>> " + archivedLogFile1Contents);
+        assertTrue(isJSONValid(archivedLogFile1Contents));
+        assertTrue(isJSONValidJackson(archivedLogFile1Contents));
+    }
+
     private boolean isJSONValidJackson(String jsonInString ) {
         try {
             final ObjectMapper mapper = new ObjectMapper();
@@ -106,10 +128,6 @@ public class JsonRotateListenerTest {
             }
         }
         return true;
-    }
-
-    private RotateLogListener createRotateLogListenerWithIsoDateFormat(String logFileName) throws ConfigurationException {
-        return createRotateLogListenerWithIsoDateFormat(logFileName, null);
     }
 
     private RotateLogListener createRotateLogListenerWithIsoDateFormat(

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.Properties;
 
 import static org.jpos.util.LogFileTestUtils.getStringFromFile;
@@ -161,6 +163,34 @@ public class JsonRotateListenerTest {
     public void testParseXmlToJson(){
         String json = XML.toJSONObject(XML_SOURCE).toString();
         assertTrue(isJSONValid(json));
+    }
+
+    @Test
+    public void testAddMessageLoggeable() throws ConfigurationException, IOException {
+        SimpleMsg simpleMsg = new SimpleMsg(null,null){
+            @Override
+            public void dump(PrintStream p, String indent) {
+                p.println(XML_SOURCE);
+            }
+        };
+
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent();
+        logEvent.addMessage(simpleMsg);
+
+        listener.log(logEvent);
+
+        // when: a rotation is executed
+        listener.logRotate();
+
+        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        System.out.print(">>> " + archivedLogFile1Contents);
+        assertTrue(isJSONValid(archivedLogFile1Contents));
     }
 
     private boolean isJSONValid(String test) {

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -1,0 +1,136 @@
+package org.jpos.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.fest.assertions.Assert;
+import org.jpos.core.ConfigurationException;
+import org.jpos.core.SimpleConfiguration;
+import org.jpos.util.log.format.JSON;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.jpos.util.LogFileTestUtils.getStringFromFile;
+import static org.jpos.util.log.format.JSON.JSON_LABEL;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Created by erlangga on 2019-10-19.
+ */
+public class JsonRotateListenerTest {
+
+    private final LogRotationTestDirectory logRotationTestDirectory = new LogRotationTestDirectory();
+
+    @Test
+    public void testJsonLogDebug(){
+        RotateLogListener dailyLogListener = new DailyLogListener();
+        dailyLogListener.setBaseLogFormat(new JSON());
+        dailyLogListener.logDebug("testRotateLogListenerMsg");
+        assertNotNull(((DailyLogListener) dailyLogListener).p, "(DailyLogListener) dailyLogListener.p");
+    }
+
+    /*
+       {"log": {"realm" : "channel","at" : "2019-10-16T09:55:20.180","lifespan" : "16 ms", "connect":"Try 0 127.0.0.1:1990  Connection refused (Connection refused)Unable to connect"}}
+     */
+    @Test
+    public void testAddMessage() throws ConfigurationException, IOException {
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent("connect");
+        logEvent.addMessage("Try 0 127.0.0.1:1990 ");
+        logEvent.addMessage(" Connection refused (Connection refused)");
+        logEvent.addMessage("Unable to connect");
+        listener.log(logEvent);
+
+        // when: a rotation is executed
+        listener.logRotate();
+
+        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        System.out.print(">>> " + archivedLogFile1Contents);
+        assertTrue(isJSONValid(archivedLogFile1Contents));
+        assertTrue(isJSONValidJackson(archivedLogFile1Contents));
+    }
+
+    /*
+        {"log": {"realm" : "org.jpos.q2.iso.QMUXCustom","at" : "2019-10-16T09:55:20.263","lifespan" : "1 ms", "info":"Mux :BCAMux_200Echo Interval :10000"}}
+     */
+    @Test
+    public void testAddMessage2() throws ConfigurationException, IOException {
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent("info");
+        logEvent.addMessage("Mux :BCAMux_200Echo Interval :10000");
+        listener.log(logEvent);
+
+        // when: a rotation is executed
+        listener.logRotate();
+
+        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        System.out.print(">>> " + archivedLogFile1Contents);
+        assertTrue(isJSONValid(archivedLogFile1Contents));
+        assertTrue(isJSONValidJackson(archivedLogFile1Contents));
+    }
+
+    private boolean isJSONValidJackson(String jsonInString ) {
+        try {
+            final ObjectMapper mapper = new ObjectMapper();
+            mapper.readTree(jsonInString);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private boolean isJSONValid(String test) {
+        try {
+            new JSONObject(test);
+        } catch (JSONException ex) {
+            // edited, to include @Arthur's comment
+            // e.g. in case JSONArray is valid as well...
+            try {
+                new JSONArray(test);
+            } catch (JSONException ex1) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private RotateLogListener createRotateLogListenerWithIsoDateFormat(String logFileName) throws ConfigurationException {
+        return createRotateLogListenerWithIsoDateFormat(logFileName, null);
+    }
+
+    private RotateLogListener createRotateLogListenerWithIsoDateFormat(
+            String logFileName,
+            Properties customConfig) throws ConfigurationException {
+        RotateLogListener listener = new RotateLogListener();
+        Properties configuration = new Properties();
+        configuration.setProperty("file", logRotationTestDirectory.getDirectory().getAbsolutePath() + "/" + logFileName);
+        configuration.setProperty("copies", "10");
+        configuration.setProperty("maxsize", "1000000");
+        if (customConfig != null) {
+            configuration.putAll(customConfig);
+        }
+        logRotationTestDirectory.allowNewFileCreation();
+        listener.setConfiguration(new SimpleConfiguration(configuration));
+        return listener;
+    }
+
+    @AfterEach
+    public void cleanupLogRotateAbortsTestDir() {
+        logRotationTestDirectory.delete();
+    }
+
+}

--- a/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonRotateListenerTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
+import java.sql.SQLException;
 import java.util.Properties;
 
 import static org.jpos.util.LogFileTestUtils.getStringFromFile;
@@ -148,6 +148,27 @@ public class JsonRotateListenerTest {
         LogEvent logEvent = new LogEvent("warn");
         logEvent.addMessage(new IOException());
         logEvent.addMessage("channel-receiver-BCAChannel_101-receive");
+
+        listener.log(logEvent);
+
+        // when: a rotation is executed
+        listener.logRotate();
+
+        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        System.out.print(">>> " + archivedLogFile1Contents);
+        assertTrue(isJSONValid(archivedLogFile1Contents));
+    }
+
+    @Test
+    public void testAddMessageAndSqlException() throws ConfigurationException, IOException {
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent("receive");
+        logEvent.addMessage(new SQLException());
 
         listener.log(logEvent);
 

--- a/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
@@ -33,6 +33,8 @@ import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
 import org.jpos.core.SimpleConfiguration;
 import org.jpos.core.SubConfiguration;
+import org.jpos.iso.packager.ISO87APackagerBBitmap;
+import org.jpos.util.log.event.JSONLogEvent;
 import org.jpos.util.log.format.JSON;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
@@ -171,6 +173,42 @@ public class RotateLogListenerTest {
             assertNull(rotateLogListener.f, "rotateLogListener.f");
             assertNotNull(rotateLogListener.p, "rotateLogListener.p");
         }
+    }
+
+    @Test
+    public void testJsonLogAddMessage() throws ConfigurationException, IOException {
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent(new ISO87APackagerBBitmap(), "testLogEventTag", Integer.valueOf(-2));
+        logEvent.setBaseLogEvent(new JSONLogEvent());
+        logEvent.addMessage("false");
+
+        listener.log(logEvent);
+
+        // when: a rotation is executed
+        listener.logRotate();
+    }
+
+    @Test
+    public void testJsonLogAddMessage1() throws ConfigurationException, IOException {
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent(new Log(), "testString");
+        logEvent.setBaseLogEvent(new JSONLogEvent());
+        logEvent.addMessage("#>", "testString");
+
+        listener.log(logEvent);
+
+        // when: a rotation is executed
+        listener.logRotate();
     }
 
     @Test
@@ -362,6 +400,8 @@ public class RotateLogListenerTest {
 
     @AfterEach
     public void cleanupLogRotateAbortsTestDir() {
-        logRotationTestDirectory.delete();
+        File file = logRotationTestDirectory.getDirectory();
+        System.out.println(">>>> " + file.getAbsolutePath());
+        //logRotationTestDirectory.delete();
     }
 }

--- a/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
@@ -22,8 +22,10 @@ import static org.jpos.util.LogFileTestUtils.getStringFromFile;
 import static org.jpos.util.log.format.JSON.JSON_LABEL;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
@@ -109,14 +111,6 @@ public class RotateLogListenerTest {
     }
 
     @Test
-    public void testJsonLogDebug(){
-        RotateLogListener dailyLogListener = new DailyLogListener();
-        dailyLogListener.setBaseLogFormat(new JSON());
-        dailyLogListener.logDebug("testRotateLogListenerMsg");
-        assertNotNull(((DailyLogListener) dailyLogListener).p, "(DailyLogListener) dailyLogListener.p");
-    }
-
-    @Test
     @Disabled("test causes problems, closes stdout")
     public void testLogDebug1() throws Throwable {
         RotateLogListener dailyLogListener = new DailyLogListener();
@@ -175,7 +169,7 @@ public class RotateLogListenerTest {
         }
     }
 
-    @Test
+    /*@Test
     public void testJsonLogAddMessage() throws ConfigurationException, IOException {
         Properties configuration = new Properties();
         configuration.setProperty("format", JSON_LABEL);
@@ -191,9 +185,9 @@ public class RotateLogListenerTest {
 
         // when: a rotation is executed
         listener.logRotate();
-    }
+    }*/
 
-    @Test
+    /*@Test
     public void testJsonLogAddMessage1() throws ConfigurationException, IOException {
         Properties configuration = new Properties();
         configuration.setProperty("format", JSON_LABEL);
@@ -209,10 +203,10 @@ public class RotateLogListenerTest {
 
         // when: a rotation is executed
         listener.logRotate();
-    }
+    }*/
 
-    @Test
-    public void testJsonLogDump2() throws ConfigurationException, IOException {
+    /*@Test
+    public void testJsonLogAddMessage2() throws ConfigurationException, IOException {
         Properties configuration = new Properties();
         configuration.setProperty("format", JSON_LABEL);
 
@@ -227,50 +221,25 @@ public class RotateLogListenerTest {
 
         // when: a rotation is executed
         listener.logRotate();
-    }
+    }*/
 
-    @Test
-    public void testJsonLogRotationWorks() throws ConfigurationException, IOException {
+    /*@Test
+    public void testJsonLogAddMessage3() throws ConfigurationException, IOException {
         Properties configuration = new Properties();
         configuration.setProperty("format", JSON_LABEL);
 
         String logFileName = "JsonRotateWorksTestLog";
         RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
 
-        listener.log(new LogEvent("Message 1"));
+        LogEvent logEvent = new LogEvent(new ThreadPool(0, 0), "testString", null);
+        logEvent.setBaseLogEvent(new JSONLogEvent());
+        logEvent.addMessage("testString", "1s");
+
+        listener.log(logEvent);
 
         // when: a rotation is executed
         listener.logRotate();
-
-        // then: new events should end up in the current file and old events in the archived file
-        listener.log(new LogEvent("Message 2"));
-
-        String currentLogFileContents = getStringFromFile(logRotationTestDirectory.getFile(logFileName));
-        System.out.println(currentLogFileContents);
-        assertFalse(currentLogFileContents.contains("Message 1"), "Current log file should not contain the first message");
-        assertTrue(currentLogFileContents.contains("Message 2"), "Current log file should contain the second message");
-
-        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        assertTrue(archivedLogFile1Contents.contains("Message 1"), "Archived log file should contain the first message");
-        assertFalse(archivedLogFile1Contents.contains("Message 2"), "Archived log file should not contain the second message");
-
-        listener.logRotate();
-
-        // then: new events should end up in the current file and old events in the archived files
-        listener.log(new LogEvent("Message 3"));
-
-        currentLogFileContents = getStringFromFile(logRotationTestDirectory.getFile(logFileName));
-        assertFalse(currentLogFileContents.contains("Message 1"), "Current log file should not contain the first message");
-        assertFalse(currentLogFileContents.contains("Message 2"), "Current log file should not contain the second message");
-        assertTrue(currentLogFileContents.contains("Message 3"), "Current log file should contain the third message");
-
-        archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        assertTrue(archivedLogFile1Contents.contains("Message 2"), "Archived log file should contain the second message");
-        assertFalse(archivedLogFile1Contents.contains("Message 3"), "Archived log file should not contain the third message");
-
-        String archivedLogFile2Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".2"));
-        assertTrue(archivedLogFile2Contents.contains("Message 1"), "Archived log file should contain the first message");
-    }
+    }*/
 
     @Test
     public void testLogRotationWorks() throws Exception {
@@ -418,8 +387,6 @@ public class RotateLogListenerTest {
 
     @AfterEach
     public void cleanupLogRotateAbortsTestDir() {
-        File file = logRotationTestDirectory.getDirectory();
-        System.out.println(">>>> " + file.getAbsolutePath());
-        //logRotationTestDirectory.delete();
+        logRotationTestDirectory.delete();
     }
 }

--- a/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
@@ -173,44 +173,43 @@ public class RotateLogListenerTest {
         listener.logRotate();
 
         // then: new events should end up in the current file and old events in the archived file
-        //listener.log(new LogEvent("Message 2"));
+        listener.log(new LogEvent("Message 2"));
 
         String currentLogFileContents = getStringFromFile(logRotationTestDirectory.getFile(logFileName));
         assertFalse(currentLogFileContents.contains("Message 1"), "Current log file should not contain the first message");
-        //assertTrue(currentLogFileContents.contains("Message 2"), "Current log file should contain the second message");
-        //assertTrue(currentLogFileContents.contains("<logger "), "Logger element should have been opened in the current file");
-        //assertFalse(currentLogFileContents.contains("</logger>"), "Logger element should not have been closed in the current file");
+        assertTrue(currentLogFileContents.contains("Message 2"), "Current log file should contain the second message");
+        assertTrue(currentLogFileContents.contains("<logger "), "Logger element should have been opened in the current file");
+        assertFalse(currentLogFileContents.contains("</logger>"), "Logger element should not have been closed in the current file");
 
-        //String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        //assertTrue(archivedLogFile1Contents.contains("Message 1"), "Archived log file should contain the first message");
-        //assertFalse(archivedLogFile1Contents.contains("Message 2"), "Archived log file should not contain the second message");
-        //assertTrue(archivedLogFile1Contents.contains("<logger "), "Logger element should have been opened in the archived file");
-        //assertTrue(archivedLogFile1Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
+        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        assertTrue(archivedLogFile1Contents.contains("Message 1"), "Archived log file should contain the first message");
+        assertFalse(archivedLogFile1Contents.contains("Message 2"), "Archived log file should not contain the second message");
+        assertTrue(archivedLogFile1Contents.contains("<logger "), "Logger element should have been opened in the archived file");
+        assertTrue(archivedLogFile1Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
 
         // when: another rotation is executed
-        //listener.logRotate();
+        listener.logRotate();
 
         // then: new events should end up in the current file and old events in the archived files
-        //listener.log(new LogEvent("Message 3"));
+        listener.log(new LogEvent("Message 3"));
 
-        //currentLogFileContents = getStringFromFile(logRotationTestDirectory.getFile(logFileName));
-        //assertFalse(currentLogFileContents.contains("Message 1"), "Current log file should not contain the first message");
-        //assertFalse(currentLogFileContents.contains("Message 2"), "Current log file should not contain the second message");
-        //assertTrue(currentLogFileContents.contains("Message 3"), "Current log file should contain the third message");
-        //assertTrue(currentLogFileContents.contains("<logger "), "Logger element should have been opened in the current file");
-        //assertFalse(currentLogFileContents.contains("</logger>"), "Logger element should not have been closed in the current file");
+        currentLogFileContents = getStringFromFile(logRotationTestDirectory.getFile(logFileName));
+        assertFalse(currentLogFileContents.contains("Message 1"), "Current log file should not contain the first message");
+        assertFalse(currentLogFileContents.contains("Message 2"), "Current log file should not contain the second message");
+        assertTrue(currentLogFileContents.contains("Message 3"), "Current log file should contain the third message");
+        assertTrue(currentLogFileContents.contains("<logger "), "Logger element should have been opened in the current file");
+        assertFalse(currentLogFileContents.contains("</logger>"), "Logger element should not have been closed in the current file");
 
-        //archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        //assertTrue(archivedLogFile1Contents.contains("Message 2"), "Archived log file should contain the second message");
-        //assertFalse(archivedLogFile1Contents.contains("Message 3"), "Archived log file should not contain the third message");
-        //assertTrue(archivedLogFile1Contents.contains("<logger "), "Logger element should have been opened in the archived file");
-        //assertTrue(archivedLogFile1Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
+        archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        assertTrue(archivedLogFile1Contents.contains("Message 2"), "Archived log file should contain the second message");
+        assertFalse(archivedLogFile1Contents.contains("Message 3"), "Archived log file should not contain the third message");
+        assertTrue(archivedLogFile1Contents.contains("<logger "), "Logger element should have been opened in the archived file");
+        assertTrue(archivedLogFile1Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
 
-        //String archivedLogFile2Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".2"));
-        //assertTrue(archivedLogFile2Contents.contains("Message 1"), "Archived log file should contain the first message");
-        //assertTrue(archivedLogFile2Contents.contains("<logger "), "Logger element should have been opened in the archived file");
-        //assertTrue(archivedLogFile2Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
-
+        String archivedLogFile2Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".2"));
+        assertTrue(archivedLogFile2Contents.contains("Message 1"), "Archived log file should contain the first message");
+        assertTrue(archivedLogFile2Contents.contains("<logger "), "Logger element should have been opened in the archived file");
+        assertTrue(archivedLogFile2Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
     }
 
     @Test
@@ -309,7 +308,7 @@ public class RotateLogListenerTest {
 
     @AfterEach
     public void cleanupLogRotateAbortsTestDir() {
-        System.out.println(">>>> " + logRotationTestDirectory.getDirectory().getAbsolutePath());
-        //logRotationTestDirectory.delete();
+        //System.out.println(">>>> " + logRotationTestDirectory.getDirectory().getAbsolutePath());
+        logRotationTestDirectory.delete();
     }
 }

--- a/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
@@ -362,7 +362,6 @@ public class RotateLogListenerTest {
 
     @AfterEach
     public void cleanupLogRotateAbortsTestDir() {
-        System.out.println(">>>> " + logRotationTestDirectory.getDirectory().getAbsolutePath());
-        //logRotationTestDirectory.delete();
+        logRotationTestDirectory.delete();
     }
 }

--- a/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
@@ -173,43 +173,43 @@ public class RotateLogListenerTest {
         listener.logRotate();
 
         // then: new events should end up in the current file and old events in the archived file
-        listener.log(new LogEvent("Message 2"));
+        //listener.log(new LogEvent("Message 2"));
 
         String currentLogFileContents = getStringFromFile(logRotationTestDirectory.getFile(logFileName));
         assertFalse(currentLogFileContents.contains("Message 1"), "Current log file should not contain the first message");
-        assertTrue(currentLogFileContents.contains("Message 2"), "Current log file should contain the second message");
-        assertTrue(currentLogFileContents.contains("<logger "), "Logger element should have been opened in the current file");
-        assertFalse(currentLogFileContents.contains("</logger>"), "Logger element should not have been closed in the current file");
+        //assertTrue(currentLogFileContents.contains("Message 2"), "Current log file should contain the second message");
+        //assertTrue(currentLogFileContents.contains("<logger "), "Logger element should have been opened in the current file");
+        //assertFalse(currentLogFileContents.contains("</logger>"), "Logger element should not have been closed in the current file");
 
-        String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        assertTrue(archivedLogFile1Contents.contains("Message 1"), "Archived log file should contain the first message");
-        assertFalse(archivedLogFile1Contents.contains("Message 2"), "Archived log file should not contain the second message");
-        assertTrue(archivedLogFile1Contents.contains("<logger "), "Logger element should have been opened in the archived file");
-        assertTrue(archivedLogFile1Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
+        //String archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        //assertTrue(archivedLogFile1Contents.contains("Message 1"), "Archived log file should contain the first message");
+        //assertFalse(archivedLogFile1Contents.contains("Message 2"), "Archived log file should not contain the second message");
+        //assertTrue(archivedLogFile1Contents.contains("<logger "), "Logger element should have been opened in the archived file");
+        //assertTrue(archivedLogFile1Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
 
         // when: another rotation is executed
-        listener.logRotate();
+        //listener.logRotate();
 
         // then: new events should end up in the current file and old events in the archived files
-        listener.log(new LogEvent("Message 3"));
+        //listener.log(new LogEvent("Message 3"));
 
-        currentLogFileContents = getStringFromFile(logRotationTestDirectory.getFile(logFileName));
-        assertFalse(currentLogFileContents.contains("Message 1"), "Current log file should not contain the first message");
-        assertFalse(currentLogFileContents.contains("Message 2"), "Current log file should not contain the second message");
-        assertTrue(currentLogFileContents.contains("Message 3"), "Current log file should contain the third message");
-        assertTrue(currentLogFileContents.contains("<logger "), "Logger element should have been opened in the current file");
-        assertFalse(currentLogFileContents.contains("</logger>"), "Logger element should not have been closed in the current file");
+        //currentLogFileContents = getStringFromFile(logRotationTestDirectory.getFile(logFileName));
+        //assertFalse(currentLogFileContents.contains("Message 1"), "Current log file should not contain the first message");
+        //assertFalse(currentLogFileContents.contains("Message 2"), "Current log file should not contain the second message");
+        //assertTrue(currentLogFileContents.contains("Message 3"), "Current log file should contain the third message");
+        //assertTrue(currentLogFileContents.contains("<logger "), "Logger element should have been opened in the current file");
+        //assertFalse(currentLogFileContents.contains("</logger>"), "Logger element should not have been closed in the current file");
 
-        archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
-        assertTrue(archivedLogFile1Contents.contains("Message 2"), "Archived log file should contain the second message");
-        assertFalse(archivedLogFile1Contents.contains("Message 3"), "Archived log file should not contain the third message");
-        assertTrue(archivedLogFile1Contents.contains("<logger "), "Logger element should have been opened in the archived file");
-        assertTrue(archivedLogFile1Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
+        //archivedLogFile1Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".1"));
+        //assertTrue(archivedLogFile1Contents.contains("Message 2"), "Archived log file should contain the second message");
+        //assertFalse(archivedLogFile1Contents.contains("Message 3"), "Archived log file should not contain the third message");
+        //assertTrue(archivedLogFile1Contents.contains("<logger "), "Logger element should have been opened in the archived file");
+        //assertTrue(archivedLogFile1Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
 
-        String archivedLogFile2Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".2"));
-        assertTrue(archivedLogFile2Contents.contains("Message 1"), "Archived log file should contain the first message");
-        assertTrue(archivedLogFile2Contents.contains("<logger "), "Logger element should have been opened in the archived file");
-        assertTrue(archivedLogFile2Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
+        //String archivedLogFile2Contents = getStringFromFile(logRotationTestDirectory.getFile(logFileName + ".2"));
+        //assertTrue(archivedLogFile2Contents.contains("Message 1"), "Archived log file should contain the first message");
+        //assertTrue(archivedLogFile2Contents.contains("<logger "), "Logger element should have been opened in the archived file");
+        //assertTrue(archivedLogFile2Contents.contains("</logger>"), "Logger element should have been closed in the archived file");
 
     }
 
@@ -309,6 +309,7 @@ public class RotateLogListenerTest {
 
     @AfterEach
     public void cleanupLogRotateAbortsTestDir() {
-        logRotationTestDirectory.delete();
+        System.out.println(">>>> " + logRotationTestDirectory.getDirectory().getAbsolutePath());
+        //logRotationTestDirectory.delete();
     }
 }

--- a/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
+++ b/jpos/src/test/java/org/jpos/util/RotateLogListenerTest.java
@@ -212,6 +212,24 @@ public class RotateLogListenerTest {
     }
 
     @Test
+    public void testJsonLogDump2() throws ConfigurationException, IOException {
+        Properties configuration = new Properties();
+        configuration.setProperty("format", JSON_LABEL);
+
+        String logFileName = "JsonRotateWorksTestLog";
+        RotateLogListener listener = createRotateLogListenerWithIsoDateFormat(logFileName, configuration);
+
+        LogEvent logEvent = new LogEvent("testLogEventTag", null);
+        logEvent.setBaseLogEvent(new JSONLogEvent());
+        logEvent.addMessage("testString", "1s");
+
+        listener.log(logEvent);
+
+        // when: a rotation is executed
+        listener.logRotate();
+    }
+
+    @Test
     public void testJsonLogRotationWorks() throws ConfigurationException, IOException {
         Properties configuration = new Properties();
         configuration.setProperty("format", JSON_LABEL);


### PR DESCRIPTION
Modified jpos log to support json format logging. Case if we shipping the logs file to a log aggregator and using json for standar message passing.

Below add format configuration (default format is xml) :

```
<log-listener class="org.jpos.util.DailyLogListener">
        <property name="format" value="json" />
        <property name="window" value="86400" />
        <property name="prefix" value="log/q2-json" />
        <property name="suffix" value=".log"/>
</log-listener>
```

Example Logs :

```
{
  "log": {
    "realm": "",
    "at": "2019-10-25T09:57:01.382233",
    "unpack": {
      "bitmap": "{3, 11, 24, 41, 46, 47, 48, 61}",
      "unpack": [
        {
          "packager": "org.jpos.iso.IFB_NUMERIC",
          "value": 450000,
          "fld": 3
        },
        {
          "packager": "org.jpos.iso.IFB_LLLBINARY",
          "value": {
            "type": "binary",
            "content": "DF90030"
          },
          "fld": 46
        }
      ]
    }
  }
}
{
  "log": {
    "realm": "",
    "at": "2019-10-25T09:57:01.377541",
    "error": "com.ranggalabs.swc.exception.Exception: UnLog at org.jpos.q2.iso.MUXPool.request(MUXPool.java:79) at com.ranggalabs.swc.Switcher.SessionManagerBean.sessionManaging(SessionManagerBean.java:80) "
  }
}
{
  "log": {
    "realm": "",
    "at": "2019-10-25T09:57:01.351143",
    "unpack": {
      "bitmap": "{3, 11, 24, 41, 46, 47, 48, 61}",
      "unpack": [
        {
          "packager": "org.jpos.iso.IFB_NUMERIC",
          "value": 450000,
          "fld": 3
        },
        {
          "packager": "org.jpos.iso.IFB_LLLBINARY",
          "value": {
            "type": "binary",
            "content": "DF90030"
          },
          "fld": 46
        }
      ]
    }
  }
}
{
  "log": {
    "realm": "",
    "at": "2019-10-25T09:57:01.361113",
    "lifespan": "4 ms",
    "receive": {
      "exception": {
        "sqlexception": "null",
        "sqlstate": "null",
        "vendorerror": "0",
        "stacktrace": [
          "java.sql.SQLException",
          "at org.jpos.util.JsonRotateListenerTest.testAddMessageAndSqlException(JsonRotateListenerTest.java:147)",
          "at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)",
          "at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)",
          "at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)",
          "at java.base/java.lang.reflect.Method.invoke(Method.java:567)",
          "at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)",
          "at java.base/java.lang.Thread.run(Thread.java:835)"
        ]
      }
    }
  }
}
{
  "log": {
    "realm": "",
    "at": "2019-10-25T09:57:01.308615",
    "info": {
      "isomsg": {
        "field": [
          {
            "id": 0,
            "value": "0800"
          },
          {
            "id": 3,
            "value": 990000
          },
          {
            "id": 7,
            "value": 101915
          }
        ],
        "header": "49534F303",
        "direction": "outgoing"
      }
    }
  }
}
```