### PR TITLE
Add support for multiple environments

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/Q2.java
+++ b/jpos/src/main/java/org/jpos/q2/Q2.java
@@ -757,10 +757,7 @@ public class Q2 implements FileFilter, Runnable {
                 System.setProperty("jpos.envdir", line.getOptionValue("Ed"));
             }
             if (line.hasOption("E")) {
-                System.setProperty("jpos.env", line.getOptionValue("E"));
-            }
-            if (line.hasOption("Ed") || line.hasOption("E")) {
-                Environment.reload();
+                System.setProperty("jpos.env", ISOUtil.commaEncode(line.getOptionValues("E")));
             }
 
             if (line.hasOption ("c")) {

--- a/jpos/src/test/java/org/jpos/q2/Q2Test.java
+++ b/jpos/src/test/java/org/jpos/q2/Q2Test.java
@@ -172,7 +172,7 @@ public class Q2Test {
     public void testGetEnvDir() throws Throwable {
         String[] args = { "-Ed", "blah/foo/bar" };
         Q2 q2 = new Q2(args);
-        Environment env = Environment.getEnvironment();
+        Environment env = Environment.reload(); // Environment.INSTANCE is polluted from previous runs
         assertEquals("blah/foo/bar", env.getEnvDir(), "env.getEnvDir()");
         q2.stop();
     }


### PR DESCRIPTION
-E (or --environent) switch can be repeated now, i.e:

   q2 --environment=default --environment=QA