### PR TITLE
Fix q2 compatibility with newer java versions

### DIFF
--- a/jpos/src/dist/bin/q2
+++ b/jpos/src/dist/bin/q2
@@ -12,9 +12,7 @@ else
     -Xmx1G \
     -Xloggc:log/gc.log \
     -Djava.net.preferIPv4Stack=true \
-    -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses \
     -XX:+UseConcMarkSweepGC  \
-    -XX:+AggressiveOpts \
     -XX:+ParallelRefProcEnabled \
     -XX:ParallelGCThreads=2 \
     -XX:+TieredCompilation \


### PR DESCRIPTION
Some of these parameters are not supported by newer Java versions, so lets just remove them.