### PR TITLE
Adding $cfg{...} syntax

### DIFF
--- a/doc/src/asciidoc/ch03/configuration.adoc
+++ b/doc/src/asciidoc/ch03/configuration.adoc
@@ -2,8 +2,8 @@
 
 == Configuration
 
-*org.jpos.core.Configuration* is a general purpose property container 
-extensively used by jPOS components. 
+*org.jpos.core.Configuration* is a general purpose property container
+extensively used by jPOS components.
 
 The Configuration interface looks like this:
 
@@ -65,7 +65,7 @@ configuration object by calling the +setConfiguration+ method on
     </object>
 ----
 
-Should +com.mycompany.MyObject+ implement +Configurable+, Q2 would call its  +setConfiguration()+ method 
+Should +com.mycompany.MyObject+ implement +Configurable+, Q2 would call its  +setConfiguration()+ method
 providing access to the underlying +myProperty+ property.
 
 It's interesting to note that Q2 provides the ability to have array of
@@ -82,10 +82,10 @@ properties under the same name, i.e:
 
 ----
 
-where one can call handy methods like  +String[] getAll(String)+. 
+where one can call handy methods like  +String[] getAll(String)+.
 
-+setConfiguration(Configuration cfg)+ can check the Configuration object and might 
-throw a +ConfigurationException+ in case a required property is not present or 
++setConfiguration(Configuration cfg)+ can check the Configuration object and might
+throw a +ConfigurationException+ in case a required property is not present or
 is invalid.
 
 [TIP]
@@ -93,25 +93,26 @@ is invalid.
 SimpleConfiguration recognizes and de-references properties with the
 format: `${xxx}` and searches for a system property, or operating system
 environment variable under the `xxx` name.
-As a fallback mechanism of last resort, the properety can be resolved from a
-YAML or properties file in the `cfg` directory (default filename `default.yml`
+As a fallback mechanism of last resort, the property can be resolved from an _environment file_, in
+YAML or _properties_ file syntax, found in the `cfg` directory (default filename `default.yml`
 or `default.cfg`, which can be overridden by the `jpos.env` system property).
 
 You can add a default value within the expression itself, using the `:` (colon) separator.
 For example `${xxx:def_value}`. If the property is not found, the default value will be used.
 
-The format `$sys{xxx}` de-reference just from system properties, and
-`$env{xxx}` just from the operating system environment.
+The format `$sys{xxx}` de-references just from system properties,
+`$env{xxx}` just from the operating system environment, and `$cfg{xxx}` just from the environment file (the.
+
 
 In the rare case where a value with the format `${...}` is required, the
 `$verb{${...}}` format (verbatim) can be used.
 
-In addition, a property named `xx.yy.zz` can be overriden by the environment
+In addition, a property named `xx.yy.zz` can be overridden by the environment
 variable `XX_YY_ZZ` (note that dots are replaced by underscore, and property
 name is converted to uppercase.
 =====
 
-The jPOS `Environment` has a ServiceLoader based plugin mechanism that support 
+The jPOS `Environment` has a ServiceLoader based plugin mechanism that support
 `EnvironmentProviders`. jPOS comes with two stock providers:
 
   - `FileEnvironmentProvider` (prefix `file::`).

--- a/jpos/src/test/java/org/jpos/core/SimpleConfigurationTest.java
+++ b/jpos/src/test/java/org/jpos/core/SimpleConfigurationTest.java
@@ -599,7 +599,7 @@ public class SimpleConfigurationTest {
         // first, the `intro` sys property is not defined, so we get the default value
         assertEquals("AAA Introduction: BBB Hello jPOS! CCC (I said: Hello jPOS!) DDD", cfg.get("myprop"));
 
-        // now, we define `intro`, so we get its value from the sys propertis
+        // now, we define `intro`, so we get its value from the sys properties
         System.setProperty("intro", "Say it:");
         assertEquals("AAA Say it: BBB Hello jPOS! CCC (I said: Hello jPOS!) DDD", cfg.get("myprop"));
     }

--- a/jpos/src/test/resources/org/jpos/core/testenv.yml
+++ b/jpos/src/test/resources/org/jpos/core/testenv.yml
@@ -1,0 +1,2 @@
+test:
+  value: "from testenv.yml"


### PR DESCRIPTION
New property syntax $cfg{...}  that will only resolve from the yml/cfg environment file.
It allows to have a nice configuration file with all config in one place, but without the danger of someone overriding some values by changing the process' ENV variable or Java system property.

Undocumented extra feature: the `cfg` directory from where the environment file is read can be changed with the `jpos.envdir` Java system property (useful for tests and who knows what else ;-) )
