### PR TITLE
Improve ssh authorized_keys permissions check.

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/ssh/SshService.java
+++ b/jpos/src/main/java/org/jpos/q2/ssh/SshService.java
@@ -36,6 +36,8 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Collections;
 import java.util.Set;
 
+import static java.nio.file.attribute.PosixFilePermission.*;
+
 public class SshService extends QBeanSupport implements SshCLIContextMBean
 {
     SshServer sshd = null;
@@ -101,7 +103,8 @@ public class SshService extends QBeanSupport implements SshCLIContextMBean
           Files.getFileAttributeView(file, PosixFileAttributeView.class)
           .readAttributes();
         Set<PosixFilePermission> perms =  attrs.permissions();
-        if (perms.size() != 1 || !perms.contains(PosixFilePermission.OWNER_READ))
+        if (perms.contains(GROUP_WRITE) || perms.contains(OTHERS_WRITE) ||
+            (perms.contains(OWNER_WRITE) && !Files.isWritable(file)))
             throw new IllegalArgumentException(
               String.format ("Invalid permissions '%s' for file '%s'", PosixFilePermissions.toString(perms), s)
             );


### PR DESCRIPTION
The current whitelist approach is overly strict and prevents valid permissions for authorized_keys from being used. Instead we should use a permissions blacklist implementation from openssh.

This is a simplified more portable variant of #327.