### PR TITLE
Run tests in parallel.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,7 @@ subprojects {
             events "passed", "skipped", "failed"
         }
         systemProperty 'user.language', 'en'
+        maxParallelForks = Runtime.runtime.availableProcessors()
     }
     jacoco {
         toolVersion = '0.8.6'


### PR DESCRIPTION
This seems to have minimal effect when running tests on Travis, however there is a significant difference when running locally on systems with many cores. This has the potential to cause errors for any tests that aren't properly isolated but it looks like we're probably fine as I'm not seeing any at the moment.

Times for clean build+tests on my 16 core 32 thread Linux box.

Without this change:
```
BUILD SUCCESSFUL in 2m 42s
```

With this change:
```
BUILD SUCCESSFUL in 1m 25s
```