### PR TITLE
Parser class for Issuer Application Data (IAD, 0x9F10).

### DIFF
--- a/jpos/src/main/java/org/jpos/emv/IssuerApplicationData.java
+++ b/jpos/src/main/java/org/jpos/emv/IssuerApplicationData.java
@@ -1,0 +1,248 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2019 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.emv;
+
+import java.io.PrintStream;
+import java.util.Objects;
+
+import org.jpos.iso.ISOUtil;
+import org.jpos.util.Loggeable;
+
+/**
+ * Issuer Application Data parser (IAD, tag 0x9F10) with support for the following formats:
+ * 
+ * - VIS 1.5
+ * - M/CHIP 4
+ * - EMV Format A (as per the EMV 4.3 Book 3 spec)
+ */
+public final class IssuerApplicationData implements Loggeable {
+
+    private final String iad;
+    private String cvn;
+    private String cvr;
+    private String dki;
+    private String idd;
+    private String dac;
+    private String counters;
+    private Format format;
+    private String cci;
+
+    /**
+     * 
+     * @param hexIAD Hexadecimal (String) representation of the IAD.
+     */
+    public IssuerApplicationData(String hexIAD) {
+
+        Objects.requireNonNull(hexIAD, "IAD data cannot be null.");
+
+        iad = hexIAD.trim();
+
+        if (iad.length() < 14)
+            throw new IllegalArgumentException("Invalid IAD length.");
+
+        format = Format.UNKNOWN;
+
+        if (iad.length() == 36 || iad.length() == 52)
+            unpackMCHIP(iad);
+        else if (iad.length() == 64 && 
+                iad.startsWith("0F") && iad.substring(32, 34).equals("0F"))
+            unpackEMVFormatA(iad);
+        else if ((iad.length() <= 46 && iad.startsWith("06")) || 
+                (iad.length() == 64 && iad.startsWith("1F")))
+            unpackVIS(iad);
+        else
+            unpackOther(iad);
+    }
+
+    /**
+     * 
+     * @param iad Byte array representation of the IAD.
+     */
+    public IssuerApplicationData(byte[] iad) {
+
+        this(ISOUtil.byte2hex(Objects.requireNonNull(iad, "IAD data cannot be null.")));
+    }
+
+    private void unpackMCHIP(String data) {
+
+        format = Format.M_CHIP;
+        dki = data.substring(0, 2);
+        cvn = data.substring(2, 4);
+        cvr = data.substring(4, 16);
+        dac = data.substring(16, 20);
+        counters = data.substring(20, 36);        
+    }
+
+    private void unpackVIS(String iad) {
+
+        format = Format.VIS;
+        boolean format2 = iad.length() == 64;
+
+        if (format2) {
+            cvn = iad.substring(2, 4);
+            dki = iad.substring(4, 6);
+            cvr = iad.substring(6, 16);
+            idd = iad.substring(16);
+        }
+        else {
+            dki = iad.substring(2, 4);
+            cvn = iad.substring(4, 6);
+            cvr = iad.substring(6, 14);
+
+            if (iad.length() > 14)
+                idd = iad.substring(13);
+        }
+    }
+
+    private void unpackEMVFormatA(String data) {
+
+        format = Format.EMV_FORMAT_A;
+        cci = data.substring(2, 4);
+        dki = data.substring(4, 6);
+        cvr = data.substring(6, 16);
+        idd = data.substring(34);
+    }  
+
+    private void unpackOther(String data) {
+
+        format = Format.OTHER;
+        dki = data.substring(2, 4);
+        cvn = data.substring(4, 6);
+
+        if (data.length() == 64) {            
+            String bridge = dki;
+            dki = cvn;
+            cvn = bridge;            
+        }
+
+        int cvrLength = Integer.parseInt(data.substring(0, 2), 16);
+        cvr = data.substring(8, 8 + cvrLength);
+
+        if ((8 + 2 + cvrLength) < data.length())
+            idd = data.substring(8 + 2 + cvrLength);        
+    }    
+
+    /**
+     * 
+     * @return A hexadecimal representation of the Derivation Key Index (DKI).
+     */
+    public String getDerivationKeyIndex() {
+        return dki;
+    }
+
+    /**
+     * 
+     * @return A hexadecimal representation of the Cryptogram Version Number (CVN).
+     */
+    public String getCryptogramVersionNumber() {
+        return cvn;
+    }
+
+    /**
+     * 
+     * @return A hexadecimal representation of the Common Core Identifier (CCI)
+     */
+    public String getCommonCoreIdentifier() {
+        return cci;
+    }
+    
+    /**
+     * 
+     * @return A hexadecimal representation of the Card Verification Results (CVR).
+     */
+    public String getCardVerificationResults() {
+        return cvr;
+    }
+
+    /**
+     * 
+     * @return A hexadecimal representation of the DAC/ICC dynamic number.
+     */
+    public String getDAC() {
+        return dac;
+    }
+
+    /**
+     * 
+     * @return A hexadecimal representation of multiple counters, depending on the format.
+     */
+    public String getCounters() {
+        return counters;
+    }
+
+    /**
+     * 
+     * @return The format of the IAD.
+     */
+    public Format getFormat() {
+        return format;
+    }
+
+    /**
+     * 
+     * @return The Isser Discretionary Data (IDD).
+     */
+    public String getIssuerDiscretionaryData() {
+        return idd;
+    }
+
+    @Override
+    public String toString() {
+        return iad;
+    }
+
+    @Override
+    public void dump(PrintStream p, String indent) {
+        
+        String inner = indent + "  ";
+        
+        p.printf("%s<iad format='%s' value='%s'>", indent, getFormat().toString(), iad);
+
+        if (cci != null)
+            p.printf("%n%sCommon core identifier: '%s'", inner, getCommonCoreIdentifier());
+
+        if (dki != null)
+            p.printf("%n%sKey derivation index: '%s'", inner, getDerivationKeyIndex());
+
+        if (cvn != null)
+            p.printf("%n%sCryptogram version number: '%s'", inner, getCryptogramVersionNumber());
+
+        if (cvr != null)
+            p.printf("%n%sCard verification results: '%s'", inner, getCardVerificationResults());
+
+        if (idd != null)
+            p.printf("%n%sIssuer discretionary data: '%s'", inner, getIssuerDiscretionaryData());            
+
+        if (dac != null)
+            p.printf("%n%sDAC/ICC dynamic number: '%s'", inner, getDAC());            
+
+        if (counters != null)
+            p.printf("%n%sPlaintext/Encrypted counters: '%s'", inner, getCounters());            
+
+        p.printf("%n%s</iad>%n", indent);  
+    }
+
+    public enum Format {
+        UNKNOWN,
+        OTHER,
+        M_CHIP,
+        EMV_FORMAT_A,
+        VIS
+    }
+}

--- a/jpos/src/test/java/org/jpos/emv/IssuerApplicationDataTest.java
+++ b/jpos/src/test/java/org/jpos/emv/IssuerApplicationDataTest.java
@@ -1,0 +1,122 @@
+package org.jpos.emv;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.jpos.emv.IssuerApplicationData.Format;
+import org.junit.jupiter.api.Test;
+
+public class IssuerApplicationDataTest {
+
+    @Test
+    public void testConstructorWithInvalidLength() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new IssuerApplicationData("9383");
+        });
+    }
+
+    @Test
+    public void testConstructorWithBlankArgument() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new IssuerApplicationData(new String(new char[64]));
+        });
+    }    
+
+    @Test
+    public void testConstructorWithNullArgument() {
+        assertThrows(NullPointerException.class, () -> {
+            new IssuerApplicationData((String) null);
+        });
+    }
+    
+    @Test
+    public void testConstructorWithEmptyByteArray() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new IssuerApplicationData(new byte[] {});
+        });
+    }
+    
+    @Test
+    public void testToString() {
+        String hexIAD = "0110250000044000DAC10000000000000000";
+        IssuerApplicationData iad = new IssuerApplicationData(hexIAD);
+        assertEquals(hexIAD, iad.toString());
+    }
+
+    @Test
+    public void testMChip4_1() {
+        String hexIAD = "0110250000044000DAC10000000000000000";
+        IssuerApplicationData iad = new IssuerApplicationData(hexIAD);
+        iad.dump(System.out, "");
+        assertEquals(Format.M_CHIP, iad.getFormat());
+        assertEquals("250000044000", iad.getCardVerificationResults(), "CVR matches.");
+        assertEquals("01", iad.getDerivationKeyIndex(), "KDI matches.");
+        assertEquals("10", iad.getCryptogramVersionNumber(), "CVN matches.");
+        assertEquals("DAC1", iad.getDAC(), "DAC/ICC dynamic number matches.");
+    }
+    
+    @Test
+    public void testMChip4_2() {
+        IssuerApplicationData iad = new IssuerApplicationData("0210A00000000000000000000000000000FF");
+        iad.dump(System.out, "");
+        assertEquals(Format.M_CHIP, iad.getFormat());
+        assertEquals("A00000000000", iad.getCardVerificationResults(), "CVR matches.");
+        assertEquals("00000000000000FF", iad.getCounters(), "Plaintext/Encrypted counters matches.");
+        assertEquals("02", iad.getDerivationKeyIndex(), "KDI matches.");
+        assertEquals("0000", iad.getDAC(), "DAC/ICC dynamic number matches.");
+
+    }
+    
+    @Test
+    public void testRandom() {
+        IssuerApplicationData iad = new IssuerApplicationData("0110201009248400000000000000000029ff");
+        iad.dump(System.out, "");    
+        assertEquals("201009248400", iad.getCardVerificationResults(), "CVR matches.");
+        assertEquals("00000000000029ff", iad.getCounters(), "Plaintext/Encrypted counters matches.");        
+    }
+        
+    @Test
+    public void testVIS15_1() {
+        IssuerApplicationData iad = new IssuerApplicationData("06010A03A40000");
+        iad.dump(System.out, "");
+        assertEquals(Format.VIS, iad.getFormat());        
+        assertEquals("03A40000", iad.getCardVerificationResults(), "CVR matches.");
+        assertEquals("0A", iad.getCryptogramVersionNumber(), "CVN matches.");
+        assertEquals("01", iad.getDerivationKeyIndex(), "KDI matches.");
+    }
+    
+    @Test
+    public void testVIS15_2() {
+        IssuerApplicationData iad = new IssuerApplicationData(
+                "1F43010020000000000000000007717300000000000000000000000000000000");
+        iad.dump(System.out, "");
+        assertEquals(Format.VIS, iad.getFormat());
+        assertEquals("01", iad.getDerivationKeyIndex(), "KDI matches.");
+        assertEquals("43", iad.getCryptogramVersionNumber(), "CVN matches.");
+        assertEquals("0020000000", iad.getCardVerificationResults(), "CVR matches.");
+        assertEquals("000000000007717300000000000000000000000000000000", iad.getIssuerDiscretionaryData(), "CVN matches.");
+    }
+    
+    @Test
+    public void testVIS15_3() {
+        String hexIAD = "06010A03A020000F04000000000000000000006232E4F9";
+        IssuerApplicationData iad = new IssuerApplicationData(hexIAD);
+        iad.dump(System.out, "");
+        assertEquals(Format.VIS, iad.getFormat());
+        assertEquals("03A02000", iad.getCardVerificationResults(), "CVR matches.");
+        assertEquals("01", iad.getDerivationKeyIndex(), "KDI matches.");
+        assertEquals("0A", iad.getCryptogramVersionNumber(), "CVN matches.");
+        assertEquals("00F04000000000000000000006232E4F9", iad.getIssuerDiscretionaryData(),
+                "Issuer discretionary data matches.");
+    }
+        
+    @Test
+    public void testEMVFormatA() {
+        IssuerApplicationData iad = new IssuerApplicationData("0FA506A231C0020000000000000000000F110601010000000000000000000000");
+        iad.dump(System.out, "");
+        assertEquals(Format.EMV_FORMAT_A, iad.getFormat());        
+        assertEquals("06", iad.getDerivationKeyIndex(), "KDI matches.");        
+        assertEquals("A231C00200", iad.getCardVerificationResults(), "CVR matches.");
+        assertEquals("110601010000000000000000000000", iad.getIssuerDiscretionaryData(), "CVN matches.");
+    }       
+}


### PR DESCRIPTION
`IssuerApplicationData` is a parser for IAD  (EMV tag `0x9F10`) with support for the following formats:

- VIS 1.5
- M/CHIP 4
- EMV Format A (as per the EMV 4.3 Book 3 spec)

It implements `Loggeable` and produces dumps like the following:

```
<iad format='M_CHIP' value='0110250000044000DAC10000000000000000'>
  Key derivation index: '01'
  Cryptogram version number: '10'
  Card verification results: '250000044000'
  DAC/ICC dynamic number: 'DAC1'
  Plaintext/Encrypted counters: '0000000000000000'
</iad>
```