### PR TITLE
Remove persistent-space from TransactionManagerTestCase.

### DIFF
--- a/jpos/src/test/resources/org/jpos/transaction/10_txnmgr_test.xml
+++ b/jpos/src/test/resources/org/jpos/transaction/10_txnmgr_test.xml
@@ -2,7 +2,6 @@
  <property name="queue"            value="TXNMGRTEST" />
  <property name="sessions"         value="4" />
  <property name="input-space" value="tspace:txnmgrtest" />
- <property name="persistent-space" value="je:txnmgrtest" />
  <property name="debug-context" value="true" />
  <property name="debug" value="true" />
  <property name="retry-interval"   value="250" />


### PR DESCRIPTION
This doesn't appear to be used and sometimes causes test failures.