### PR TITLE
Ensure StringBuilder exceptions are deterministic on Java 15.

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/filter/StatefulFilter.java
+++ b/jpos/src/main/java/org/jpos/iso/filter/StatefulFilter.java
@@ -157,7 +157,10 @@ public class StatefulFilter implements ISOFilter, Configurable{
         throws ISOFilter.VetoException 
     {
         int[] key = getKey();
-        StringBuilder b = new StringBuilder(getKeyPrefix());
+        String keyPrefix = getKeyPrefix();
+        if (keyPrefix == null)
+            throw new NullPointerException("key prefix can not be null");
+        StringBuilder b = new StringBuilder(keyPrefix);
         for (int aKey : key) {
             b.append("|");
             b.append(m.getString(aKey));

--- a/jpos/src/main/java/org/jpos/q2/QFactory.java
+++ b/jpos/src/main/java/org/jpos/q2/QFactory.java
@@ -287,6 +287,8 @@ public class QFactory {
      */
     public String getAttributeName(String name)
     {
+        if (name == null)
+            throw new NullPointerException("attribute name can not be null");
         StringBuilder tmp = new StringBuilder(name);
         if (tmp.length() > 0)
             tmp.setCharAt(0,name.toUpperCase().charAt(0)) ;

--- a/jpos/src/main/java/org/jpos/q2/iso/QMUX.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QMUX.java
@@ -244,6 +244,8 @@ public class QMUX
     }
 
     public String getKey (ISOMsg m) throws ISOException {
+        if (out == null)
+            throw new NullPointerException ("Misconfigured QMUX. Please verify out queue is not null.");
         StringBuilder sb = new StringBuilder (out);
         sb.append ('.');
         sb.append (mapMTI(m.getMTI()));

--- a/jpos/src/main/java/org/jpos/util/FSDMsg.java
+++ b/jpos/src/main/java/org/jpos/util/FSDMsg.java
@@ -601,6 +601,8 @@ public class FSDMsg implements Loggeable, Cloneable {
     }
     protected Element getSchema (String prefix, String suffix, String defSuffix)
         throws JDOMException, IOException {
+        if (basePath == null)
+            throw new NullPointerException("basePath can not be null");
         StringBuilder sb = new StringBuilder (basePath);
         sb.append (prefix);
         prefix = sb.toString(); // little hack, we'll reuse later with defSuffix

--- a/jpos/src/test/java/org/jpos/iso/filter/StatefulFilterTest.java
+++ b/jpos/src/test/java/org/jpos/iso/filter/StatefulFilterTest.java
@@ -339,11 +339,7 @@ public class StatefulFilterTest {
 		    new ISOMsg("testStatefulFilterMti"), new LogEvent());
 	    fail("Expected NullPointerException to be thrown");
 	} catch (NullPointerException ex) {
-		if (isJavaVersionAtMost(JAVA_14)) {
-			assertNull(ex.getMessage(), "ex.getMessage()");
-		} else {
-			assertEquals("Cannot invoke \"String.length()\" because \"str\" is null", ex.getMessage(), "ex.getMessage()");
-		}
+		assertEquals("key prefix can not be null", ex.getMessage(), "ex.getMessage()");
 	}
     }
 
@@ -360,7 +356,7 @@ public class StatefulFilterTest {
 		if (isJavaVersionAtMost(JAVA_14)) {
 			assertNull(ex.getMessage(), "ex.getMessage()");
 		} else {
-			assertEquals("Cannot read the array length because \"<local7>\" is null", ex.getMessage(), "ex.getMessage()");
+			assertEquals("Cannot read the array length because \"<local8>\" is null", ex.getMessage(), "ex.getMessage()");
 		}
 	}
     }

--- a/jpos/src/test/java/org/jpos/q2/QFactory2Test.java
+++ b/jpos/src/test/java/org/jpos/q2/QFactory2Test.java
@@ -126,11 +126,7 @@ public class QFactory2Test {
             new QFactory(new ObjectName(""), null).getAttributeName(null);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
-            if (isJavaVersionAtMost(JAVA_14)) {
-                assertNull(ex.getMessage(), "ex.getMessage()");
-            } else {
-                assertEquals("Cannot invoke \"String.length()\" because \"str\" is null", ex.getMessage(), "ex.getMessage()");
-            }
+            assertEquals("attribute name can not be null", ex.getMessage(), "ex.getMessage()");
         }
     }
 

--- a/jpos/src/test/java/org/jpos/q2/iso/QMUXTest.java
+++ b/jpos/src/test/java/org/jpos/q2/iso/QMUXTest.java
@@ -65,11 +65,7 @@ public class QMUXTest {
             qMUX.getKey(m);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
-            if (isJavaVersionAtMost(JAVA_14)) {
-                assertNull(ex.getMessage(), "ex.getMessage()");
-            } else {
-                assertEquals("Cannot invoke \"String.length()\" because \"str\" is null", ex.getMessage(), "ex.getMessage()");
-            }
+            assertEquals("Misconfigured QMUX. Please verify out queue is not null.", ex.getMessage(), "ex.getMessage()");
             assertEquals(0, m.getDirection(), "m.getDirection()");
         }
     }
@@ -239,11 +235,7 @@ public class QMUXTest {
             qMUX.request(m, 100L);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
-            if (isJavaVersionAtMost(JAVA_14)) {
-                assertNull(ex.getMessage(), "ex.getMessage()");
-            } else {
-                assertEquals("Cannot invoke \"String.length()\" because \"str\" is null", ex.getMessage(), "ex.getMessage()");
-            }
+            assertEquals("Misconfigured QMUX. Please verify out queue is not null.", ex.getMessage(), "ex.getMessage()");
             assertNull(qMUX.sp, "qMUX.sp");
             assertEquals(0, m.getDirection(), "m.getDirection()");
         }

--- a/jpos/src/test/java/org/jpos/util/FSDMsgTest.java
+++ b/jpos/src/test/java/org/jpos/util/FSDMsgTest.java
@@ -752,11 +752,7 @@ public class FSDMsgTest {
             fSDMsg.pack();
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
-            if (isJavaVersionAtMost(JAVA_14)) {
-                assertNull(ex.getMessage(), "ex.getMessage()");
-            } else {
-                assertEquals("Cannot invoke \"String.length()\" because \"str\" is null", ex.getMessage(), "ex.getMessage()");
-            }
+            assertEquals("basePath can not be null", ex.getMessage(), "ex.getMessage()");
             assertEquals(0, fSDMsg.fields.size(), "fSDMsg.fields.size()");
             assertEquals("testFSDMsgBaseSchema", fSDMsg.baseSchema, "fSDMsg.baseSchema");
         }
@@ -1056,11 +1052,7 @@ public class FSDMsgTest {
             fSDMsg.unpack(b);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
-            if (isJavaVersionAtMost(JAVA_14)) {
-                assertNull(ex.getMessage(), "ex.getMessage()");
-            } else {
-                assertEquals("Cannot invoke \"String.length()\" because \"str\" is null", ex.getMessage(), "ex.getMessage()");
-            }
+            assertEquals("basePath can not be null", ex.getMessage(), "ex.getMessage()");
             assertEquals(0, fSDMsg.fields.size(), "fSDMsg.fields.size()");
             assertEquals("testFSDMsgBaseSchema", fSDMsg.baseSchema, "fSDMsg.baseSchema");
             assertEquals(1, b.length, "b.length");
@@ -1095,11 +1087,7 @@ public class FSDMsgTest {
             fSDMsg.unpack(is);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
-            if (isJavaVersionAtMost(JAVA_14)) {
-                assertNull(ex.getMessage(), "ex.getMessage()");
-            } else {
-                assertEquals("Cannot invoke \"String.length()\" because \"str\" is null", ex.getMessage(), "ex.getMessage()");
-            }
+            assertEquals("basePath can not be null", ex.getMessage(), "ex.getMessage()");
             assertEquals(0, fSDMsg.fields.size(), "fSDMsg.fields.size()");
             assertEquals("testFSDMsgBaseSchema", fSDMsg.baseSchema, "fSDMsg.baseSchema");
             assertEquals(3, is.available(), "(ByteArrayInputStream) is.available()");


### PR DESCRIPTION
It appears the NullPointerException exception message is non-deterministic when passing null to StringBuilder under Java 15 due to what appears to be a race of some sort likely due to internal implementation changes in StringBuilder.

Fix this by checking for and raising our own NullPointerException before null gets passed to StringBuilder.