### PR TITLE
Run tests under openjdk 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ jdk:
   - openjdk11
   - openjdk12
   - openjdk13
+  - openjdk14
 before_script:
   - echo $JAVA_OPTS
   - export JAVA_OPTS=-Xmx4G


### PR DESCRIPTION
May want to wait on merging this until there's a final release for gradle 6.3(it's currently on release candidate 3) which is required for Java 14 support but tests all seem to be passing under Java 14 at least.