### PR TITLE
Transaction manager: fix typo in log line for disabled participants.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ txnmgrtest/
 .gradle
 build
 .nb-gradle
-
+# VSCode Ignores
+.vscode/settings.json

--- a/jpos/src/main/java/org/jpos/transaction/TransactionManager.java
+++ b/jpos/src/main/java/org/jpos/transaction/TransactionManager.java
@@ -795,7 +795,7 @@ public class TransactionManager
             if (QFactory.isEnabled(el)) {
                 group.add(createParticipant(el));
             } else {
-                getLog().warn ("participant ignored (enabled='" + QFactory.getEnabledAttribute(e) + "'): " + el.getAttributeValue("class") + "/" + el.getAttributeValue("realm"));
+                getLog().warn ("participant ignored (enabled='" + QFactory.getEnabledAttribute(el) + "'): " + el.getAttributeValue("class") + "/" + el.getAttributeValue("realm"));
             }
         }
         return group;


### PR DESCRIPTION
Before this change, warnings about disabled participants looked like this:

```
<log realm="org.jpos.transaction.TransactionManager" at="2020-05-26T14:18:09.524">
  <warn>
    participant ignored (enabled='true'): org.jpos.ss.miniatm.TranslatePINBlock/translate-pinblock
  </warn>
</log>
```

Notice `enabled='true'`, which is misleading since the participant is, in fact, disabled.