### PR TITLE
Add haveged to travis to ensure it always has enough entropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: required
 dist: xenial
+addons:
+  apt:
+    packages: haveged
 language: java
 jdk:
   - openjdk8


### PR DESCRIPTION
Seems tests are randomly failing a small percentage of the time due to removal of #292. Lets see if this fixes that.