### PR TITLE
jPOS-260 FSDMsg copy doesn't support a default value

### DIFF
--- a/jpos/src/main/java/org/jpos/util/FSDMsg.java
+++ b/jpos/src/main/java/org/jpos/util/FSDMsg.java
@@ -553,6 +553,9 @@ public class FSDMsg implements Loggeable, Cloneable {
     public void copy (String fieldName, FSDMsg msg) {
         fields.put (fieldName, msg.get (fieldName));
     }
+    public void copy (String fieldName, FSDMsg msg, String def) {
+        fields.put (fieldName, msg.get(fieldName, def));
+    }
     public byte[] getHexBytes (String name) {
         String s = get (name);
         return s == null ? null : ISOUtil.hex2byte (s);

--- a/jpos/src/test/java/org/jpos/util/FSDMsgTest.java
+++ b/jpos/src/test/java/org/jpos/util/FSDMsgTest.java
@@ -105,6 +105,17 @@ public class FSDMsgTest {
     }
 
     @Test
+    void testCopyWithDefault() throws Throwable {
+        FSDMsg original = new FSDMsg("testFSDMsgBasePath");
+        FSDMsg copy = new FSDMsg("testFSDMsgBasePath");
+        original.set("testfield", "avalue");
+        copy.copy("testfield", original, "default");
+        copy.copy("notset", original, "default");
+        assertEquals("avalue", copy.get("testfield"));
+        assertEquals("default", copy.get("notset"));
+    }
+
+    @Test
     public void testCopyThrowsNullPointerException() throws Throwable {
         FSDMsg fSDMsg = new FSDMsg("testFSDMsgBasePath", "testFSDMsgBaseSchema");
         try {


### PR DESCRIPTION
Additional copy method was added since some people might rely on the existing behavior of the existing copy method.