### PR TITLE
add cfg option packager-log-fieldname

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
@@ -40,9 +40,10 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     protected int thirdBitmapField= -999;       // for implementations where the tertiary bitmap is inside a Data Element
 
     protected Logger logger = null;
+    protected boolean logFieldName= false;
     protected String realm = null;
     protected int headerLength = 0;
-    
+
     public void setFieldPackager (ISOFieldPackager[] fld) {
         this.fld = fld;
     }
@@ -63,7 +64,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     }
 
     /**
-     * usually 2 for normal fields, 1 for bitmap-less or ANSI X9.2 
+     * usually 2 for normal fields, 1 for bitmap-less or ANSI X9.2
      * @return first valid field
      */
     protected int getFirstField() {
@@ -304,7 +305,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                         ISOComponent c = fld[i].createComponent(i);
                         consumed += fld[i].unpack (c, b, consumed);
                         if (evt != null)
-                            fieldUnpackLogger(evt, i, c, fld);
+                            fieldUnpackLogger(evt, i, c, fld[i], logFieldName);
                         m.set(c);
 
                         if (i == thirdBitmapField && fld.length > 129 &&          // fld[128] is at pos 129
@@ -364,23 +365,23 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
         }
     }
 
-    public void unpack (ISOComponent m, InputStream in) 
-        throws IOException, ISOException 
+    public void unpack (ISOComponent m, InputStream in)
+        throws IOException, ISOException
     {
         LogEvent evt = logger != null ? new LogEvent (this, "unpack") : null;
         try {
-            if (m.getComposite() != m) 
+            if (m.getComposite() != m)
                 throw new ISOException ("Can't call packager on non Composite");
 
-            // if ISOMsg and headerLength defined 
-            if (m instanceof ISOMsg && ((ISOMsg) m).getHeader()==null && headerLength>0) 
+            // if ISOMsg and headerLength defined
+            if (m instanceof ISOMsg && ((ISOMsg) m).getHeader()==null && headerLength>0)
             {
             	byte[] h = new byte[headerLength];
             	in.read(h, 0, headerLength);
             	((ISOMsg) m).setHeader(h);
-            }            
-            
-            
+            }
+
+
             if (!(fld[0] instanceof ISOMsgFieldPackager) &&
                 !(fld[0] instanceof ISOBitMapPackager))
             {
@@ -398,9 +399,9 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                 if (evt != null)
                     evt.addMessage ("<bitmap>"+bmap.toString()+"</bitmap>");
                 m.set (bitmap);
-                maxField = Math.min(maxField, bmap.size());
+             maxField = Math.min(maxField, bmap.size());
             }
-                
+
             for (int i=getFirstField(); i<maxField; i++) {
                 if (bmap == null && fld[i] == null)
                     continue;
@@ -412,7 +413,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                     ISOComponent c = fld[i].createComponent(i);
                     fld[i].unpack (c, in);
                     if (evt != null)
-                        fieldUnpackLogger(evt, i, c, fld);
+                        fieldUnpackLogger(evt, i, c, fld[i], logFieldName);
                     m.set(c);
                 }
             }
@@ -425,7 +426,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                         ISOComponent c = fld[i+128].createComponent(i);
                         fld[i+128].unpack (c, in);
                         if (evt != null)
-                            fieldUnpackLogger(evt, i+128, c, fld);
+                            fieldUnpackLogger(evt, i+128, c, fld[i+128], logFieldName);
                         m.set(c);
                     }
                 }
@@ -451,10 +452,14 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
      * Internal helper logging function.
      * Assumes evt is not null.
      */
-    private static void fieldUnpackLogger(LogEvent evt, int fldno, ISOComponent c, ISOFieldPackager fld[]) throws ISOException
+    private static void fieldUnpackLogger(LogEvent evt, int fldno, ISOComponent c, ISOFieldPackager fld, boolean logFieldName) throws ISOException
     {
         evt.addMessage ("<unpack fld=\""+fldno
-            +"\" packager=\""+fld[fldno].getClass().getName()+ "\">");
+            +"\" packager=\""+fld.getClass().getName()+ "\">");
+
+        if (logFieldName)
+            evt.addMessage("  <!-- "+fld.getDescription()+" -->");
+
         if (c.getValue() instanceof ISOMsg)
             evt.addMessage (c.getValue());
         else if (c.getValue() instanceof byte[]) {
@@ -488,8 +493,8 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
      * @param   fldNumber the Field Number
      * @param   fieldPackager the Field Packager
      */
-    public void setFieldPackager 
-        (int fldNumber, ISOFieldPackager fieldPackager) 
+    public void setFieldPackager
+        (int fldNumber, ISOFieldPackager fieldPackager)
     {
         fld[fldNumber] = fieldPackager;
     }

--- a/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
@@ -40,7 +40,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     protected int thirdBitmapField= -999;       // for implementations where the tertiary bitmap is inside a Data Element
 
     protected Logger logger = null;
-    protected boolean logFieldName= false;
+    protected boolean logFieldName= true;
     protected String realm = null;
     protected int headerLength = 0;
 

--- a/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
@@ -399,7 +399,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
                 if (evt != null)
                     evt.addMessage ("<bitmap>"+bmap.toString()+"</bitmap>");
                 m.set (bitmap);
-             maxField = Math.min(maxField, bmap.size());
+                maxField = Math.min(maxField, bmap.size());
             }
 
             for (int i=getFirstField(); i<maxField; i++) {

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
@@ -50,12 +50,12 @@ import java.util.TreeMap;
  * GenericPackager uses an XML config file to describe the layout of an ISOMessage
  * The general format is as follows
  * &lt;isopackager&gt;
- *     &lt;isofield 
+ *     &lt;isofield
  *         id="[field id]"
  *         name="[field name]"
  *         length="[max field length]"
  *         class="[org.jpos.iso.IF_*]"
- *         pad="true|false"&gt;  
+ *         pad="true|false"&gt;
  *     &lt;/isofield&gt;
  *     ...
  * &lt;/isopackager&gt;
@@ -67,8 +67,8 @@ import java.util.TreeMap;
  *     length="[field length]"
  *     class="[org.jpos.iso.IF_*]"
  *     packager="[org.jpos.iso.packager.*]"&gt;
- *      
- *     &lt;isofield 
+ *
+ *     &lt;isofield
  *         id="[subfield id]"
  *         name="[subfield name]"
  *         length="[max subfield length]"
@@ -89,11 +89,11 @@ import java.util.TreeMap;
  */
 
 @SuppressWarnings("unchecked")
-public class GenericPackager 
+public class GenericPackager
     extends ISOBasePackager implements Configurable
 {
    /* Values copied from ISOBasePackager
-      These can be changes using attributes on the isopackager node */ 
+      These can be changes using attributes on the isopackager node */
     private int maxValidField=128;
     private boolean emitBitmap=true;
     private int bitmapField=1;
@@ -105,8 +105,8 @@ public class GenericPackager
         super();
     }
 
-    /** 
-     * Create a GenericPackager with the field descriptions 
+    /**
+     * Create a GenericPackager with the field descriptions
      * from an XML File
      * @param filename The XML field description file
      */
@@ -116,8 +116,8 @@ public class GenericPackager
         readFile(filename);
     }
 
-    /** 
-     * Create a GenericPackager with the field descriptions 
+    /**
+     * Create a GenericPackager with the field descriptions
      * from an XML InputStream
      * @param input The XML field description InputStream
      */
@@ -132,12 +132,13 @@ public class GenericPackager
      * <ul>
      *  <li>packager-config
      *  <li>packager-logger
+     *  <li>packager-log-fieldname
      *  <li>packager-realm
      * </ul>
      *
      * @param cfg Configuration
      */
-    public void setConfiguration (Configuration cfg) 
+    public void setConfiguration (Configuration cfg)
         throws ConfigurationException
     {
         filename = cfg.get("packager-config", null);
@@ -148,8 +149,11 @@ public class GenericPackager
         {
             String loggerName = cfg.get("packager-logger");
             if (loggerName != null)
-                setLogger(Logger.getLogger (loggerName), 
+                setLogger(Logger.getLogger (loggerName),
                            cfg.get ("packager-realm"));
+
+            logFieldName= cfg.getBoolean("packager-log-fieldname"); // inherited protected logFieldName
+
             readFile(filename);
         } catch (ISOException e)
         {
@@ -195,7 +199,7 @@ public class GenericPackager
             } else {
                 createXMLReader().parse(filename);
             }
-        } 
+        }
         catch (Exception e) {
             throw new ISOException("Error reading " + filename, e);
         }
@@ -214,7 +218,7 @@ public class GenericPackager
     {
         try {
             createXMLReader().parse(new InputSource(input));
-        } 
+        }
         catch (Exception e) {
             throw new ISOException(e);
         }
@@ -229,7 +233,7 @@ public class GenericPackager
                     if (o instanceof LogSource) {
                         ((LogSource)o).setLogger (logger, realm + "-fld-" + i);
                     }
-                } 
+                }
             }
         }
     }
@@ -239,8 +243,8 @@ public class GenericPackager
             reader = XMLReaderFactory.createXMLReader();
         } catch (SAXException e) {
             reader = XMLReaderFactory.createXMLReader (
-                System.getProperty( 
-                    "org.xml.sax.driver", 
+                System.getProperty(
+                    "org.xml.sax.driver",
                     "org.apache.crimson.parser.XMLReaderImpl"
                 )
             );
@@ -274,7 +278,7 @@ public class GenericPackager
         String headerLenStr = atts.getValue("headerLength");
 
         if (maxField != null)
-            maxValidField = Integer.parseInt(maxField); 
+            maxValidField = Integer.parseInt(maxField);
 
         if (emitBmap != null)
             emitBitmap = Boolean.valueOf(emitBmap);
@@ -308,7 +312,7 @@ public class GenericPackager
          * We first check whether the DTD points to a well defined URI,
          * and resolve to our internal DTDs.<p>
          *
-         * If the systemId points to a file, then we attempt to read the 
+         * If the systemId points to a file, then we attempt to read the
          * DTD from the filesystem, in case they've been modified by the user.
          * Otherwise, we fallback to the built-in DTDs inside jPOS.<p>
          *
@@ -426,7 +430,7 @@ public class GenericPackager
                     fieldStack.push(new Integer(id));
 
                     ISOFieldPackager f;
-                    f = (ISOFieldPackager) Class.forName(type).newInstance();   
+                    f = (ISOFieldPackager) Class.forName(type).newInstance();
                     f.setDescription(name);
                     f.setLength(Integer.parseInt(size));
                     f.setPad(Boolean.parseBoolean(pad));
@@ -520,7 +524,7 @@ public class GenericPackager
                 msgPackager.setLogger (getLogger(), getRealm() + "-fld-" + fno);
 
                 // Create the ISOMsgField packager with the retrieved msg and field Packagers
-                ISOMsgFieldPackager mfp = 
+                ISOMsgFieldPackager mfp =
                     new ISOMsgFieldPackager(fieldPackager, msgPackager);
 
                 // Add the newly created ISOMsgField packager to the

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
@@ -152,7 +152,8 @@ public class GenericPackager
                 setLogger(Logger.getLogger (loggerName),
                            cfg.get ("packager-realm"));
 
-            logFieldName= cfg.getBoolean("packager-log-fieldname"); // inherited protected logFieldName
+            // inherited protected logFieldName
+            logFieldName= cfg.getBoolean("packager-log-fieldname", logFieldName);
 
             readFile(filename);
         } catch (ISOException e)


### PR DESCRIPTION
Now, when configuring a `GenericPackager` we can add 
```xml
  <property name="packager-log-fieldname" value="true"/>
```
This will enable the logging of each field's name(description), looking like
```xml
    <unpack fld="3" packager="org.jpos.iso.IFE_NUMERIC">
      <!-- PROCESSING CODE -->
      <value>000000</value>
    </unpack>
    <unpack fld="4" packager="org.jpos.iso.IFE_NUMERIC">
      <!-- AMOUNT, TRANSACTION -->
      <value>000000000100</value>
    </unpack>
    <unpack fld="7" packager="org.jpos.iso.IFE_NUMERIC">
      <!-- TRANSMISSION DATE AND TIME -->
      <value>0805053740</value>
    </unpack>
    <unpack fld="11" packager="org.jpos.iso.IFE_NUMERIC">
      <!-- SYSTEM TRACE AUDIT NUMBER -->
      <value>670771</value>
    </unpack>
```