### PR TITLE
Feature/negate op in environment expressions

### DIFF
--- a/jpos/src/test/resources/org/jpos/core/testenv.yml
+++ b/jpos/src/test/resources/org/jpos/core/testenv.yml
@@ -1,5 +1,17 @@
 test:
   value: "from testenv.yml"
+
+  true_boolean: true
+  false_boolean: false
+  yes_lower: yes          # converted to true by yaml parser
+  no_upper: NO            # converted to false by yaml parser
+
+  annotation:
+    envstring: "from testenv.yml"
+
+  one: UNO
+  two: DOS
+
 ---
 system:
   property:


### PR DESCRIPTION
Add support for environment expressions with a negate/NOT operator, such as `${!server.enabled:false}`

Extensive test cases have been added.

Some observations:
* The operator only makes sense for "booleanish" values. That means,  the property is resolved to `true/false/yes/no`, or their string equivalents (upper/lowercase)).
* All booleanish values, when **negated** are resolved down into `"true"`/`"false"` or `true`/`false` (depending on the retrieval through `Environment.get()` or `SimpleConfiguration#getBoolean()`)
* When using `SimpleConfiguration#getBoolean()` an **undefined** property always resolves as `false` (original behavior).    
Therefore, when **negating an undefined** property,  `getBoolean()` will return true
* When an **undefined** property is used in an expression with a **default**, the default is always honored (i.e.  a `getBoolean()` on `${!__undefined__:true}` will return `true`, and if calling `Environment.get()` directly, it will return the string `"true"`)
* A negate operator will never negate the default value. It's assumed that the intended meaning of a default is to be used **literally** (when the property in question couldn't be resolved)

