### PR TITLE
Feature/negate op in environment expressions

### DIFF
--- a/jpos/src/main/java/org/jpos/core/Environment.java
+++ b/jpos/src/main/java/org/jpos/core/Environment.java
@@ -1,6 +1,6 @@
 /*
  * jPOS Project [http://jpos.org]
- * Copyright (C) 2000-2022 jPOS Software SRL
+ * Copyright (C) 2000-2023 jPOS Software SRL
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -19,7 +19,6 @@
 package org.jpos.core;
 
 import org.jpos.iso.ISOUtil;
-import org.jpos.util.Caller;
 import org.jpos.util.Loggeable;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.scanner.ScannerException;
@@ -37,8 +36,8 @@ public class Environment implements Loggeable {
     private static final String SYSTEM_PREFIX = "sys";
     private static final String ENVIRONMENT_PREFIX = "env";
 
-    private static Pattern valuePattern = Pattern.compile("^(.*)(\\$)([\\w]*)\\{([-\\w.]+)(:(.*?))?\\}(.*)$");
-    // make groups easier to read :-)                       11112222233333333   44444444445566665    7777
+    private static Pattern valuePattern = Pattern.compile("^(.*)(\\$)([\\w]*)\\{([-!\\w.]+)(:(.*?))?\\}(.*)$");
+    // make groups easier to read :-)                       11112222233333333   4444444444455666665    7777
 
     private static Pattern verbPattern = Pattern.compile("^\\$verb\\{([\\w\\W]+)\\}$");
     private static Environment INSTANCE;
@@ -58,6 +57,14 @@ public class Environment implements Loggeable {
             e.printStackTrace();
             throw new RuntimeException(e);
         }
+    }
+
+    protected static Map<String,String> notMap = new HashMap<>();
+    static {
+        notMap.put("false", "true");
+        notMap.put("true",  "false");
+        notMap.put("yes",   "no");
+        notMap.put("no",    "yes");
     }
 
     private Environment() throws IOException {
@@ -127,9 +134,14 @@ public class Environment implements Loggeable {
                 return s;                           // return the whole thing
 
             while (m != null && m.matches()) {
+                boolean negated = false;
                 String previousR = r;
                 String gPrefix = m.group(3);
                 String gValue = m.group(4);
+                if (gValue.startsWith("!")) {
+                    negated = true;
+                    gValue = gValue.substring(1);
+                }
                 gPrefix = gPrefix != null ? gPrefix : "";
                 switch (gPrefix) {
                     case CFG_PREFIX:
@@ -143,19 +155,20 @@ public class Environment implements Loggeable {
                         break;
                     default:
                         if (gPrefix.length() == 0) {
-                            r = System.getenv(gValue); // ENV has priority
+                            r = System.getenv(gValue);                              // ENV has priority
                             r = r == null ? System.getenv(gValue.replace('.', '_').toUpperCase()) : r;
-                            r = r == null ? System.getProperty(gValue) : r; // then System.property
-                            r = r == null ? propRef.get().getProperty(gValue) : r; // then jPOS --environment
+                            r = r == null ? System.getProperty(gValue) : r;         // then System.property
+                            r = r == null ? propRef.get().getProperty(gValue) : r;  // then jPOS --environment
                         } else {
                             return s; // do nothing - unknown prefix
                         }
                 }
 
-                if (r == null) {
-                    String defValue = m.group(6);
+                String defValue = null;
+                if (r == null) {                                // unresolved property
+                    defValue = m.group(6);
                     if (defValue != null)
-                        r = defValue;
+                        r = defValue;                           // use default value from now on
                 }
 
                 if (r != null) {
@@ -165,15 +178,26 @@ public class Environment implements Loggeable {
                             r = p.get(r.substring(l));
                         }
                     }
+
+                    if (negated && r != null &&
+                        defValue == null)                       // we don't want to negate a default literal boolean!
+                    {
+                        String rNorm = r.trim().toLowerCase();
+                        r = notMap.getOrDefault(rNorm, r);      // if not a booleanish string, return unchanged
+                    }
+
                     if (m.group(1) != null) {
                         r = m.group(1) + r;
                     }
                     if (m.group(7) != null)
                         r = r + m.group(7);
+
                     m = valuePattern.matcher(r);
-                }
-                else
+                } else {                // property was undefined/unresolved and no default was provided
+                    if (negated)
+                        r = "true";     // a negated undefined is interpreted as true
                     m = null;
+                }
 
                 if (Objects.equals(r, previousR))
                     break;
@@ -241,14 +265,15 @@ public class Environment implements Loggeable {
 
     @SuppressWarnings("unchecked")
     public static void flat (Properties properties, String prefix, Map<String,Object> c, boolean dereference) {
-        for (Object o : c.entrySet()) {
-            Map.Entry<String,Object> entry = (Map.Entry<String,Object>) o;
+        for (Map.Entry<String,Object> entry : c.entrySet()) {
             String p = prefix == null ? entry.getKey() : (prefix + "." + entry.getKey());
             if (entry.getValue() instanceof Map) {
-                flat(properties, p, (Map) entry.getValue(), dereference);
+                flat(properties, p, (Map<String,Object>)entry.getValue(), dereference);
             } else {
                 Object obj = entry.getValue();
-                properties.put (p, "" + (dereference && obj instanceof String ? Environment.get((String) obj) : entry.getValue()));
+                properties.put (p, (dereference && obj instanceof String ?
+                                    Environment.get((String) obj) :
+                                    entry.getValue().toString()));
             }
         }
     }

--- a/jpos/src/test/java/org/jpos/core/EnvironmentTest.java
+++ b/jpos/src/test/java/org/jpos/core/EnvironmentTest.java
@@ -1,6 +1,6 @@
 /*
  * jPOS Project [http://jpos.org]
- * Copyright (C) 2000-2022 jPOS Software SRL
+ * Copyright (C) 2000-2023 jPOS Software SRL
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -90,4 +91,89 @@ public class EnvironmentTest {
         System.setProperty("loop", "${loop}");
         assertEquals("${loop}", Environment.get("${loop}"));
     }
+
+    @Test
+    public void multiExpr() {
+        assertEquals("the numbers UNO and DOS and NaN",
+                    Environment.get("the numbers ${test.one} and ${test.two} and ${test.three:NaN}"));
+    }
+
+    @Test
+    public void testNegateExprFromEnvironment() {
+        assertEquals("true", Environment.get("${test.true_boolean}"),
+                    "${test.true_boolean} should return \"true\"");
+
+        assertEquals("false", Environment.get("${!test.true_boolean}"),
+                    "${!test.true_boolean} should return \"false\"");
+
+        assertEquals("true", Environment.get("${!test.false_boolean}"),
+                    "${!test.false_boolean} should return \"true\"");
+
+        // In the yaml file the definition is "test.no_upper: NO",
+        // but it's converted to a boolean false by yaml parser.
+        // This is converted into a string "false" by the Environment flattening process.
+        assertEquals("true", Environment.get("${!test.no_upper}"),
+                    "test.no_upper: NO, so ${!test.no_upper} should return \"true\"");
+
+        // The system properties are already strings, soy "YES" is maintained as is
+        System.setProperty("enabled.value", "YES");
+        assertEquals("no", Environment.get("${!enabled.value}"),
+                    "enabled.value=\"YES\", so ${!enabled.value} should return \"no\"");
+
+        assertEquals("DOS", Environment.get("${!test.two}"),
+                    "${!test.two} should return DOS, since negate operator is ignored for non-boolean strings");
+    }
+
+    @Test
+    public void testNegateExprFromSimpleConfiguration() {
+        Properties props = new Properties();
+        props.put("literal-true", "true");
+        props.put("literal-NO",   "NO");
+
+        // In the yaml file the definition is "test.two: DOS",
+        props.put(    "expr-test-two",              "${test.two}");                    // must return false, since getBoolean is false for non-booleanish values
+        props.put("neg-expr-test-two",              "${!test.two}");                   // same as above, the negation op has no effect on non-booleanish values
+
+        props.put(    "expr-test-true-no-def",      "${test.true_boolean}");
+        props.put(    "expr-test-true-def",         "${test.true_boolean:false}");      // must return true, ignoring default
+
+        props.put(    "expr-test-no_upper-no-def",  "${test.no_upper}");
+        props.put("neg-expr-test-false-def",        "${!test.false_boolean:false}");    // must return true, ignoring default
+
+        // unresolved properties (they aren't defined anywhere)
+        props.put(    "undefined-no-def",  "${__undefined__}");
+        props.put(    "undefined-def",     "${__undefined__:true}");
+        props.put("neg-undefined-no-def",  "${!__undefined__}");
+        props.put("neg-undefined-def",     "${!__undefined__:true}");
+
+        SimpleConfiguration conf = new SimpleConfiguration(props);
+
+
+        assertTrue(conf.getBoolean("literal-true"), "literal-true");
+        assertFalse(conf.getBoolean("literal-NO"),  "literal-NO");
+
+        assertFalse(conf.getBoolean(    "expr-test-two"),        "expr-test-two: ${test.two} must return \"false\" for getBoolean");
+        assertFalse(conf.getBoolean("neg-expr-test-two"),    "neg-expr-test-two: ${!test.two} must return \"false\" for getBoolean");
+
+        assertTrue(conf.getBoolean("expr-test-true-no-def"),    "expr-test-true-no-def");
+        assertTrue(conf.getBoolean("expr-test-true-def"),       "expr-test-true-def must be true, ignoring default");
+
+
+        assertFalse(conf.getBoolean("expr-test-no_upper-no-def"),
+                "expr-test-no_upper-no-def");
+        assertTrue(conf.getBoolean("neg-expr-test-false-def"),
+                "neg-expr-test-false-def: ${!test.false_boolean:false} must be true, ignoring default");
+
+
+        assertFalse(conf.getBoolean("undefined-no-def"),
+                "undefined-no-def must be false, since it can't resolve");
+        assertTrue(conf.getBoolean("undefined-def"),
+                "undefined-def must be true, since the default is true and must be honored");
+
+        assertTrue(conf.getBoolean("neg-undefined-no-def"),
+            "neg-undefined-no-def: ${!__undefined__} must be true, since it's the opposite of undefined");
+        assertTrue(conf.getBoolean("neg-undefined-def"),
+            "neg-undefined-def: ${!__undefined__:true} must be true, since the default is true and must be honored");
+    }
+
 }

--- a/jpos/src/test/resources/org/jpos/core/testenv.yml
+++ b/jpos/src/test/resources/org/jpos/core/testenv.yml
@@ -1,5 +1,17 @@
 test:
   value: "from testenv.yml"
+
+  true_boolean: true
+  false_boolean: false
+  yes_lower: yes          # converted to true by yaml parser
+  no_upper: NO            # converted to false by yaml parser
+
+  annotation:
+    envstring: "from testenv.yml"
+
+  one: UNO
+  two: DOS
+
 ---
 system:
   property:


### PR DESCRIPTION
(this is equivalent to PR #518 done against current `master`)

Add support for environment expressions with a negate/NOT operator, such as `${!server.enabled:false}`

Extensive test cases have been added.

Some observations:
* The operator only makes sense for "booleanish" values. That means,  the property is resolved to `true/false/yes/no`, or their string equivalents (upper/lowercase)).
* All booleanish values, when **negated** are resolved down into `"true"`/`"false"` or `true`/`false` (depending on the retrieval through `Environment.get()` or `SimpleConfiguration#getBoolean()`)
* When using `SimpleConfiguration#getBoolean()` an **undefined** property always resolves as `false` (original behavior).    
Therefore, when **negating an undefined** property,  `getBoolean()` will return true
* When an **undefined** property is used in an expression with a **default**, the default is always honored (i.e.  a `getBoolean()` on `${!__undefined__:true}` will return `true`, and if calling `Environment.get()` directly, it will return the string `"true"`)
* A negate operator will never negate the default value. It's assumed that the intended meaning of a default is to be used **literally** (when the property in question couldn't be resolved)

