### PR TITLE
Refactor Q2 to use NIO API for file operations without changing existing public interfaces.

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/qbean/SystemMonitor.java
+++ b/jpos/src/main/java/org/jpos/q2/qbean/SystemMonitor.java
@@ -35,6 +35,7 @@ import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
 import java.net.InetAddress;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -205,6 +206,10 @@ public class SystemMonitor extends QBeanSupport
         p.printf ("%s    user name: %s%n", indent, System.getProperty("user.name"));
         p.printf ("%s         host: %s%n", indent, localHost);
         p.printf ("%s          cwd: %s%n", indent, System.getProperty("user.dir"));
+        Path pid = getServer().getPidPath();
+        if (pid != null) {
+            p.printf ("%s     pid file: %s%n", indent, pid.toAbsolutePath().toString());
+        }
         p.printf ("%s   free space: %s%n", indent, freeSpace);
 
         if (!freeSpace.equals(usableSpace))

--- a/jpos/src/test/java/org/jpos/q2/Q2Test.java
+++ b/jpos/src/test/java/org/jpos/q2/Q2Test.java
@@ -74,14 +74,10 @@ public class Q2Test {
         args[0] = "";
         Q2 q2 = new Q2(args);
         try {
-            q2.accept(null);
+            q2.accept((File)null);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
-            if (isJavaVersionAtMost(JAVA_14)) {
-                assertNull(ex.getMessage(), "ex.getMessage()");
-            } else {
-                assertEquals("Cannot invoke \"java.io.File.canRead()\" because \"f\" is null", ex.getMessage(), "ex.getMessage()");
-            }
+            assertEquals("Cannot invoke \"org.jpos.q2.Q2.accept()\" because \"f\" is null", ex.getMessage(), "ex.getMessage()");
         } finally {
             q2.stop();
         }


### PR DESCRIPTION
Basically #342 but with no changes to existing public API's.

The main reason for this change is to improve thread safety of the lower level file interface code so that the q2 configuration can be safely managed via API interfaces down the line.