### PR TITLE
Allow empty defaults in environment references

### DIFF
--- a/jpos/src/main/java/org/jpos/core/Environment.java
+++ b/jpos/src/main/java/org/jpos/core/Environment.java
@@ -32,8 +32,8 @@ public class Environment implements Loggeable {
     private static final String SYSTEM_PREFIX = "sys";
     private static final String ENVIRONMENT_PREFIX = "env";
 
-    private static Pattern valuePattern = Pattern.compile("^(.*)(\\$)([\\w]*)\\{([-\\w.]+)(:(.+?))?\\}(.*)$");
-    // make groups easier to read :-)                       11112222233333333   444444444455666665    7777
+    private static Pattern valuePattern = Pattern.compile("^(.*)(\\$)([\\w]*)\\{([-\\w.]+)(:(.*))?\\}(.*)$");
+    // make groups easier to read :-)                       11112222233333333   44444444445566665    7777
 
     private static Pattern verbPattern = Pattern.compile("^\\$verb\\{([\\w\\W]+)\\}$");
     private static Environment INSTANCE;

--- a/jpos/src/test/java/org/jpos/core/EnvironmentTest.java
+++ b/jpos/src/test/java/org/jpos/core/EnvironmentTest.java
@@ -1,0 +1,12 @@
+package org.jpos.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EnvironmentTest {
+    @Test
+    public void testEmptyDefault() {
+        assertEquals("", Environment.get("${test:}"));
+    }
+}


### PR DESCRIPTION
So you can have `"${propname:}"` and get an empty string instead of `"${propname:}"` if `propname` not defined in environment