### PR TITLE
QueryHost force abort when expired in continuations mode

### DIFF
--- a/jpos/src/main/java/org/jpos/transaction/TransactionManager.java
+++ b/jpos/src/main/java/org/jpos/transaction/TransactionManager.java
@@ -275,6 +275,9 @@ public class TransactionManager
                         if (prof != null)
                             prof.reenable();
                         pausedCounter.decrementAndGet();
+
+                        if (evt != null && abort)
+                            evt.addMessage ("   [force abort]");
                     }
                 } else 
                     pt = null;
@@ -312,7 +315,8 @@ public class TransactionManager
                     if (prof == null)
                         prof = new Profiler();
                     else
-                        prof.checkPoint("resume");
+                        prof.checkPoint("resume" +
+                                        (pt != null && pt.isAborting() ? " [force abort]" : ""));
                 }
                 snapshot (id, context, PREPARING);
                 setThreadLocal(id, context);

--- a/jpos/src/main/java/org/jpos/transaction/participant/QueryHost.java
+++ b/jpos/src/main/java/org/jpos/transaction/participant/QueryHost.java
@@ -100,16 +100,19 @@ public class QueryHost implements TransactionParticipant, ISOResponseListener, C
         return PREPARED | NO_JOIN | READONLY;
     }
 
+    @Override
     public void responseReceived (ISOMsg resp, Object handBack) {
         Context ctx = (Context) handBack;
         ctx.put (responseName, resp);
         ctx.resume();
     }
+    @Override
     public void expired (Object handBack) {
         Context ctx = (Context) handBack;
         String ds = ctx.getString(destination);
         String muxName = cfg.get ("mux." + ds , "mux." + ds);
         ctx.getResult().fail(CMF.HOST_UNREACHABLE, Caller.info(), "'%s' does not respond", muxName).FAIL();
+        ctx.getPausedTransaction().forceAbort();
         ctx.resume();
     }
 


### PR DESCRIPTION
The synchronous, non-continuations, mode aborts then txn when the mux does not respond.

When in continuations mode, the txn will just simply proceed on to the next participant (who now has the responsibility to explicitly check if `QueryHost` really succeeded).

By doing a `ctx.getPausedTransaction().forceAbort()` when the `mux.request` expired, we now have the same behavior in practice:  the txnmgr will initiate an **abort phase** right after resuming the txn.