### PR TITLE
Basic support for string array auto-configuration.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -11,7 +11,7 @@ Hani S. Kirollos <h.samuel-at-egyptianbanks.net>
 Jonathan O'Connor <Jonathan.O'Connor-at-xcom.de>
 Cameron Young <cn_young-at-attcanada.ca>
 Alireza Taherkordi <taherkordy-at-dpi2.dpi.net.ir>
-Alcarraz, Andrés <alcarraz-at-jpos.org>
+Alcarraz, Andrés <alcarraz-at-gmail.com>
 Alwyn Schoeman <alwyn.schoeman-at-gmail.com>
 Carlos Quiroz <carlos.quiroz-at-welho.com>
 Kris Leite <yahoo-at-imcsoftware.com>

--- a/doc/src/asciidoc/ch02/jposiso.adoc
+++ b/doc/src/asciidoc/ch02/jposiso.adoc
@@ -670,7 +670,7 @@ Let's have a look at a very simple filter, DelayFilter:
 [source,java]
 ----
 
-    public class DelayFilter implements ISOFilter, ReConfigurable {
+    public class DelayFilter implements ISOFilter, Configurable {
         long delay;
         public DelayFilter() {
             super();

--- a/jpos/src/main/java/org/jpos/q2/QFactory.java
+++ b/jpos/src/main/java/org/jpos/q2/QFactory.java
@@ -463,6 +463,8 @@ public class QFactory {
                             field.set(obj, cfg.getLong(config.value()));
                         else if (c.isAssignableFrom(boolean.class) || c.isAssignableFrom(Boolean.class))
                             field.set(obj, cfg.getBoolean(config.value()));
+                        else if (c.isArray() && c.getComponentType().isAssignableFrom(String.class))
+                            field.set(obj, cfg.getAll(config.value()));
                     }
                 }
             }

--- a/jpos/src/test/java/org/jpos/core/ConfigAnnotationTest.java
+++ b/jpos/src/test/java/org/jpos/core/ConfigAnnotationTest.java
@@ -18,10 +18,14 @@
 
 package org.jpos.core;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.jpos.core.annotation.Config;
 import org.jpos.q2.QFactory;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,11 +38,13 @@ public class ConfigAnnotationTest {
         cfg.put("mylong", "10000");
         cfg.put("myint", "1000");
         cfg.put("myboolean", "yes");
+        cfg.put("myarray", new String[] { "one", "two"});
         QFactory.autoconfigure(bean, cfg);
         assertEquals("My String", bean.getMystring());
         assertEquals(1000, bean.getMyint());
         assertEquals(10000L, bean.getMylong());
         assertTrue(bean.isMyboolean());
+        assertThat("myarray should have the configured values", bean.getMyarray(), is(new String[]{"one", "two"}));
     }
 
     @Test
@@ -50,12 +56,14 @@ public class ConfigAnnotationTest {
         cfg.put("myint", "1000");
         cfg.put("myboolean", "yes");
         cfg.put("mychildstring", "My Child String");
+        cfg.put("myarray", new String[] { "one", "two"});
         QFactory.autoconfigure(bean, cfg);
         assertEquals("My String", bean.getMystring());
         assertEquals(1000, bean.getMyint());
         assertEquals(10000L, bean.getMylong());
         assertEquals("My Child String", bean.getChildString());
         assertTrue(bean.isMyboolean());
+        assertThat("myarray should have the configured values", bean.getMyarray(), is(new String[]{"one", "two"}));
     }
 
 
@@ -71,7 +79,10 @@ public class ConfigAnnotationTest {
 
         @Config("myboolean")
         private boolean myboolean;
-
+        
+        @Config("myarray")
+        private String[] myarray;
+        
         public String getMystring() {
             return mystring;
         }
@@ -86,6 +97,9 @@ public class ConfigAnnotationTest {
 
         public boolean isMyboolean() {return myboolean; }
 
+        public String[] getMyarray() {
+            return myarray;
+        }
 
         @Override
         public String toString() {
@@ -93,6 +107,7 @@ public class ConfigAnnotationTest {
               "mystring='" + mystring + '\'' +
               ", myint=" + myint +
               ", mylong=" + mylong +
+              ", myarray=[" + String.join(", ", myarray)+"]" + 
               '}';
         }
     }


### PR DESCRIPTION
Proposal for a basic support for autoconfiguration of string array fields. 

More complex logic could be added to support different ways of defining string arrays, or even collections of other types, in a single property, if desired, but this could do for now.

An unrelated fix for the doc is also included, that may not deserve a specific PR, and updating my mail address also.

If preferred, I can break this PR in 2 or 3.