### PR TITLE
Isolate tests using JESpace to their own folders.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install: true
 script:
   - java -version
   - ulimit -a
-  - TERM=dumb ./gradlew jpos:assemble jpos:check --info --no-parallel
+  - TERM=dumb ./gradlew jpos:assemble jpos:check --info
 deploy:
   provider: script
   script: bash .travis/update-gh-pages.sh

--- a/jpos/libraries.gradle
+++ b/jpos/libraries.gradle
@@ -14,7 +14,7 @@ ext {
         mockito_jupiter: 'org.mockito:mockito-junit-jupiter:3.3.3',
         fest_assert: 'org.easytesting:fest-assert:1.4',
         xmlunit: 'xmlunit:xmlunit:1.6',
-        junit: 'org.junit.jupiter:junit-jupiter:5.6.2',
+        junit: 'org.junit.jupiter:junit-jupiter:5.7.0',
         bouncycastle: [
             'org.bouncycastle:bcprov-jdk15on:1.64',
             'org.bouncycastle:bcpg-jdk15on:1.64'

--- a/jpos/src/test/java/org/jpos/space/JESpaceTestCase.java
+++ b/jpos/src/test/java/org/jpos/space/JESpaceTestCase.java
@@ -30,15 +30,20 @@ import org.jpos.util.Profiler;
 import org.jpos.iso.ISOUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
 
 @SuppressWarnings("unchecked")
 public class JESpaceTestCase {
     public static final int COUNT = 100;
     JESpace<String,Object> sp;
     @BeforeEach
-    public void setUp () {
-        sp = (JESpace<String,Object>) 
-            JESpace.getSpace ("space-test", "build/resources/test/space-test");
+    public void setUp (TestInfo testInfo, @TempDir Path spaceTestDir) throws IOException {
+        sp = (JESpace<String,Object>)
+            JESpace.getSpace (testInfo.getDisplayName(), spaceTestDir.toString());
     }
     @Test
     public void testSimpleOut() throws Exception {

--- a/jpos/src/test/java/org/jpos/transaction/TransactionManagerTestCase.java
+++ b/jpos/src/test/java/org/jpos/transaction/TransactionManagerTestCase.java
@@ -24,6 +24,13 @@ import org.jpos.space.SpaceFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 @SuppressWarnings("unchecked")
 public class TransactionManagerTestCase {
@@ -33,9 +40,10 @@ public class TransactionManagerTestCase {
     public static String QUEUE_EMPTY = "TXNMGRTEST.EMPTY";
 
     @BeforeEach
-    public void setUp () throws Exception {
+    public void setUp (@TempDir Path deployDir) throws Exception {
         sp = SpaceFactory.getSpace("tspace:txnmgrtest");
-        q2 = new Q2("build/resources/test/org/jpos/transaction");
+        Files.copy(Paths.get("build/resources/test/org/jpos/transaction"), deployDir, REPLACE_EXISTING);
+        q2 = new Q2(deployDir.toString());
         q2.start();
     }
 //    public void testSimpleTransaction() {


### PR DESCRIPTION
Lets see if this lets us reliably run tests without `--no-parallel`.