### PR TITLE
Connection confirmation message for BaseChannel in client mode

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/BaseChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/BaseChannel.java
@@ -337,6 +337,8 @@ public abstract class BaseChannel extends Observable
                 int ii = nextHostPort++ % hosts.length;
                 evt.addMessage ("Try " + i + " " + hosts[ii]+":"+ports[ii]);
                 s = newSocket (hosts[ii], ports[ii]);
+                evt.addMessage ("  Connection established to "
+                                + s.getInetAddress().getHostAddress() + ":" + s.getPort());
                 break;
             } catch (IOException e) {
                 evt.addMessage ("  " + e.getMessage());


### PR DESCRIPTION
When attempting a connection, instead of just saying `Try...` and leave it at that, it will now give a nice and reassuring message upon success, such as:
```
  <connect>
    Try 0 isobridge.jpos.org:9000
      Connection established to 52.7.83.125:9000
  </connect>
```

As seen above, it also informs you of the remote host:port
