### PR TITLE
DUKPT: support KSN of length > 16

### DIFF
--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -2309,9 +2309,9 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
 
         byte[] curkey = calculateInitialKey(ksn, bdk, true);
 
-        byte[] smidr = ISOUtil.hex2byte(
-                ksn.getBaseKeyID() + ksn.getDeviceID() + ksn.getTransactionCounter()
-        );
+        String sn = ksn.getBaseKeyID() + ksn.getDeviceID() + ksn.getTransactionCounter();
+        if (sn.length() > 16) sn = sn.substring(sn.length()-16);
+        byte[] smidr = ISOUtil.hex2byte(sn);
         byte[] reg3 = ISOUtil.hex2byte(ksn.getTransactionCounter());
         reg3 = and(reg3, _1FFFFF);
         byte[] shiftr = _100000;

--- a/jpos/src/test/java/org/jpos/security/jceadapter/DUKPTTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/DUKPTTest.java
@@ -119,6 +119,7 @@ public class DUKPTTest {
         test_DUKPT ("test-bdk", new KeySerialNumber ("987654", "3210", "EFFA00"), ISOUtil.hex2byte ("849763B43E5F9CFF"), PAN,true);
         test_DUKPT ("test-bdk", new KeySerialNumber ("987654", "3210", "EFFC00"), ISOUtil.hex2byte ("DEFC6F09F8927B71"), PAN,true);
         test_DUKPT ("test-bdk", new KeySerialNumber ("987654", "3210", "F00000"), ISOUtil.hex2byte ("73EC88AD0AC5830E"), PAN,true);
+        test_DUKPT ("test-bdk", new KeySerialNumber ("9876543210", "0000", "400002"), ISOUtil.hex2byte ("AEF0F261B1222EB1"), PAN,true);
     }
 
     @Test


### PR DESCRIPTION
Derivation of current key in DUKPT was assuming KSN always of length 16.