### PR TITLE
bug 355: fix MAX_TAG_BYTES constant to support 3 bytes.

### DIFF
--- a/jpos/src/main/java/org/jpos/tlv/packager/bertlv/BERTLVPackager.java
+++ b/jpos/src/main/java/org/jpos/tlv/packager/bertlv/BERTLVPackager.java
@@ -54,7 +54,7 @@ import java.util.Map;
 public abstract class BERTLVPackager extends GenericPackager {
 
     private static final int MAX_LENGTH_BYTES = 5;
-    private static final int MAX_TAG_BYTES = 2;
+    private static final int MAX_TAG_BYTES = 3;
 
     private static final LiteralInterpreter literalInterpreter = LiteralInterpreter.INSTANCE;
     private static final AsciiInterpreter asciiInterpreter = AsciiInterpreter.INSTANCE;


### PR DESCRIPTION
In the project we could have a tag id constructed of 3 bytes. This patch
allows us to handle it correctly.