### PR TITLE
Experimental jolokia based Q2 config element json converter.

### DIFF
--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -25,8 +25,10 @@ dependencies {
 
     implementation libraries.osgi_core
     implementation libraries.javassist
+    implementation libraries.jolokia_jmx
     implementation libraries.yaml;
     implementation libraries.jdbm
+    implementation libraries.json
     implementation libraries.sleepycat_je
     implementation libraries.sshd
     implementation libraries.eddsa

--- a/jpos/libraries.gradle
+++ b/jpos/libraries.gradle
@@ -2,6 +2,8 @@ ext {
     libraries = [
         jdom: 'org.jdom:jdom2:2.0.6',
         jdbm: 'jdbm:jdbm:1.0',
+        json: 'org.json:json:20200518',
+        jolokia_jmx: 'org.jolokia:jolokia-jmx:1.6.2',
         sleepycat_je: 'com.sleepycat:je:18.3.12',
         commons_cli: 'commons-cli:commons-cli:1.4',
         commons_lang3: 'org.apache.commons:commons-lang3:3.11',

--- a/jpos/src/main/java/org/jpos/util/JPOSElementSimplifier.java
+++ b/jpos/src/main/java/org/jpos/util/JPOSElementSimplifier.java
@@ -1,0 +1,98 @@
+package org.jpos.util;
+
+import org.jdom2.Element;
+import org.jolokia.converter.json.simplifier.SimplifierExtractor;
+import org.jpos.core.Configuration;
+import org.jpos.core.ConfigurationException;
+import org.jpos.q2.QFactory;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.jpos.q2.Q2.getQ2;
+
+public class JPOSElementSimplifier extends SimplifierExtractor<Element> {
+    /**
+     * Construct the simplifier for Property elements
+     */
+    public JPOSElementSimplifier() {
+        super(Element.class);
+
+        Object[][] pAttrs = {
+                { "name", new NameAttributeExtractor() },
+                { "objectName", new ObjectNameAttributeExtractor() },
+                { "attr", new AttrAttributeExtractor() },
+                { "property", new PropertyAttributeExtractor() },
+                { "hasChildNodes", new ChildAttributeExtractor() }
+        };
+        addExtractors(pAttrs);
+    }
+
+    // ==================================================================================
+    private static class ObjectNameAttributeExtractor implements AttributeExtractor<Element> {
+        /** {@inheritDoc} */
+        public Object extract(Element element)  { return element.getAttributeValue("class"); }
+    }
+    private static class AttrAttributeExtractor implements AttributeExtractor<Element> {
+        /** {@inheritDoc} */
+        public Object extract(Element element) {
+            Map<String, Object> map = null;
+            try {
+                QFactory factory = getQ2().getFactory();
+                AttributeList attributeList = factory.getAttributeList(element);
+                for (Attribute key: attributeList.asList()) {
+                    if (map == null)
+                        map = new HashMap<>();
+                    map.put(key.getName(), key.getValue());
+                }
+            } catch (ConfigurationException configurationException) {
+                return null;
+            }
+            return map;
+        }
+    }
+    private static class PropertyAttributeExtractor implements AttributeExtractor<Element> {
+        /** {@inheritDoc} */
+        public Object extract(Element element) {
+            Map<String, Object> map = null;
+            try {
+                QFactory factory = getQ2().getFactory();
+                Configuration simpleConfig = factory.getConfiguration(element);
+                for (String key: simpleConfig.keySet()) {
+                    if (map == null)
+                        map = new HashMap<>();
+                    map.put(key, simpleConfig.get(key));
+                }
+            } catch (ConfigurationException configurationException) {
+                return null;
+            }
+            return map;
+        }
+    }
+    private static class NameAttributeExtractor implements AttributeExtractor<Element> {
+        /** {@inheritDoc} */
+        public Object extract(Element element) { return element.getName(); }
+    }
+    private static class ChildAttributeExtractor implements AttributeExtractor<Element> {
+        /** {@inheritDoc} */
+        public Object extract(Element element) {
+            List<Element> extracted = null;
+            List<Element> children = element.getChildren();
+            for(Element child: children){
+                String key = child.getName();
+                if (!Stream.of("property", "attr").anyMatch(key::equals)) {
+                    if (extracted == null) {
+                        extracted = new ArrayList<>();
+                    }
+                    extracted.add(child);
+                }
+            }
+            return extracted;
+        }
+    }
+}


### PR DESCRIPTION
Potential alternative to #344 based on jolokia. I'm not entirely sure how it would get integrated but jolokia seems to allow for [json based mbeans](https://jolokia.org/reference/html/jmx.html#json-mbean) as well.

Example config dump:
```json
{
    "99_sysmon": {
        "name": "sysmon",
        "property": {"metrics-dir": "log"},
        "attr": {
            "SleepTime": 3600000,
            "DetailRequired": true
        }
    },
    "00_logger": {
        "name": "logger",
        "property": {"redirect": "stdout, stderr"},
        "objectName": "org.jpos.q2.qbean.LoggerAdaptor",
        "hasChildNodes": [
            {
                "name": "log-listener",
                "objectName": "org.jpos.util.SimpleLogListener"
            },
            {
                "name": "log-listener",
                "property": {
                    "compression-format": "gzip",
                    "window": "86400",
                    "suffix": ".log",
                    "date-format": "-yyyy-MM-dd-HH",
                    "prefix": "log/q2"
                },
                "objectName": "org.jpos.util.DailyLogListener"
            }
        ]
    }
}
```