### PR TITLE
Fix bug where BeforeAll and AfterAll are not static.

### DIFF
--- a/jpos/src/test/java/org/jpos/q2/Q2Test.java
+++ b/jpos/src/test/java/org/jpos/q2/Q2Test.java
@@ -42,16 +42,16 @@ import org.junit.jupiter.api.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class Q2Test {
-    String[] m_args = new String[0];
-    Q2 m_q2;
+    static String[] m_args = new String[0];
+    static Q2 m_q2;
 
     @BeforeAll
-    public void setUp() {
+    public static void setUp() {
         m_q2 = new Q2(m_args);
     }
 
     @AfterAll
-    public void tearDown() throws Exception {
+    public static void tearDown() throws Exception {
         m_q2.shutdown(true);
     }
 

--- a/jpos/src/test/java/org/jpos/q2/iso/QMUXTestCase.java
+++ b/jpos/src/test/java/org/jpos/q2/iso/QMUXTestCase.java
@@ -40,15 +40,15 @@ import java.lang.reflect.Field;
 @SuppressWarnings("unchecked")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class QMUXTestCase implements ISOResponseListener {
-    Q2 q2;
-    Space sp;
-    MUX mux;
+    static Q2 q2;
+    static Space sp;
+    static MUX mux;
     boolean expiredCalled;
     ISOMsg responseMsg;
-    Object receivedHandback;
+    static Object receivedHandback;
 
     @BeforeAll
-    public void setUp() throws Exception {
+    public static void setUp() throws Exception {
         sp = SpaceFactory.getSpace();
         q2 = new Q2("build/resources/test/org/jpos/q2/iso");
         q2.start();
@@ -96,7 +96,7 @@ public class QMUXTestCase implements ISOResponseListener {
     }
 
     @AfterAll
-    public void tearDown() throws Exception {
+    public static void tearDown() throws Exception {
         Thread.sleep(2000L); // let the thing run
         q2.shutdown(true);
         Thread.sleep(2000L);


### PR DESCRIPTION
Per docs these must be static:
https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/BeforeAll.html
https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/AfterAll.html

Fixes a bug similar to [#170](https://github.com/jpos/jPOS-EE/pull/170)