### PR TITLE
Expand javadoc for ThroughputControl.

### DIFF
--- a/jpos/src/main/java/org/jpos/util/ThroughputControl.java
+++ b/jpos/src/main/java/org/jpos/util/ThroughputControl.java
@@ -21,9 +21,23 @@ package org.jpos.util;
 import java.time.Instant;
 
 /**
- * ThroughputControl can be used to limit the throughput 
+ * ThroughputControl limits the throughput 
  * of a process to a maximum number of transactions in 
  * a given period of time.
+ *
+ * As an example, the following code will cap the transaction count
+ * at 15 every second (a.k.a. 15 TPS).
+ *
+ * <pre>
+ *
+ *  ThroughputControl throughput = new ThroughputControl(15, 1000);
+ *
+ *  while (isConditionTrue()) {
+ *      throughput.control();
+ *      // Do stuff.
+ *  }
+ *
+ * </pre>
  */
 public class ThroughputControl {
     private int[] period;

--- a/jpos/src/main/java/org/jpos/util/ThroughputControl.java
+++ b/jpos/src/main/java/org/jpos/util/ThroughputControl.java
@@ -22,7 +22,7 @@ import java.time.Instant;
 
 /**
  * ThroughputControl can be used to limit the throughput 
- * of a system to a maximum number of transactions in 
+ * of a process to a maximum number of transactions in 
  * a given period of time.
  */
 public class ThroughputControl {
@@ -33,16 +33,16 @@ public class ThroughputControl {
     private long[] sleep;
 
     /**
-     * @param maxTransactions ditto
-     * @param periodInMillis ditto
+     * @param maxTransactions Transaction count threshold.
+     * @param periodInMillis Time window, expressed in milliseconds.
      */
     public ThroughputControl (int maxTransactions, int periodInMillis) {
         this (new int[] { maxTransactions },
               new int[] { periodInMillis });
     }
     /**
-     * @param maxTransactions ditto
-     * @param periodInMillis ditto
+     * @param maxTransactions An array with transaction count thresholds.
+     * @param periodInMillis An array of time windows, expressed in milliseconds.
      */
     public ThroughputControl (int[] maxTransactions, int[] periodInMillis) {
         super();
@@ -61,10 +61,11 @@ public class ThroughputControl {
     }
 
     /**
-     * control should be called on every transaction.
-     * it may sleep for a while in order to control the system throughput
+     * This method should be called on every transaction.
+     * It will pause the thread for a while when the threshold is reached 
+     * in order to control the process throughput.
      * 
-     * @return aprox sleep time or zero if no sleep
+     * @return Returns sleep time in milliseconds when threshold is reached. Otherwise, zero.
      */
     public long control() {
         boolean delayed = false;


### PR DESCRIPTION
This PR expands the in-line documentation for `ThroughputControl` by describing the constructor's params and providing a usage example.