### PR TITLE
ChannelAdaptor respect 'enabled' on filters config

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/iso/ChannelAdaptor.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/ChannelAdaptor.java
@@ -223,6 +223,7 @@ public class ChannelAdaptor
     {
         for (Object o : e.getChildren("filter")) {
             Element f = (Element) o;
+            if (!QFactory.isEnabled(f)) continue;
             String clazz = QFactory.getAttributeValue(f, "class");
             ISOFilter filter = (ISOFilter) fact.newInstance(clazz);
             fact.setLogger(filter, f);


### PR DESCRIPTION
The beans created with the QFactory should respect the `enabled`
attribute in the definition XML, this commit add this control to the
ChannelAdaptor ISO filters.

Signed-off-by: Arturo Volpe <avolpe@fintech.works>