### PR TITLE
Issue/charset getbytes

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOUtil.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOUtil.java
@@ -675,7 +675,21 @@ public class ISOUtil {
      */
     public static byte[] hex2byte (String s) {
         if (s.length() % 2 == 0) {
-            return hex2byte (s.getBytes(), 0, s.length() >> 1);
+            return hex2byte (s.getBytes(CHARSET), 0, s.length() >> 1);
+        } else {
+        	// Padding left zero to make it even size #Bug raised by tommy
+        	return hex2byte("0"+s);
+        }
+    }
+    /**
+     * Converts a hex string into a byte array
+     * @param s source string (with Hex representation)
+     * @param charset character set to be used
+     * @return byte array
+     */
+    public static byte[] hex2byte (String s, Charset charset) {
+        if (s.length() % 2 == 0) {
+            return hex2byte (s.getBytes(charset), 0, s.length() >> 1);
         } else {
         	// Padding left zero to make it even size #Bug raised by tommy
         	return hex2byte("0"+s);

--- a/jpos/src/main/java/org/jpos/iso/ISOUtil.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOUtil.java
@@ -674,12 +674,7 @@ public class ISOUtil {
      * @return byte array
      */
     public static byte[] hex2byte (String s) {
-        if (s.length() % 2 == 0) {
-            return hex2byte (s.getBytes(CHARSET), 0, s.length() >> 1);
-        } else {
-        	// Padding left zero to make it even size #Bug raised by tommy
-        	return hex2byte("0"+s);
-        }
+        return hex2byte (s, CHARSET);
     }
     /**
      * Converts a hex string into a byte array
@@ -688,11 +683,12 @@ public class ISOUtil {
      * @return byte array
      */
     public static byte[] hex2byte (String s, Charset charset) {
+        if (charset == null) charset = CHARSET;
         if (s.length() % 2 == 0) {
             return hex2byte (s.getBytes(charset), 0, s.length() >> 1);
         } else {
         	// Padding left zero to make it even size #Bug raised by tommy
-        	return hex2byte("0"+s);
+        	return hex2byte("0"+s, charset);
         }
     }
 


### PR DESCRIPTION
Dear Alejandro,
This is regarding the issue discussed on Slack support related to charset in FSDMsg and so the proposed solution was to pass default charset in String.getBytes in ISOUtil.hex2byte. I have added a new ISOUtil.hex2byte which accepts a charset and modified the original ISOUtil.hex2byte.

Please review.

Regards,
Keshaw Sinha