### PR TITLE
Allow subclass to override prefix and suffix.

### DIFF
--- a/jpos/src/main/java/org/jpos/util/DailyLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/DailyLogListener.java
@@ -71,10 +71,9 @@ public class DailyLogListener extends RotateLogListener{
         maxSize = cfg.getLong("maxsize",DEF_MAXSIZE);
         sleepTime = cfg.getLong("sleeptime", DEF_WIN) * 1000;
 
-        String suffix = cfg.get("suffix", DEF_SUFFIX), prefix = cfg.get("prefix");
-        setSuffix(suffix);
-        setPrefix(prefix);
-        logName = prefix + suffix;
+        setSuffix(cfg.get("suffix", DEF_SUFFIX));
+        setPrefix(cfg.get("prefix"));
+        logName = getPrefix() + getSuffix();
 
 		maxAge = cfg.getLong("maxage", DEF_MAXAGE);
 		if (maxAge > 0) {


### PR DESCRIPTION
As reported by Praveen on the [mailing list](https://groups.google.com/g/jpos-users/c/jfZmYbzsx1M/m/KLW79BvdBAAJ) subclass cannot override the prefix.

This PR allows it to do it.