### PR TITLE
Properly recognize subsequent bytes in TLV fields

### DIFF
--- a/jpos/src/main/java/org/jpos/tlv/TLVClass.java
+++ b/jpos/src/main/java/org/jpos/tlv/TLVClass.java
@@ -1,0 +1,41 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2022 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.tlv;
+
+public enum TLVClass {
+    UNIVERSAL(0),
+    APPLICATION(1 << 6),
+    CONTEXT_SPECIFIC(2 << 6),
+    PRIVATE(3 << 6);
+
+    int value;
+
+    TLVClass(int value) {
+        this.value = value;
+    }
+
+    public static TLVClass valueOf (byte firstByte) {
+        int i = (int) firstByte & 0xC0;
+        for (TLVClass c : values()) {
+            if (c.value == i)
+                return c;
+        }
+        return UNIVERSAL;
+    }
+}

--- a/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVListTest.java
@@ -60,7 +60,7 @@ public class TLVListTest {
 
     static final int TEST_TAG1      = 0x64;
     static final int TEST_TAG2      = 0x46;
-    static final int TEST_TAG3      = 0x1fe8;
+    static final int TEST_TAG3      = 0x1f08;
 
     TLVList instance;
 
@@ -142,10 +142,10 @@ public class TLVListTest {
     @Test
     public void testAppendThreeBytesTag() {
         byte[] expected = ISOUtil.hex2byte("37D47C");
-        instance.append(0xbf5f37, expected);
+        instance.append(0xbf8f37, expected);
         byte[] result = instance.pack();
         assertEquals(7, result.length);
-        assertArrayEquals(ISOUtil.hex2byte("BF5F37"), Arrays.copyOf(result, 3));
+        assertArrayEquals(ISOUtil.hex2byte("BF8F37"), Arrays.copyOf(result, 3));
         assertArrayEquals(expected, Arrays.copyOfRange(result, 4, 7));
     }
 
@@ -426,9 +426,9 @@ public class TLVListTest {
         instance.append(0x0a, new byte[0]);
         instance.append(instance.createTLVMsg(0x0d, null));
         instance.append(0x3f10, new byte[2]);
-        instance.append(0x1f7fa0, new byte[1]);
+        instance.append(0x1f7f, new byte[1]);
         TLVMsg result = instance.index(10);
-        assertEquals(0x1f7fa0, result.getTag());
+        assertEquals(0x1f7f, result.getTag());
     }
 
     @Test
@@ -962,4 +962,13 @@ public class TLVListTest {
         });
     }
 
+    @Test
+    public void testUnpackSubsequentBytes() throws Exception {
+        byte[] buf = ISOUtil.hex2byte("9F816E0100DF3F0101");
+        instance.unpack(buf, 0);
+        System.out.println (ISOUtil.hexString(instance.getValue(0x9f816e)));
+        assertArrayEquals(ISOUtil.hex2byte("00"), instance.getValue(0x9f816e));
+        assertArrayEquals(ISOUtil.hex2byte("01"),instance.getValue(0xDF3F));
+        assertArrayEquals(buf, instance.pack());
+    }
 }

--- a/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
+++ b/jpos/src/test/java/org/jpos/tlv/TLVMsgTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 public class TLVMsgTest {
 
     static final int TEST_TAG1      = 0x64;
-    static final int TEST_TAG3      = 0x1fe8;
+    static final int TEST_TAG3      = 0x1f68;
 
     TLVMsg msg;
     TLVList tl;
@@ -108,7 +108,7 @@ public class TLVMsgTest {
     public void testGetTLVEmptyValue2() {
         byte[] value = new byte[0];
         byte[] result = tl.createTLVMsg(TEST_TAG3, value).getTLV();
-        assertArrayEquals(ISOUtil.hex2byte("1FE800"), result);
+        assertArrayEquals(ISOUtil.hex2byte("1F6800"), result);
     }
 
     @Test


### PR DESCRIPTION
Fixes some tests using made up invalid tags

relates to #410