### PR TITLE
Update ThreadPool.java

### DIFF
--- a/jpos/src/main/java/org/jpos/util/ThreadPool.java
+++ b/jpos/src/main/java/org/jpos/util/ThreadPool.java
@@ -163,7 +163,6 @@ public class ThreadPool extends ThreadGroup implements LogSource, Loggeable, Con
         p.println (inner  + "<jobs>" + getJobCount() + "</jobs>");
         p.println (inner  + "<size>" + getPoolSize() + "</size>");
         p.println (inner  + "<max>"  + getMaxPoolSize() + "</max>");
-        p.println (inner  + "<active>" + getActiveCount() + "</active>");
         p.println (inner  + "<idle>"  + getIdleCount() + "</idle>");
         p.println (inner  + "<active>"  + getActiveCount() + "</active>");
         p.println (inner  + "<pending>" + getPendingCount() + "</pending>");


### PR DESCRIPTION
Active count logged twice, remove one entry.

  <warn>
    pool exhausted ServerSocket[addr=0.0.0.0/0.0.0.0,localport=8888]
    <thread-pool name="discover-network-server-ThreadPool-0">
      <jobs>3</jobs>
      <size>3</size>
      <max>3</max>
      <active>3</active>
      <idle>0</idle>
      <active>3</active>
      <pending>0</pending>
    </thread-pool>
  </warn>