### PR TITLE
Deprecate SunJSSESocketFactory

### DIFF
--- a/doc/src/asciidoc/ch08/channel_adaptor.adoc
+++ b/doc/src/asciidoc/ch08/channel_adaptor.adoc
@@ -112,7 +112,7 @@ properties are +storepassword+, +keypassword+ and +keystore+.
 The configuration would look like this:
 
 ------
- <property name="socketFactory" value="org.jpos.iso.SunJSSESocketFactory" />
+ <property name="socketFactory" value="org.jpos.iso.GenericSSLSocketFactory" />
  <property name="storepassword" value="password" />
  <property name="keypassword"   value="password" />
  <property name="keystore" value="cfg/mykeystore.ks" />

--- a/jpos/src/main/java/org/jpos/iso/SunJSSESocketFactory.java
+++ b/jpos/src/main/java/org/jpos/iso/SunJSSESocketFactory.java
@@ -28,7 +28,9 @@ import java.security.Security;
  * @author  Bharavi Gade
  * @author Alwyn Schoeman
  * @since   1.3.3
+ * @deprecated use GenericSSLSocketFactory()
  */
+@Deprecated
 public class SunJSSESocketFactory extends GenericSSLSocketFactory {
     static {
         try {

--- a/jpos/src/test/java/org/jpos/iso/BaseChannelTest.java
+++ b/jpos/src/test/java/org/jpos/iso/BaseChannelTest.java
@@ -638,7 +638,7 @@ public class BaseChannelTest {
 
     @Test
     public void testGetSocketFactory() throws Throwable {
-        ISOClientSocketFactory socketFactory = new SunJSSESocketFactory();
+        ISOClientSocketFactory socketFactory = new GenericSSLSocketFactory();
         BaseChannel gZIPChannel = new GZIPChannel();
         gZIPChannel.setSocketFactory(socketFactory);
         ISOClientSocketFactory result = gZIPChannel.getSocketFactory();
@@ -902,7 +902,7 @@ public class BaseChannelTest {
     @Test
     public void testSetConfiguration() throws Throwable {
         BaseChannel gZIPChannel = new GZIPChannel(new ISO93BPackager(), null);
-        gZIPChannel.setSocketFactory(new SunJSSESocketFactory());
+        gZIPChannel.setSocketFactory(new GenericSSLSocketFactory());
         gZIPChannel.setConfiguration(new SimpleConfiguration());
         assertEquals(300000, gZIPChannel.getTimeout(), "(GZIPChannel) gZIPChannel.getTimeout()");
         assertEquals(100000, gZIPChannel.getMaxPacketLength(), "(GZIPChannel) gZIPChannel.getMaxPacketLength()");
@@ -1098,7 +1098,7 @@ public class BaseChannelTest {
     @Test
     public void testSetSocketFactory() throws Throwable {
         BaseChannel x25Channel = new X25Channel();
-        ISOClientSocketFactory socketFactory = new SunJSSESocketFactory();
+        ISOClientSocketFactory socketFactory = new GenericSSLSocketFactory();
         x25Channel.setSocketFactory(socketFactory);
         assertSame(socketFactory, ((X25Channel) x25Channel).socketFactory, "(X25Channel) x25Channel.socketFactory");
     }

--- a/jpos/src/test/java/org/jpos/iso/SslChannelIntegrationTest.java
+++ b/jpos/src/test/java/org/jpos/iso/SslChannelIntegrationTest.java
@@ -82,7 +82,7 @@ public class SslChannelIntegrationTest {
 
     private XMLChannel newClientChannel() throws IOException, ISOException {
         XMLChannel clientChannel = new XMLChannel(new XMLPackager());
-        clientChannel.setSocketFactory(new SunJSSESocketFactory());
+        clientChannel.setSocketFactory(new GenericSSLSocketFactory());
         clientChannel.setConfiguration(clientConfiguration());
         clientChannel.setLogger(logger, "client.channel");
         clientChannel.setHost("localhost", PORT);
@@ -94,7 +94,7 @@ public class SslChannelIntegrationTest {
         clientSide.setLogger(logger, "server.channel");
 
         ISOServer isoServer = new ISOServer(PORT, clientSide, new ThreadPool());
-        isoServer.setSocketFactory(new SunJSSESocketFactory());
+        isoServer.setSocketFactory(new GenericSSLSocketFactory());
         isoServer.setConfiguration(serverConfiguration());
         isoServer.setLogger(logger, "server");
         isoServer.addISORequestListener(new TestListener());

--- a/jpos/src/test/java/org/jpos/iso/channel/VAPChannelTest.java
+++ b/jpos/src/test/java/org/jpos/iso/channel/VAPChannelTest.java
@@ -35,10 +35,7 @@ import java.net.ServerSocket;
 import org.jpos.core.Configuration;
 import org.jpos.core.SimpleConfiguration;
 import org.jpos.core.SubConfiguration;
-import org.jpos.iso.ISOMsg;
-import org.jpos.iso.ISOPackager;
-import org.jpos.iso.ISOVMsg;
-import org.jpos.iso.SunJSSESocketFactory;
+import org.jpos.iso.*;
 import org.jpos.iso.header.BASE1Header;
 import org.jpos.iso.header.BaseHeader;
 import org.jpos.iso.packager.Base1Packager;
@@ -228,7 +225,7 @@ public class VAPChannelTest {
     @Test
     public void testSetConfiguration() throws Throwable {
         VAPChannel vAPChannel = new VAPChannel(new Base1Packager());
-        vAPChannel.setSocketFactory(new SunJSSESocketFactory());
+        vAPChannel.setSocketFactory(new GenericSSLSocketFactory());
         vAPChannel.setConfiguration(new SimpleConfiguration());
         assertEquals("000000", vAPChannel.srcid, "vAPChannel.srcid");
         assertEquals("000000", vAPChannel.dstid, "vAPChannel.dstid");


### PR DESCRIPTION
This isn't available on newer Java versions and should be replaced with GenericSSLSocketFactory.