### PR TITLE
Initialize ServiceConfig prior to calling readCongig. Add unit test

### DIFF
--- a/jpos/src/main/java/org/jpos/core/Environment.java
+++ b/jpos/src/main/java/org/jpos/core/Environment.java
@@ -64,8 +64,8 @@ public class Environment implements Loggeable {
         name = System.getProperty ("jpos.env");
         name = name == null ? "default" : name;
         envDir = System.getProperty("jpos.envdir", DEFAULT_ENVDIR);
-        readConfig ();
         serviceLoader = ServiceLoader.load(EnvironmentProvider.class);
+        readConfig ();
     }
 
     public String getName() {
@@ -196,7 +196,7 @@ public class Environment implements Loggeable {
           .stringPropertyNames()
           .stream()
           .filter(e -> e.startsWith(SP_PREFIX))
-          .forEach(prop -> System.setProperty(prop.substring(SP_PREFIX_LENGTH), (String) properties.get(prop)));
+          .forEach(prop -> System.setProperty(prop.substring(SP_PREFIX_LENGTH), this.getProperty((String) properties.get(prop))));
     }
 
     private boolean readYAML () throws IOException {

--- a/jpos/src/test/java/org/jpos/core/EnvironmentTest.java
+++ b/jpos/src/test/java/org/jpos/core/EnvironmentTest.java
@@ -70,6 +70,7 @@ public class EnvironmentTest {
     public void testFromCfg() {
         System.setProperty("test.value", "from sys prop");
         assertEquals("from testenv.yml", Environment.get("$cfg{test.value}"));
+        assertEquals("from testenv.yml", System.getProperty("test.sys"));
     }
 
 

--- a/jpos/src/test/resources/org/jpos/core/testenv.yml
+++ b/jpos/src/test/resources/org/jpos/core/testenv.yml
@@ -1,2 +1,7 @@
 test:
   value: "from testenv.yml"
+---
+system:
+  property:
+    test:
+      sys: ${test.value}


### PR DESCRIPTION
serviceLoader has to be initialized prior to calling readConfig. Otherwise you will get an NPE when calling getProperty from extractSystemProperties.