### PR TITLE
Use monotonic clocks for MUXPool and fix send/timeout bugs.

### DIFF
--- a/jpos/src/test/java/org/jpos/q2/iso/MUXPoolTest.java
+++ b/jpos/src/test/java/org/jpos/q2/iso/MUXPoolTest.java
@@ -93,7 +93,7 @@ public class MUXPoolTest {
             if (isJavaVersionAtMost(JAVA_14)) {
                 assertNull(ex.getMessage(), "ex.getMessage()");
             } else {
-                assertEquals("Cannot read the array length because \"<local4>\" is null", ex.getMessage(), "ex.getMessage()");
+                assertEquals("Cannot read the array length because \"<local6>\" is null", ex.getMessage(), "ex.getMessage()");
             }
         }
     }


### PR DESCRIPTION
This also avoids using Duration for performance. `System.nanoTime()` is faster than `System.currentTimeMillis()` on Linux so moving to monotonic clocks should also improve performance.