### PR TITLE
Use a closure to ensure DirectoryStream doesn't leak file descriptors.

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/Q2.java
+++ b/jpos/src/main/java/org/jpos/q2/Q2.java
@@ -381,15 +381,16 @@ public class Q2 implements DirectoryStream.Filter<Path>, FileFilter, Runnable {
     }
     private boolean scan () throws IOException {
         boolean rc = false;
-        DirectoryStream<Path> file = Files.newDirectoryStream(deployDir,this);
-        // Arrays.sort (file); --apr not required - we use TreeMap
-        if (file == null) {
-            // Shutting down might be best, how to trigger from within?
-            throw new Error("Deploy directory \""+deployDir.toAbsolutePath().toString()+"\" is not available");
-        } else {
-            for (Path f : file) {
-                if (register(f))
-                    rc = true;
+        try (DirectoryStream<Path> file = Files.newDirectoryStream(deployDir,this)) {
+            // Arrays.sort (file); --apr not required - we use TreeMap
+            if (file == null) {
+                // Shutting down might be best, how to trigger from within?
+                throw new Error("Deploy directory \"" + deployDir.toAbsolutePath().toString() + "\" is not available");
+            } else {
+                for (Path f : file) {
+                    if (register(f))
+                        rc = true;
+                }
             }
         }
         return rc;
@@ -557,10 +558,11 @@ public class Q2 implements DirectoryStream.Filter<Path>, FileFilter, Runnable {
     private boolean register (Path f) throws IOException {
         boolean rc = false;
         if (Files.isDirectory(f)) {
-            DirectoryStream<Path> file = Files.newDirectoryStream(f, this);
-            for (Path aFile : file) {
-                if (register(aFile))
-                    rc = true;
+            try (DirectoryStream<Path> file = Files.newDirectoryStream(f, this)) {
+                for (Path aFile : file) {
+                    if (register(aFile))
+                        rc = true;
+                }
             }
         } else if (dirMap.get (f) == null) {
             dirMap.put (f, new QEntry (isBundle(f)));


### PR DESCRIPTION
Seems this was the cause of the issue in #359.