### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,10 @@ import org.gradle.internal.os.OperatingSystem
 apply from: 'jpos/libraries.gradle'
 
 allprojects {
+    tasks.withType(JavaCompile).configureEach {
+        options.fork = true
+    }
+
     apply plugin: 'idea'
     apply plugin: 'eclipse'
 }
@@ -165,4 +169,3 @@ task aggregatedJavadoc (type: Javadoc, description: "Aggregated Javadocs") {
         project.sourceSets.main.compileClasspath})
     failOnError = false
 }
-


### PR DESCRIPTION

[Compiler daemon](https://docs.gradle.org/current/userguide/performance.html#compiler_daemon). The Gradle Java plugin allows you to run the compiler as a separate process by setting `options.fork = true`. This feature can lead to much less garbage collection and make Gradle’s infrastructure faster. This project has more than 1000 source files. We can consider enabling this feature.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
