### PR TITLE
Important key block fixes

### DIFF
--- a/jpos/src/main/java/org/jpos/security/SecureKeyBlockBuilder.java
+++ b/jpos/src/main/java/org/jpos/security/SecureKeyBlockBuilder.java
@@ -20,6 +20,7 @@ package org.jpos.security;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -57,11 +58,13 @@ public class SecureKeyBlockBuilder {
 
     protected static final int SIZE_HEADER_AES          = 8;
 
-    private final List<Character> versionsWith4CharacterMAC = Arrays.asList(
-         'A' // TR-31:2005 'A' Key block protected using the Key Variant Binding Method
-        ,'B' // TR-31:2010 'B' Key block protected using the Key Derivation Binding Method
-        ,'C' // TR-31:1010 'C' Key block protected using the Key Variant Binding Method
-        ,'0' // Proprietary '0' Key block protected using the 3-DES key
+    private final List<Character> versionsWith4CharacterMAC = new ArrayList<>(
+        Arrays.asList(
+             'A' // TR-31:2005 'A' Key block protected using the Key Variant Binding Method
+            ,'B' // TR-31:2010 'B' Key block protected using the Key Derivation Binding Method
+            ,'C' // TR-31:1010 'C' Key block protected using the Key Variant Binding Method
+            ,'0' // Proprietary '0' Key block protected using the 3-DES key
+        )
     );
 
     /**

--- a/jpos/src/main/java/org/jpos/security/SecureKeyBlockBuilder.java
+++ b/jpos/src/main/java/org/jpos/security/SecureKeyBlockBuilder.java
@@ -54,15 +54,15 @@ public class SecureKeyBlockBuilder {
 
     protected static final int SIZE_OPTHDR_LENGTH       = 2;
 
-    protected static final int SIZE_HEADER_3DES         = 4;
+    protected static final int SIZE_HEADER_3DES         = 8;
 
-    protected static final int SIZE_HEADER_AES          = 8;
+    protected static final int SIZE_HEADER_AES          = 16;
 
-    private final List<Character> versionsWith4CharacterMAC = new ArrayList<>(
+    private final List<Character> versionsWith8CharacterMAC = new ArrayList<>(
         Arrays.asList(
              'A' // TR-31:2005 'A' Key block protected using the Key Variant Binding Method
             ,'B' // TR-31:2010 'B' Key block protected using the Key Derivation Binding Method
-            ,'C' // TR-31:1010 'C' Key block protected using the Key Variant Binding Method
+            ,'C' // TR-31:2010 'C' Key block protected using the Key Variant Binding Method
             ,'0' // Proprietary '0' Key block protected using the 3-DES key
         )
     );
@@ -78,9 +78,9 @@ public class SecureKeyBlockBuilder {
     }
 
     /**
-     * Configure key block versions with 4 digits key block MAC.
+     * Configure key block versions with 8 digits key block MAC.
      * <p>
-     * Default 4 digits key block MAC versions are:
+     * Default 8 digits <i>(4 bytes)</i> key block MAC versions are:
      * <ul>
      *   <li>'A' TR-31:2005 Key block protected using the Key Variant Binding Method
      *   <li>'B' TR-31:2010 Key block protected using the Key Derivation Binding Method
@@ -90,17 +90,17 @@ public class SecureKeyBlockBuilder {
      * @param versions the string with versions characters
      * @return This builder instance
      */
-    public SecureKeyBlockBuilder with4characterMACVersions(String versions) {
-        Objects.requireNonNull(versions, "The versions with 4 digits MAC cannot be null");
-        versionsWith4CharacterMAC.clear();
+    public SecureKeyBlockBuilder with8characterMACVersions(String versions) {
+        Objects.requireNonNull(versions, "The versions with 8 digits MAC cannot be null");
+        versionsWith8CharacterMAC.clear();
         for (Character ch : versions.toCharArray())
-            versionsWith4CharacterMAC.add(ch);
+            versionsWith8CharacterMAC.add(ch);
 
         return this;
     }
 
     protected int getMACLength(SecureKeyBlock skb) {
-        if (versionsWith4CharacterMAC.contains(skb.getKeyBlockVersion()))
+        if (versionsWith8CharacterMAC.contains(skb.getKeyBlockVersion()))
             return SIZE_HEADER_3DES;
 
         return SIZE_HEADER_AES;

--- a/jpos/src/test/java/org/jpos/security/SecureKeyBlockBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/security/SecureKeyBlockBuilderTest.java
@@ -31,15 +31,23 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class SecureKeyBlockBuilderTest {
 
-    private static final byte[] KEYBLOCK_MAC8 = ISOUtil.hex2byte("A1B2C3D4");
+    /**
+     * Test MAC with a length of 8 bytes.
+     */
+    private static final byte[] KEYBLOCK_MAC8 = ISOUtil.hex2byte("A1B2C3D4E5F60728");
 
-    private static final byte[] KEYBLOCK_MAC4 = ISOUtil.hex2byte("E1F2");
+    /**
+     * Test MAC with a length of 4 bytes.
+     */
+    private static final byte[] KEYBLOCK_MAC4 = ISOUtil.hex2byte("E1F22F1E");
 
     private static final byte[] KEYBLOCK_ENCKEY = ISOUtil.hex2byte("A9B8C7D6E5F49382");
 
     private static final String OPTHEADER_KS = "KS0ETest KS.12";
 
     private static final String OPTHEADER_KV = "KV08abcd";
+
+    Throwable thrown;
 
     SecureKeyBlockBuilder instance;
 
@@ -55,9 +63,9 @@ public class SecureKeyBlockBuilderTest {
      */
     @Test
     public void testBuildNull() {
-        assertThrows(NullPointerException.class, () -> {
-            instance.build(null);
-        });
+        thrown = assertThrows(NullPointerException.class,
+            () -> instance.build(null)
+        );
     }
 
     /**
@@ -65,10 +73,9 @@ public class SecureKeyBlockBuilderTest {
      */
     @Test
     public void testBuildToShort() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            String data = "10024V2TG17N00";
-            instance.build(data);
-        });
+        thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.build("10024V2TG17N00")
+        );
     }
 
     /**
@@ -76,11 +83,11 @@ public class SecureKeyBlockBuilderTest {
      */
     @Test
     public void testBuildWithoutEncKey() {
-        String data = "10024V2TG17N0033" + ISOUtil.hexString(KEYBLOCK_MAC8);
+        String data = "10032V2TG17N0033" + ISOUtil.hexString(KEYBLOCK_MAC8);
         ret = instance.build(data);
 
         assertEquals('1', ret.getKeyBlockVersion());
-        assertEquals(24, ret.getKeyBlockLength());
+        assertEquals(32, ret.getKeyBlockLength());
         assertEquals(KeyUsage.VISAPVV, ret.getKeyUsage());
         assertEquals(Algorithm.TDES, ret.getAlgorithm());
         assertEquals(ModeOfUse.GENONLY, ret.getModeOfUse());
@@ -116,11 +123,11 @@ public class SecureKeyBlockBuilderTest {
      */
     @Test
     public void testBuildWithoutWithoutEncKey() {
-        String data = "00020P0ANc4S0021" + ISOUtil.hexString(KEYBLOCK_MAC4);
+        String data = "00024P0ANc4S0021" + ISOUtil.hexString(KEYBLOCK_MAC4);
         ret = instance.build(data);
 
         assertEquals('0', ret.getKeyBlockVersion());
-        assertEquals(20, ret.getKeyBlockLength());
+        assertEquals(24, ret.getKeyBlockLength());
         assertEquals(KeyUsage.PINENC, ret.getKeyUsage());
         assertEquals(Algorithm.AES, ret.getAlgorithm());
         assertEquals(ModeOfUse.ANY, ret.getModeOfUse());
@@ -136,11 +143,11 @@ public class SecureKeyBlockBuilderTest {
      */
     @Test
     public void testBuildMAC8() {
-        String data = "00036V2RG17N0003" + ISOUtil.hexString(KEYBLOCK_ENCKEY) + ISOUtil.hexString(KEYBLOCK_MAC4);
+        String data = "00040V2RG17N0003" + ISOUtil.hexString(KEYBLOCK_ENCKEY) + ISOUtil.hexString(KEYBLOCK_MAC4);
         ret = instance.build(data);
 
         assertEquals('0', ret.getKeyBlockVersion());
-        assertEquals(36, ret.getKeyBlockLength());
+        assertEquals(40, ret.getKeyBlockLength());
         assertEquals(KeyUsage.VISAPVV, ret.getKeyUsage());
         assertEquals(Algorithm.RSA, ret.getAlgorithm());
         assertEquals(ModeOfUse.GENONLY, ret.getModeOfUse());
@@ -153,11 +160,11 @@ public class SecureKeyBlockBuilderTest {
 
     @Test
     public void testBuildWithOptHeaders() {
-        String data = "D0046V2TGc3E0233" + OPTHEADER_KV + OPTHEADER_KS + ISOUtil.hexString(KEYBLOCK_MAC8);
+        String data = "D0054V2TGc3E0233" + OPTHEADER_KV + OPTHEADER_KS + ISOUtil.hexString(KEYBLOCK_MAC8);
         ret = instance.build(data);
 
         assertEquals('D', ret.getKeyBlockVersion());
-        assertEquals(46, ret.getKeyBlockLength());
+        assertEquals(54, ret.getKeyBlockLength());
 
         assertNull(ret.getKeyBytes());
         assertArrayEquals(KEYBLOCK_MAC8, ret.getKeyBlockMAC());
@@ -175,11 +182,11 @@ public class SecureKeyBlockBuilderTest {
 
     @Test
     public void testBuildOptHeadersReversed() {
-        String data = "E0046V2TGc3E0233" + OPTHEADER_KS + OPTHEADER_KV + ISOUtil.hexString(KEYBLOCK_MAC8);
+        String data = "E0054V2TGc3E0233" + OPTHEADER_KS + OPTHEADER_KV + ISOUtil.hexString(KEYBLOCK_MAC8);
         ret = instance.build(data);
 
         assertEquals('E', ret.getKeyBlockVersion());
-        assertEquals(46, ret.getKeyBlockLength());
+        assertEquals(54, ret.getKeyBlockLength());
 
         assertNull(ret.getKeyBytes());
         assertArrayEquals(KEYBLOCK_MAC8, ret.getKeyBlockMAC());
@@ -200,7 +207,7 @@ public class SecureKeyBlockBuilderTest {
      */
     @Test
     public void testToKeyBlock() {
-        String data = "E0046V2TGc3E0233" + OPTHEADER_KS + OPTHEADER_KV + ISOUtil.hexString(KEYBLOCK_MAC8);
+        String data = "E0054V2TGc3E0233" + OPTHEADER_KS + OPTHEADER_KV + ISOUtil.hexString(KEYBLOCK_MAC8);
         ret = instance.build(data);
 
         assertEquals(data, instance.toKeyBlock(ret));
@@ -211,7 +218,7 @@ public class SecureKeyBlockBuilderTest {
      */
     @Test
     public void testToKeyBlockReversed() {
-        String data = "E0046V2TGc3E0233" + OPTHEADER_KV + OPTHEADER_KS + ISOUtil.hexString(KEYBLOCK_MAC8);
+        String data = "E0054V2TGc3E0233" + OPTHEADER_KV + OPTHEADER_KS + ISOUtil.hexString(KEYBLOCK_MAC8);
         ret = instance.build(data);
 
         assertEquals(data, instance.toKeyBlock(ret));

--- a/jpos/src/test/java/org/jpos/security/SecureKeyBlockTest.java
+++ b/jpos/src/test/java/org/jpos/security/SecureKeyBlockTest.java
@@ -36,9 +36,15 @@ public class SecureKeyBlockTest {
 
     private static final String NL = System.getProperty("line.separator");
 
-    private static final byte[] KEYBLOCK_MAC8 = ISOUtil.hex2byte("A1B2C3D4");
+    /**
+     * Test MAC with a length of 8 bytes.
+     */
+    private static final byte[] KEYBLOCK_MAC8 = ISOUtil.hex2byte("A1B2C3D4E5F60728");
 
-    private static final byte[] KEYBLOCK_MAC4 = ISOUtil.hex2byte("E1F2");
+    /**
+     * Test MAC with a length of 4 bytes.
+     */
+    private static final byte[] KEYBLOCK_MAC4 = ISOUtil.hex2byte("E1F22F1E");
 
     private static final byte[] KEYBLOCK_ENCKEY = ISOUtil.hex2byte("A9B8C7D6E5F49382");
 


### PR DESCRIPTION
The `SecureKeyBlockBuilder` cannot properly parse keys formatted as key blok because the length of `MAC` was misinterpreted.