### PR TITLE
Update jacoco to 0.8.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ subprojects {
         systemProperty 'user.language', 'en'
     }
     jacoco {
-        toolVersion = '0.8.5'
+        toolVersion = '0.8.6'
     }
 }
 


### PR DESCRIPTION
Fixes non-fatal Exception with Java 15:
`java.lang.IllegalArgumentException: Unsupported class file major version 59`