### PR TITLE
feat: Add Application Cryptogram Spec

### DIFF
--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CVN10DataBuilder.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CVN10DataBuilder.java
@@ -1,0 +1,29 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.emv.IssuerApplicationData;
+import org.jpos.tlv.TLVList;
+
+import static org.jpos.emv.cryptogram.CryptogramDataBuilder.minimumSetOfDataElement;
+
+/**
+ * 
+ * Visa CVN 10 - Data Builder
+ *
+ * @author Rainer Reyes
+ */
+public class CVN10DataBuilder implements CryptogramDataBuilder {
+    
+    @Override
+    public String getDefaultARPCRequest(boolean approved) {
+        return approved ? "0000" : "9900";
+    }
+
+
+    @Override
+    public String buildARQCRequest(TLVList data, IssuerApplicationData iad) {
+        StringBuilder sb = new StringBuilder();
+        minimumSetOfDataElement(data).stream().forEach(sb::append);
+        sb.append(iad.getCardVerificationResults());
+        return sb.toString();
+    }
+}

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CVN18DataBuilder.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CVN18DataBuilder.java
@@ -1,0 +1,32 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.emv.IssuerApplicationData;
+import org.jpos.tlv.TLVList;
+
+import static org.jpos.emv.cryptogram.CryptogramDataBuilder.minimumSetOfDataElement;
+
+/**
+ * Visa CVN 18 - Data Builder
+ * @author Rainer Reyes
+ */
+public class CVN18DataBuilder implements CryptogramDataBuilder {
+    
+    @Override
+    public String getDefaultARPCRequest(boolean approved) {
+        /* for success:
+         * 00830000
+         * Byte 6, bit 1: Issuer Approves Online Transaction
+         * Byte 6, bits 7–8: Update Counters:
+         * • 11 = Add transaction to offline counter
+         */
+        return approved ? "00830000" : "00000000";
+    }
+
+    @Override
+    public String buildARQCRequest(TLVList data, IssuerApplicationData iad) {
+        StringBuilder sb = new StringBuilder();
+        minimumSetOfDataElement(data).stream().forEach(sb::append);
+        sb.append(iad.toString());
+        return sb.toString();
+    }
+}

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CVN22DataBuilder.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CVN22DataBuilder.java
@@ -1,0 +1,9 @@
+package org.jpos.emv.cryptogram;
+
+/**
+ * Visa CVN '22' - Data Builder
+ * @author Rainer Reyes
+ */
+public class CVN22DataBuilder extends CVN18DataBuilder {
+
+}

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CVNMCDataBuilder.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CVNMCDataBuilder.java
@@ -1,0 +1,38 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.emv.IssuerApplicationData;
+import org.jpos.tlv.TLVList;
+
+/**
+ * M/CHIP Data builder
+ *
+ * @author Rainer Reyes
+ */
+public class CVNMCDataBuilder implements CryptogramDataBuilder {
+    // counter is used only in M/CHIP advance
+    private final boolean includeCounters;
+
+    public CVNMCDataBuilder(boolean includeCounters) {
+        this.includeCounters = includeCounters;
+    }
+
+
+    @Override
+    public String buildARQCRequest(TLVList data, IssuerApplicationData iad) {
+
+        StringBuilder sb = new StringBuilder();
+        CryptogramDataBuilder.minimumSetOfDataElement(data).stream().forEach(sb::append);
+        sb.append(iad.getCardVerificationResults());
+
+        if (includeCounters) {
+            sb.append(iad.getCounters());
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getDefaultARPCRequest(boolean approved) {
+        return approved ? "0012" : "9900";
+    }
+    
+}

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CryptogramDataBuilder.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CryptogramDataBuilder.java
@@ -1,0 +1,61 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.emv.EMVStandardTagType;
+import org.jpos.emv.IssuerApplicationData;
+import org.jpos.tlv.TLVList;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+
+/**
+ * Interface that provides methods to build strings for ARPC and ARQC generation
+ *
+ * @author Rainer Reyes
+ */
+public interface CryptogramDataBuilder {
+
+    /**
+     * Method that selects the  minimum set of data elements recommended for
+     * the generation of application cryptograms described in EMV Book 2 sec 8.1.1
+     *
+     * @param data ICC data
+     * @return Minimum Set of Data Elements for Application Cryptogram Generation
+     */
+    static List<String> minimumSetOfDataElement(TLVList data) {
+        return Arrays.asList(
+                data.getString(EMVStandardTagType.AMOUNT_AUTHORISED_NUMERIC_0x9F02.getTagNumber()),
+                Optional.ofNullable(data.getString(EMVStandardTagType.AMOUNT_OTHER_NUMERIC_0x9F03.getTagNumber()))
+                        .orElse("000000000000"),
+                data.getString(EMVStandardTagType.TERMINAL_COUNTRY_CODE_0x9F1A.getTagNumber()),
+                data.getString(EMVStandardTagType.TERMINAL_VERIFICATION_RESULTS_0x95.getTagNumber()),
+                data.getString(EMVStandardTagType.TRANSACTION_CURRENCY_CODE_0x5F2A.getTagNumber()),
+                data.getString(EMVStandardTagType.TRANSACTION_DATE_0x9A.getTagNumber()),
+                data.getString(EMVStandardTagType.TRANSACTION_TYPE_0x9C.getTagNumber()),
+                data.getString(EMVStandardTagType.UNPREDICTABLE_NUMBER_0x9F37.getTagNumber()),
+                data.getString(EMVStandardTagType.APPLICATION_INTERCHANGE_PROFILE_0x82.getTagNumber()),
+                data.getString(EMVStandardTagType.APPLICATION_TRANSACTION_COUNTER_0x9F36.getTagNumber())
+        );
+    }
+
+
+    /**
+     * Method that returns default issuer response data (ARC or CSU)
+     *
+     * @param approved true if transaction was approved, otherwise false
+     * @return String representing  default issuer response data that will be used to generate the ARPC
+     */
+    String getDefaultARPCRequest(boolean approved);
+
+    /**
+     * Select necessary data elements and create the string used to generate the ARQC
+     * <p>
+     *
+     * @param data ICC data received
+     * @param iad  Issuer application Data
+     * @return String used to generate the ARQC
+     */
+    String buildARQCRequest(TLVList data, IssuerApplicationData iad);
+
+}

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CryptogramSpec.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CryptogramSpec.java
@@ -1,0 +1,48 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.security.ARPCMethod;
+import org.jpos.security.MKDMethod;
+import org.jpos.security.SKDMethod;
+
+/**
+ * 
+ * Interface that represents the parameters and data used by the cryptogram generation algorithm
+ * 
+ * 
+ * 
+ * @author Rainer Reyes
+ */
+public interface CryptogramSpec {
+
+    /**
+     * Return method of the derivation of ICC Master Key used for Application Cryptogram generation
+     * 
+     * @return Master Key Derivation Method
+     */
+    MKDMethod getMKDMethod();
+
+    /**
+     * 
+     * Return method of the derivation of Unique DEA Key UDK (Session Key) used for Application Cryptogram generation
+     * @return Session Key Derivation Method
+     */
+    SKDMethod getSKDMethod();
+
+    /**
+     * Returns method of generation of the response cryptogram
+     * 
+     * @return ARPC Generation Method
+     */
+    ARPCMethod getARPCMethod();
+
+    /**
+     * 
+     * Returns class in charge of selecting the data elements and building the string 
+     * that will be used for the generation of the cryptogram
+     * 
+     * @return Cryptogram Data Builder 
+     */
+    CryptogramDataBuilder getDataBuilder();
+
+
+}

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/MChipCryptogram.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/MChipCryptogram.java
@@ -1,0 +1,52 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.security.ARPCMethod;
+import org.jpos.security.MKDMethod;
+import org.jpos.security.SKDMethod;
+
+/**
+ * M/Chip Cryptogram Specification 
+ * 
+ * @author Rainer Reyes
+ */
+public class MChipCryptogram implements CryptogramSpec {
+
+    private final CVNMCDataBuilder dataBuilder;
+    private final SKDMethod skdMethod;
+
+
+    public MChipCryptogram(String cryptogramVersionNumber) {
+        byte data = (byte) Integer.parseInt(cryptogramVersionNumber, 16);
+        this.dataBuilder = new CVNMCDataBuilder((data & 1) == 1); // byte 1 = 1
+        // byte 3-2
+        if ((data >> 1 & 0x03) == 0x00) { // bits = 00
+            // byte 3-2 = 00
+            skdMethod = SKDMethod.MCHIP;
+        } else if ((data >> 1 & 0x03) == 0x02) { // bits = 10
+            // byte 3-2 = 10
+            skdMethod = SKDMethod.EMV_CSKD;
+        } else {
+            throw new RuntimeException("Cryptogram version not supported");
+        }
+    }
+
+    @Override
+    public MKDMethod getMKDMethod() {
+        return MKDMethod.OPTION_A;
+    }
+
+    @Override
+    public SKDMethod getSKDMethod() {
+        return skdMethod;
+    }
+
+    @Override
+    public ARPCMethod getARPCMethod() {
+        return ARPCMethod.METHOD_1;
+    }
+
+    @Override
+    public CryptogramDataBuilder getDataBuilder() {
+        return dataBuilder;
+    }
+}

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/VISACryptogram.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/VISACryptogram.java
@@ -1,0 +1,58 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.security.ARPCMethod;
+import org.jpos.security.MKDMethod;
+import org.jpos.security.SKDMethod;
+
+/**
+ * VISA Cryptogram Specification
+ *
+ * @author Rainer Reyes
+ */
+public class VISACryptogram implements CryptogramSpec {
+
+    private final Integer number;
+    private final CryptogramDataBuilder dataBuilder;
+    private final ARPCMethod arpcMethod;
+    private final SKDMethod skdMethod;
+
+    public VISACryptogram(String cryptogramVersionNumber) {
+        this.number = Integer.parseInt(cryptogramVersionNumber, 16);
+        if (number == 10) {
+            this.dataBuilder = new CVN10DataBuilder();
+            this.arpcMethod = ARPCMethod.METHOD_1;
+            this.skdMethod = SKDMethod.VSDC;
+        } else if (number == 18) { // CVN 18
+            this.dataBuilder = new CVN18DataBuilder();
+            this.arpcMethod = ARPCMethod.METHOD_2;
+            this.skdMethod = SKDMethod.EMV_CSKD;
+        } else if (number == 34) {//CVN '22'
+            this.dataBuilder = new CVN22DataBuilder();
+            this.arpcMethod = ARPCMethod.METHOD_2;
+            this.skdMethod = SKDMethod.EMV_CSKD;
+        } else {
+            throw new RuntimeException("Cryptogram version not supported");
+        }
+    }
+
+
+    @Override
+    public MKDMethod getMKDMethod() {
+        return MKDMethod.OPTION_A;
+    }
+
+    @Override
+    public SKDMethod getSKDMethod() {
+        return skdMethod;
+    }
+
+    @Override
+    public ARPCMethod getARPCMethod() {
+        return arpcMethod;
+    }
+
+    @Override
+    public CryptogramDataBuilder getDataBuilder() {
+        return dataBuilder;
+    }
+}

--- a/jpos/src/test/java/org/jpos/emv/IssuerApplicationDataTest.java
+++ b/jpos/src/test/java/org/jpos/emv/IssuerApplicationDataTest.java
@@ -18,11 +18,13 @@
 
 package org.jpos.emv;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.jpos.emv.IssuerApplicationData.Format;
+import org.jpos.emv.cryptogram.MChipCryptogram;
+import org.jpos.emv.cryptogram.CryptogramSpec;
+import org.jpos.emv.cryptogram.VISACryptogram;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IssuerApplicationDataTest {
 
@@ -38,7 +40,7 @@ public class IssuerApplicationDataTest {
         assertThrows(IllegalArgumentException.class, () -> {
             new IssuerApplicationData(new String(new char[64]));
         });
-    }    
+    }
 
     @Test
     public void testConstructorWithNullArgument() {
@@ -46,14 +48,14 @@ public class IssuerApplicationDataTest {
             new IssuerApplicationData((String) null);
         });
     }
-    
+
     @Test
     public void testConstructorWithEmptyByteArray() {
         assertThrows(IllegalArgumentException.class, () -> {
-            new IssuerApplicationData(new byte[] {});
+            new IssuerApplicationData(new byte[]{});
         });
     }
-    
+
     @Test
     public void testToString() {
         String hexIAD = "0110250000044000DAC10000000000000000";
@@ -72,7 +74,7 @@ public class IssuerApplicationDataTest {
         assertEquals("10", iad.getCryptogramVersionNumber(), "CVN matches.");
         assertEquals("DAC1", iad.getDAC(), "DAC/ICC dynamic number matches.");
     }
-    
+
     @Test
     public void testMChip4_2() {
         IssuerApplicationData iad = new IssuerApplicationData("0210A00000000000000000000000000000FF");
@@ -84,37 +86,37 @@ public class IssuerApplicationDataTest {
         assertEquals("0000", iad.getDAC(), "DAC/ICC dynamic number matches.");
 
     }
-    
+
     @Test
     public void testRandom() {
         IssuerApplicationData iad = new IssuerApplicationData("0110201009248400000000000000000029ff");
-        iad.dump(System.out, "");    
+        iad.dump(System.out, "");
         assertEquals("201009248400", iad.getCardVerificationResults(), "CVR matches.");
-        assertEquals("00000000000029ff", iad.getCounters(), "Plaintext/Encrypted counters matches.");        
+        assertEquals("00000000000029ff", iad.getCounters(), "Plaintext/Encrypted counters matches.");
     }
-        
+
     @Test
     public void testVIS15_1() {
         IssuerApplicationData iad = new IssuerApplicationData("06010A03A40000");
         iad.dump(System.out, "");
-        assertEquals(Format.VIS, iad.getFormat());        
+        assertEquals(Format.VIS, iad.getFormat());
         assertEquals("03A40000", iad.getCardVerificationResults(), "CVR matches.");
         assertEquals("0A", iad.getCryptogramVersionNumber(), "CVN matches.");
         assertEquals("01", iad.getDerivationKeyIndex(), "KDI matches.");
     }
-    
+
     @Test
     public void testVIS15_2() {
         IssuerApplicationData iad = new IssuerApplicationData(
-                "1F43010020000000000000000007717300000000000000000000000000000000");
+                "1F22010020000000000000000007717300000000000000000000000000000000");
         iad.dump(System.out, "");
         assertEquals(Format.VIS, iad.getFormat());
         assertEquals("01", iad.getDerivationKeyIndex(), "KDI matches.");
-        assertEquals("43", iad.getCryptogramVersionNumber(), "CVN matches.");
+        assertEquals("22", iad.getCryptogramVersionNumber(), "CVN matches.");
         assertEquals("0020000000", iad.getCardVerificationResults(), "CVR matches.");
         assertEquals("000000000007717300000000000000000000000000000000", iad.getIssuerDiscretionaryData(), "CVN matches.");
     }
-    
+
     @Test
     public void testVIS15_3() {
         String hexIAD = "06010A03A020000F04000000000000000000006232E4F9";
@@ -127,14 +129,46 @@ public class IssuerApplicationDataTest {
         assertEquals("00F04000000000000000000006232E4F9", iad.getIssuerDiscretionaryData(),
                 "Issuer discretionary data matches.");
     }
-        
+
     @Test
     public void testEMVFormatA() {
         IssuerApplicationData iad = new IssuerApplicationData("0FA506A231C0020000000000000000000F110601010000000000000000000000");
         iad.dump(System.out, "");
-        assertEquals(Format.EMV_FORMAT_A, iad.getFormat());        
-        assertEquals("06", iad.getDerivationKeyIndex(), "KDI matches.");        
+        assertEquals(Format.EMV_FORMAT_A, iad.getFormat());
+        assertEquals("06", iad.getDerivationKeyIndex(), "KDI matches.");
         assertEquals("A231C00200", iad.getCardVerificationResults(), "CVR matches.");
         assertEquals("110601010000000000000000000000", iad.getIssuerDiscretionaryData(), "CVN matches.");
-    }       
+    }
+
+    @Test
+    public void testVISA() {
+        CryptogramSpec spec = new IssuerApplicationData("06010A03000000").getCryptogramSpec();
+        assertTrue(spec instanceof VISACryptogram, "Cryptogram Spec should be VISA");
+
+        spec = new IssuerApplicationData("06011203000000").getCryptogramSpec();
+        assertTrue(spec instanceof VISACryptogram, "Cryptogram Spec should be VISA");
+
+        spec = new IssuerApplicationData("1F22010300000000000000000000000000000000000000000000000000000000").getCryptogramSpec();
+        assertTrue(spec instanceof VISACryptogram, "Cryptogram Spec should be VISA");
+    }
+
+    @Test
+    public void testMChip() {
+        CryptogramSpec spec = new IssuerApplicationData("0110608003220000B6A400000000000000FF").getCryptogramSpec();
+        assertTrue(spec instanceof MChipCryptogram, "Cryptogram Spec should be M/Chip");
+
+        spec = new IssuerApplicationData("0114020000044000DAC10000000000000000").getCryptogramSpec();
+        assertTrue(spec instanceof MChipCryptogram, "Cryptogram Spec should be M/Chip");
+
+    }
+
+    @Test
+    public void testCryptogramSpecNotSupported() {
+        assertThrows(Exception.class,
+                () -> new IssuerApplicationData(
+                        "0F0000000000000000000000000000000F000000000000000000000000000000").getCryptogramSpec());
+
+    }
+
+
 }

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/CVN10DataBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/CVN10DataBuilderTest.java
@@ -1,0 +1,43 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.emv.IssuerApplicationData;
+import org.jpos.tlv.TLVList;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Rainer Reyes
+ */
+class CVN10DataBuilderTest {
+    private final CVN10DataBuilder builder = new CVN10DataBuilder();
+
+    @Test
+    void testBuildARQCRequest() {
+
+        // Visa Smart Debit/Credit (VSDC) Contact & Contactless Issuer Implementation Guide - October 2018 - Page 170 H.1 Example 1
+
+
+        TLVList data = new TLVList();
+        data.append(0x9F02, "000000000100");
+        data.append(0x9F03, "000000000000");
+        data.append(0x9F1A, "0840");
+        data.append(0x95, "0000000000");
+        data.append(0x5F2A, "0840");
+        data.append(0x9A, "181231");
+        data.append(0x9C, "01");
+        data.append(0x9F37, "ABCDEF10");
+        data.append(0x82, "1800");
+        data.append(0x9F36, "0002");
+        data.append(0x9f10, "06010A03000000");
+
+        IssuerApplicationData iad = new IssuerApplicationData(data.getString(0x9f10));
+
+        assertEquals(
+                "00000000010000000000000008400000000000084018123101ABCDEF101800000203000000",
+                builder.buildARQCRequest(data, iad)
+        );
+
+
+    }
+}

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/CVN18DataBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/CVN18DataBuilderTest.java
@@ -1,0 +1,43 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.emv.IssuerApplicationData;
+import org.jpos.tlv.TLVList;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Rainer Reyes
+ */
+class CVN18DataBuilderTest {
+    private final CVN18DataBuilder builder = new CVN18DataBuilder();
+
+    @Test
+    void testBuildARQCRequest() {
+
+        // Visa Smart Debit/Credit (VSDC) Contact & Contactless Issuer Implementation Guide - October 2018 - Page 172 H.1 Example 1
+
+
+        TLVList data = new TLVList();
+        data.append(0x9F02, "000000000100");
+        data.append(0x9F03, "000000000000");
+        data.append(0x9F1A, "0840");
+        data.append(0x95, "0000000000");
+        data.append(0x5F2A, "0840");
+        data.append(0x9A, "181231");
+        data.append(0x9C, "01");
+        data.append(0x9F37, "ABCDEF10");
+        data.append(0x82, "1800");
+        data.append(0x9F36, "0001");
+        data.append(0x9f10, "06011203000000");
+
+        IssuerApplicationData iad = new IssuerApplicationData(data.getString(0x9f10));
+
+        assertEquals(
+                "00000000010000000000000008400000000000084018123101ABCDEF101800000106011203000000",
+                builder.buildARQCRequest(data, iad)
+        );
+
+
+    }
+}

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/CVN22DataBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/CVN22DataBuilderTest.java
@@ -1,0 +1,41 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.emv.IssuerApplicationData;
+import org.jpos.tlv.TLVList;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Rainer Reyes
+ */
+class CVN22DataBuilderTest {
+    private final CVN22DataBuilder builder = new CVN22DataBuilder();
+
+    @Test
+    void testBuildARQCRequest() {
+
+        // Visa Smart Debit/Credit (VSDC) Contact & Contactless Issuer Implementation Guide - October 2018 - Page 174 H.1 Example 1
+
+
+        TLVList data = new TLVList();
+        data.append(0x9F02, "000000000100");
+        data.append(0x9F03, "000000000000");
+        data.append(0x9F1A, "0840");
+        data.append(0x95, "0000000000");
+        data.append(0x5F2A, "0840");
+        data.append(0x9A, "181231");
+        data.append(0x9C, "01");
+        data.append(0x9F37, "ABCDEF10");
+        data.append(0x82, "1800");
+        data.append(0x9F36, "0001");
+        data.append(0x9f10, "1F22010300000000000000000000000000000000000000000000000000000000");
+
+        IssuerApplicationData iad = new IssuerApplicationData(data.getString(0x9f10));
+
+        assertEquals(
+                "00000000010000000000000008400000000000084018123101ABCDEF10180000011F22010300000000000000000000000000000000000000000000000000000000",
+                builder.buildARQCRequest(data, iad)
+        );
+    }
+}

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/CVNMCDataBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/CVNMCDataBuilderTest.java
@@ -1,0 +1,42 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.emv.IssuerApplicationData;
+import org.jpos.tlv.TLVList;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Rainer Reyes
+ */
+class CVNMCDataBuilderTest {
+
+    @Test
+    void buildARPCRequest() {
+
+        CVNMCDataBuilder builder = new CVNMCDataBuilder(false);
+
+        TLVList data = new TLVList()
+                .append(0x9f02, "000000010000")
+                .append(0x9f03, "000000001000")
+                .append(0x9f1A, "0840")
+                .append(0x95, "0000001080")
+                .append(0x5f2A, "0840")
+                .append(0x9a, "980704")
+                .append(0x9c, "00")
+                .append(0x9f37, "11111111")
+                .append(0x82, "5800")
+                .append(0x9f36, "3456")
+                .append(0x9f10, "0110608003220000B6A400000000000000FF");
+
+        IssuerApplicationData iad = new IssuerApplicationData(data.getString(0x9f10));
+
+        assertEquals(
+                "000000010000000000001000084000000010800840980704001111111158003456608003220000",
+                builder.buildARQCRequest(data, iad)
+        );
+
+    }
+
+
+}

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/MCHIPCryptogramTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/MCHIPCryptogramTest.java
@@ -1,0 +1,37 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.security.ARPCMethod;
+import org.jpos.security.MKDMethod;
+import org.jpos.security.SKDMethod;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Rainer Reyes
+ */
+class MCHIPCryptogramTest {
+
+    @Test
+    void testNotSupported(){
+        assertThrows(Exception.class,()->new MChipCryptogram("FF"));
+    }
+    
+    @Test
+    void testMChipVersionBit00(){
+        MChipCryptogram spec = new MChipCryptogram("10");
+        assertEquals(spec.getMKDMethod(), MKDMethod.OPTION_A);
+        assertEquals(spec.getSKDMethod(), SKDMethod.MCHIP);
+        assertEquals(spec.getARPCMethod(), ARPCMethod.METHOD_1);
+        assertTrue(spec.getDataBuilder() instanceof CVNMCDataBuilder);
+    }
+
+    @Test
+    void testMChipVersionBit10(){
+        MChipCryptogram spec = new MChipCryptogram("14");
+        assertEquals(spec.getMKDMethod(), MKDMethod.OPTION_A);
+        assertEquals(spec.getSKDMethod(), SKDMethod.EMV_CSKD);
+        assertEquals(spec.getARPCMethod(), ARPCMethod.METHOD_1);
+        assertTrue(spec.getDataBuilder() instanceof CVNMCDataBuilder);
+    }
+}

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/VISACryptogramTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/VISACryptogramTest.java
@@ -1,0 +1,47 @@
+package org.jpos.emv.cryptogram;
+
+import org.jpos.security.ARPCMethod;
+import org.jpos.security.MKDMethod;
+import org.jpos.security.SKDMethod;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Rainer Reyes
+ */
+class VISACryptogramTest {
+
+    @Test
+    void testNotSupported() {
+        assertThrows(Exception.class, () -> new VISACryptogram("99"));
+    }
+
+    @Test
+    void testCVN10() {
+        VISACryptogram spec = new VISACryptogram("0A");
+        assertEquals(spec.getMKDMethod(), MKDMethod.OPTION_A);
+        assertEquals(spec.getSKDMethod(), SKDMethod.VSDC);
+        assertEquals(spec.getARPCMethod(), ARPCMethod.METHOD_1);
+        assertTrue(spec.getDataBuilder() instanceof CVN10DataBuilder);
+    }
+
+    @Test
+    void testCVN18() {
+        VISACryptogram spec = new VISACryptogram("12");
+        assertEquals(spec.getMKDMethod(), MKDMethod.OPTION_A);
+        assertEquals(spec.getSKDMethod(), SKDMethod.EMV_CSKD);
+        assertEquals(spec.getARPCMethod(), ARPCMethod.METHOD_2);
+        assertTrue(spec.getDataBuilder() instanceof CVN18DataBuilder);
+    }
+
+    @Test
+    void testCVN22() {
+        VISACryptogram spec = new VISACryptogram("22");
+        assertEquals(spec.getMKDMethod(), MKDMethod.OPTION_A);
+        assertEquals(spec.getSKDMethod(), SKDMethod.EMV_CSKD);
+        assertEquals(spec.getARPCMethod(), ARPCMethod.METHOD_2);
+        assertTrue(spec.getDataBuilder() instanceof CVN22DataBuilder);
+    }
+
+}


### PR DESCRIPTION
### **Quick summary**
In an online authorization scenario, an ARQC (Authorization ReQuest Cryptogram ) is generated on the card chip, forwarded to the card scheme, and later validated by the Issuer. To perform an adequate validation, the issuer needs to consider:

- different cryptogram algorithm (versions)

- a different collection of data that might be part of the cryptogram

This PR aims to create a set of components that could simplify the process of validating an ARQC and generating the adequate ARPC (Application Response Cryptogram) in a version-agnostic approach.

### **Implementation details**

We are proposing a set of java components that could be able to:

- Validate the cryptogram with a version-agnostic approach.

- Automatically detect the cryptogram version (particularly useful for environment where several cryptogram version might coexist).

- Give flexibility to the set of data elements used for the cryptogram validation.

These requirements could be better appreciated in this sample code:
```java
ISOMsg request = ...;
ISOMsg response = ...;
TLVList tlv = parse(request.get(55));
IssuerApplicationData iad = new IssuerApplicationData(tlv.getString(0x9f10));
CryptogramSpec spc = iad.getCryptogramSpec();
CryptogramDataBuilder dataBuilder = spc.getDataBuilder();

boolean isValid = hsm.validateARQC(spc.getMKDMethod(), spc.getSKDMethod(), f55.getString(0x9f26), ..., dataBuilder.buildARQCRequest(tlv, iad)); 
if (isValid) {
   String arpcRequest = spc.getDefaultARPCRequestData(true);
   String arpc = hsm.generateARPC(spc.getMKDMethod(), spc.getSKDMethod(), f55.getString(0x9f26), ..., arpcRequest);

   TLVList responseTLV = new TLVList();
   responseTLV.put(0x9f10, arpc + arpcRequest);
   response.set(55, serialize(responseTLV));
} else { 
   response.unset(55);
   reseponse.set(39, INVALID_ARQC);
}
```
To cover these requirements, the following changes are added:

- Interfaces are added to generically represent the different cryptogram generation algorithms. Additionally, an interface is created that represents the set of data used by the different algorithms to generate the cryptogram.

- Specification of the application cryptogram generation algorithm used by M/Chip and VISA are added.

- Support to detect the specifications of the cryptogram generation algorithm is added, It is using the format and CVN information contained in IAD.