### PR TITLE
Add Environment awareness to the SimpleConfiguration Factory.

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/SimpleConfigurationFactory.java
+++ b/jpos/src/main/java/org/jpos/q2/SimpleConfigurationFactory.java
@@ -18,63 +18,108 @@
 
 package org.jpos.q2;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
 import org.jdom2.Element;
 import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
 import org.jpos.core.Environment;
 import org.jpos.core.SimpleConfiguration;
+import org.jpos.iso.ISOUtil;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-
 public class SimpleConfigurationFactory implements ConfigurationFactory {
+    @Override
     public Configuration getConfiguration(Element e) throws ConfigurationException {
-        Properties props = new Properties ();
-        Iterator iter = e.getChildren ("property").iterator();
-        while (iter.hasNext()) {
-            Element property = (Element) iter.next ();
-            String name  = property.getAttributeValue("name");
+        Properties props = new Properties();
+        for (Element property : e.getChildren("property")) {
+            String name = property.getAttributeValue("name");
             String value = property.getAttributeValue("value");
-            String file  = property.getAttributeValue("file");
-            if (file != null) {
-                file = Environment.get(file);
-                try {
-                    if (file.endsWith(".yml")) {
-                        readYAML(props, file);
-                    } else {
-                        props.load(new FileInputStream(new File(file)));
-                    }
-                } catch (Exception ex) {
-                    throw new ConfigurationException(file, ex);
-                }
-            }
-            else if (name != null && value != null) {
-                Object obj = props.get (name);
-                if (obj instanceof String[]) {
-                    String[] mobj = (String[]) obj;
-                    String[] m = new String[mobj.length + 1];
-                    System.arraycopy(mobj,0,m,0,mobj.length);
-                    m[mobj.length] = value;
-                    props.put (name, m);
-                } else if (obj instanceof String) {
-                    String[] m = new String[2];
-                    m[0] = (String) obj;
-                    m[1] = value;
-                    props.put (name, m);
-                } else
-                    props.put (name, value);
+            String baseFile = property.getAttributeValue("file");
+            if (baseFile != null) {
+            	boolean isEnv = Boolean.parseBoolean(property.getAttributeValue("env", "false"));
+                processFile(props, baseFile, isEnv);
+            } else if (name != null && value != null) {
+                processProperty(props, name, value);
             }
         }
         return new SimpleConfiguration(props);
     }
 
-    private void readYAML (Properties props, String fileName) throws IOException {
+    protected void processProperty(Properties props, String name, String value) {
+        Object obj = props.get(name);
+        if (obj instanceof String[]) {
+            String[] mobj = (String[]) obj;
+            String[] m = new String[mobj.length + 1];
+            System.arraycopy(mobj, 0, m, 0, mobj.length);
+            m[mobj.length] = value;
+            props.put(name, m);
+        } else if (obj instanceof String) {
+            String[] m = new String[2];
+            m[0] = (String) obj;
+            m[1] = value;
+            props.put(name, m);
+        } else
+            props.put(name, value);
+    }
+
+    protected void processFile(Properties props, String baseFile, boolean isEnv) throws ConfigurationException {
+        baseFile = Environment.get(baseFile);
+        boolean foundFile = false;
+        for (String file : getFiles(baseFile, isEnv?Environment.getEnvironment().getName():"")) {
+            foundFile |= readYamlFile(props, file);
+        }
+        if (!foundFile) {
+            throw new ConfigurationException("Could not find any matches for file: " + baseFile);
+        }
+    }
+
+    protected List<String> getFiles(String baseFile, String environmnents) {
+        List<String> files = new ArrayList<>();
+        files.add(baseFile);
+        if (baseFile.endsWith(".yml") || baseFile.endsWith(".properties")) {
+            baseFile = baseFile.substring(0, baseFile.lastIndexOf("."));
+        }
+        for (String env : ISOUtil.commaDecode(environmnents)) {
+            if (!ISOUtil.isBlank(env)) {
+                files.add(baseFile + "-" + env + ".yml");
+                files.add(baseFile + "-" + env + ".properties");
+            }
+        }
+        return files;
+    }
+
+    protected boolean readYamlFile(Properties props, String fileName) throws ConfigurationException {
+        try {
+            if (fileName.endsWith(".yml")) {
+                return readYAML(props, fileName);
+            } else {
+                return readPropertyFile(props, fileName);
+            }
+        } catch (Exception ex) {
+            throw new ConfigurationException(fileName, ex);
+        }
+    }
+
+    protected boolean readPropertyFile(Properties props, String fileName) throws IOException {
+        File f = new File(fileName);
+        if (f.exists() && f.canRead()) {
+            try (FileInputStream in = new FileInputStream(f)) {
+                props.load(in);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean readYAML(Properties props, String fileName) throws IOException {
         File f = new File(fileName);
         if (f.exists() && f.canRead()) {
             try (InputStream fis = new FileInputStream(f)) {
@@ -84,8 +129,8 @@ public class SimpleConfigurationFactory implements ConfigurationFactory {
                     Environment.flat(props, null, (Map<String, Object>) d, true);
                 });
             }
-        } else {
-            throw new IOException ("Invalid file '" + fileName + "'");
+            return true;
         }
+        return false;
     }
 }

--- a/jpos/src/test/java/org/jpos/q2/SimpleConfigurationFactoryTest.java
+++ b/jpos/src/test/java/org/jpos/q2/SimpleConfigurationFactoryTest.java
@@ -1,0 +1,136 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2021 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.q2;
+
+import org.jdom2.Element;
+import org.jpos.core.Configuration;
+import org.jpos.core.ConfigurationException;
+import org.jpos.core.Environment;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SimpleConfigurationFactoryTest {
+    static String oldEnv;
+    static final String TEST_BASE_FILE = "build/resources/test/org/jpos/q2/configFactoryTest.yml";
+
+	SimpleConfigurationFactory f = new SimpleConfigurationFactory();
+
+    @BeforeAll
+    public static void setUp() throws IOException
+    {
+        oldEnv = System.getProperty("jpos.env");            // save it to restore it later
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        // restore old env
+        if (oldEnv != null)
+            System.setProperty("jpos.env", oldEnv);
+        else
+            System.clearProperty("jpos.env");
+
+        Environment.reload();
+    }
+
+
+    Element getBaseElement(String fileName, boolean withEnv) {
+    	Element root = new Element("root");
+    	Element property = new Element("property");
+    	property.setAttribute("file", fileName);
+    	if (withEnv) {
+    		property.setAttribute("env", "true");
+    	}
+    	root.addContent(property);
+    	return root;
+    }
+    
+    void setEnv(String env) throws IOException {
+    	System.setProperty("jpos.env", env);
+    	Environment.reload();
+    }
+
+    @Test
+    public void testFileList() {
+    	assertEquals(Arrays.asList("file.yml", "file-env1.yml", "file-env1.properties", "file-env2.yml", "file-env2.properties"), 
+    			f.getFiles("file.yml", "env1,env2"));
+    }
+
+    @Test
+    public void testFromSimpleFile() throws ConfigurationException {    	
+    	Element e = getBaseElement(TEST_BASE_FILE, false);
+    	Configuration cfg = f.getConfiguration(e);
+    	assertEquals("configFactoryTest", cfg.get("base.name"));
+    	assertEquals("true", cfg.get("configFactoryTest"));
+    	assertEquals("", cfg.get("configFactoryTest-testenv"));
+    	assertEquals("", cfg.get("configFactoryTest-testenv2"));
+    }
+
+    @Test
+    public void testFromSimpleFileWithEnvironment() throws ConfigurationException, IOException {
+    	setEnv("testenv");
+    	Element e = getBaseElement(TEST_BASE_FILE, false);
+    	Configuration cfg = f.getConfiguration(e);
+    	assertEquals("configFactoryTest", cfg.get("base.name"));
+    	assertEquals("true", cfg.get("configFactoryTest"));
+    	assertEquals("", cfg.get("configFactoryTest1"));
+    	assertEquals("", cfg.get("configFactoryTest2"));
+    }
+
+    @Test
+    public void testFromSimpleFileWithEnvironmentSet() throws ConfigurationException, IOException {
+    	setEnv("testenv");
+    	Element e = getBaseElement(TEST_BASE_FILE, true);
+    	Configuration cfg = f.getConfiguration(e);
+    	assertEquals("configFactoryTest-testenv", cfg.get("base.name"));
+    	assertEquals("true", cfg.get("configFactoryTest"));
+    	assertEquals("true", cfg.get("configFactoryTest1"));
+    	assertEquals("", cfg.get("configFactoryTest2"));
+    }
+
+    @Test
+    public void testFromSimpleFileWithEnvironmentSet2() throws ConfigurationException, IOException {
+    	setEnv("testenv2");
+    	Element e = getBaseElement(TEST_BASE_FILE, true);
+    	Configuration cfg = f.getConfiguration(e);
+    	assertEquals("configFactoryTest-testenv2", cfg.get("base.name"));
+    	assertEquals("true", cfg.get("configFactoryTest"));
+    	assertEquals("", cfg.get("configFactoryTest1"));
+    	assertEquals("true", cfg.get("configFactoryTest2"));
+    }
+
+    @Test
+    public void testFromSimpleFileWithEnvironmentMultiple() throws ConfigurationException, IOException {
+    	setEnv("testenv,testenv2");
+    	Element e = getBaseElement(TEST_BASE_FILE, true);
+    	Configuration cfg = f.getConfiguration(e);
+    	assertEquals("configFactoryTest-testenv2", cfg.get("base.name"));
+    	assertEquals("true", cfg.get("configFactoryTest"));
+    	assertEquals("true", cfg.get("configFactoryTest1"));
+    	assertEquals("true", cfg.get("configFactoryTest2"));
+    }
+
+}

--- a/jpos/src/test/resources/org/jpos/q2/configFactoryTest-testenv.yml
+++ b/jpos/src/test/resources/org/jpos/q2/configFactoryTest-testenv.yml
@@ -1,0 +1,4 @@
+base:
+   name: configFactoryTest-testenv
+---
+configFactoryTest1: true

--- a/jpos/src/test/resources/org/jpos/q2/configFactoryTest-testenv2.yml
+++ b/jpos/src/test/resources/org/jpos/q2/configFactoryTest-testenv2.yml
@@ -1,0 +1,4 @@
+base:
+   name: configFactoryTest-testenv2
+---
+configFactoryTest2: true

--- a/jpos/src/test/resources/org/jpos/q2/configFactoryTest.yml
+++ b/jpos/src/test/resources/org/jpos/q2/configFactoryTest.yml
@@ -1,0 +1,4 @@
+base:
+   name: configFactoryTest
+---
+configFactoryTest: true


### PR DESCRIPTION
Allow for file property to have and env variable that can look into the environment being set and lookup the files based on the environment.
i.e. 
```xml
<property file="module.yml" env="true"/>
```
If the environment is set to prod (jpos.env=prod), then it will attempt to load module.yml, module-prod.yml or module-prod.properties.

This allows to define a base property file and potentially override some attributes for other environments.