### PR TITLE
Support for LogEventWriters, allowing the customization of how LogEve…

### DIFF
--- a/jpos/src/main/java/org/jpos/util/LogEventWriter.java
+++ b/jpos/src/main/java/org/jpos/util/LogEventWriter.java
@@ -1,0 +1,36 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2020 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.util;
+
+import java.io.PrintStream;
+
+/**
+ * LogEventWriters allow the customization of how LogListeners write LogEvent data to
+ * output streams.
+ *
+ * Its purpose is the formatting of output data and not the modification of individual events.
+ *
+ * @author Alwyn Schoeman
+ * @since 2.1.4
+ */
+public interface LogEventWriter {
+    void write(LogEvent ev);
+    void setPrintStream(PrintStream printStream);
+    void close();
+}

--- a/jpos/src/main/java/org/jpos/util/SimpleLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/SimpleLogListener.java
@@ -18,7 +18,14 @@
 
 package org.jpos.util;
 
+import org.jdom2.Element;
+import org.jpos.core.Configurable;
+import org.jpos.core.ConfigurationException;
+import org.jpos.core.XmlConfigurable;
+import org.jpos.q2.SimpleConfigurationFactory;
+
 import java.io.PrintStream;
+import java.util.function.Consumer;
 
 /**
  * @author <a href="mailto:apr@cs.com.uy">Alejandro P. Revilla</a>
@@ -26,7 +33,8 @@ import java.io.PrintStream;
  * @see org.jpos.core.Configurable
  * @since jPOS 1.2
  */
-public class SimpleLogListener implements LogListener {
+public class SimpleLogListener implements LogListener, XmlConfigurable, Consumer<LogEventWriter> {
+    LogEventWriter writer = null;
     PrintStream p;
 
     public SimpleLogListener () {
@@ -39,19 +47,67 @@ public class SimpleLogListener implements LogListener {
     }
     public synchronized void setPrintStream (PrintStream p) {
         this.p = p;
+        if (writer != null) {
+            writer.setPrintStream(p);
+        }
     }
     public synchronized void close() {
+        // writer either wraps or use same PrintStream
+        if (writer != null) {
+            writer.close();
+            p = null;
+        }
         if (p != null) {
             p.close();
             p = null;
         }
     }
     public synchronized LogEvent log (LogEvent ev) {
-        if (p != null) {
-            ev.dump (p, "");
-            p.flush();
+        if (writer != null) {
+            writer.write(ev);
+        } else {
+            if (p != null) {
+                ev.dump(p, "");
+                p.flush();
+            }
         }
         return ev;
+    }
+
+    @Override
+    public void accept(LogEventWriter writer) {
+        if (p != null) {
+            writer.setPrintStream(p);
+        }
+        this.writer = writer;
+    }
+
+    @Override
+    public void setConfiguration(Element e) throws ConfigurationException {
+        Element ew = e.getChild("writer");
+        LogEventWriter writer;
+        if (ew != null) {
+            String clazz = ew.getAttributeValue("class");
+            if (clazz != null) {
+                try {
+                    writer = (LogEventWriter) Class.forName(clazz).newInstance();
+                } catch (Exception ex) {
+                    throw new ConfigurationException(ex);
+                }
+                if (writer != null) {
+                    if (writer instanceof Configurable) {
+                        SimpleConfigurationFactory factory = new SimpleConfigurationFactory();
+                        ((Configurable) writer).setConfiguration(factory.getConfiguration(ew));
+                    }
+                    if (writer instanceof XmlConfigurable) {
+                        ((XmlConfigurable) writer).setConfiguration(ew);
+                    }
+                    accept(writer);
+                }
+            } else {
+                throw new ConfigurationException("The writer configuration requires a class attribute");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
…nt writes to the output stream.

Added LogEventWriter interface.
Modified SimpleLogListener to support the interface, thus allowing log output customization for all derived classes of SimpleLogListener.

The purpose of this change is to decouple LogEvent from the LogListener.
This will allow the following:
* Modification of LogEvent's configuration without impacting existing call sites or polluting the LogListener with configuration options.
* The responsibility of writing to output streams can eventually be removed from LogEvent.  LogEvent should only hold data and the writer should be the one formatting that data.  Thus different formats can be accomplished using a different writer.  There are some huge challenges in doing this, but it brings this one step closer.