### PR TITLE
Add constructors to parse Key Serial Numbers.

### DIFF
--- a/jpos/src/main/java/org/jpos/security/KeySerialNumber.java
+++ b/jpos/src/main/java/org/jpos/security/KeySerialNumber.java
@@ -18,6 +18,7 @@
 
 package  org.jpos.security;
 
+import org.jpos.iso.ISOUtil;
 import org.jpos.util.Loggeable;
 
 import java.io.PrintStream;
@@ -66,6 +67,34 @@ public class KeySerialNumber
         setBaseKeyID(baseKeyID);
         setDeviceID(deviceID);
         setTransactionCounter(transactionCounter);
+    }
+
+    /**
+     * Constructs a key serial number object from its hexadecimal representation.
+     * @param hexKSN hexadecimal representation of the KSN.
+     * @param idLength length of the base key ID.
+     * @param deviceLength length of the device ID.
+     * @param counterLength length of the transaction counter.
+     */
+    public KeySerialNumber(String hexKSN, int idLength, int deviceLength, int counterLength) {
+        if (hexKSN == null || hexKSN.trim().length() == 0)
+            throw new IllegalArgumentException("KSN cannot be empty.");
+        if (idLength + deviceLength + counterLength > hexKSN.length())
+            throw new IllegalArgumentException("Length spec doesn't match KSN.");
+        setBaseKeyID(hexKSN.substring(0, idLength));
+        setDeviceID(hexKSN.substring(idLength, idLength + deviceLength));
+        setTransactionCounter(hexKSN.substring(idLength + deviceLength, idLength + deviceLength + counterLength));
+    }
+
+    /**
+     * Constructs a key serial number object from its binary representation.
+     * @param binKSN binary representation of the KSN.
+     * @param idLength length of the base key ID.
+     * @param deviceLength length of the device ID.
+     * @param counterLength length of the transaction counter.
+     */
+    public KeySerialNumber(byte[] binKSN, int idLength, int deviceLength, int counterLength) {
+        this(ISOUtil.byte2hex(binKSN).toUpperCase(), idLength, deviceLength, counterLength);
     }
 
     /**

--- a/jpos/src/test/java/org/jpos/security/KeySerialNumberTest.java
+++ b/jpos/src/test/java/org/jpos/security/KeySerialNumberTest.java
@@ -22,12 +22,14 @@ import static org.apache.commons.lang3.JavaVersion.JAVA_14;
 import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
+import org.jpos.iso.ISOUtil;
 import org.junit.jupiter.api.Test;
 
 public class KeySerialNumberTest {
@@ -122,5 +124,45 @@ public class KeySerialNumberTest {
         keySerialNumber.setTransactionCounter("testKeySerialNumberTransactionCounter1");
         assertEquals("testKeySerialNumberTransactionCounter1",
                 keySerialNumber.transactionCounter, "keySerialNumber.transactionCounter");
+    }
+
+    @Test
+    public void testBinaryConstructor() {
+        byte[] ksnBin = ISOUtil.hex2byte("9876543210E00008");
+        KeySerialNumber ksn = new KeySerialNumber(ksnBin, 6, 5, 5);
+        assertEquals("987654", ksn.getBaseKeyID());
+        assertEquals("3210E", ksn.getDeviceID());
+        assertEquals("00008", ksn.getTransactionCounter());
+    }
+
+    @Test
+    public void testHexConstructor() {
+        String ksnHex = "9876543210E00008";
+        KeySerialNumber ksn = new KeySerialNumber(ksnHex, 6, 5, 5);
+        assertEquals("987654", ksn.getBaseKeyID());
+        assertEquals("3210E", ksn.getDeviceID());
+        assertEquals("00008", ksn.getTransactionCounter());
+    }
+
+
+    @Test
+    public void testHexConstructorWrongLength() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new KeySerialNumber("9876543210E008", 6, 5, 5);
+        });
+    }
+
+    @Test
+    public void testHexConstructorNullKSN() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new KeySerialNumber((String) null, 6, 5, 5);
+        });
+    }
+
+    @Test
+    public void testHexConstructorEmptyKSN() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new KeySerialNumber("                ", 6, 5, 5);
+        });
     }
 }

--- a/jpos/src/test/java/org/jpos/security/KeySerialNumberTest.java
+++ b/jpos/src/test/java/org/jpos/security/KeySerialNumberTest.java
@@ -144,7 +144,6 @@ public class KeySerialNumberTest {
         assertEquals("00008", ksn.getTransactionCounter());
     }
 
-
     @Test
     public void testHexConstructorWrongLength() {
         assertThrows(IllegalArgumentException.class, () -> {


### PR DESCRIPTION
This PR extends `KeySerialNumber` by adding two new constructors that build an instance from its hexadecimal or binary representation.

Example:

```java
String ksnHex = "9876543210E00008";
KeySerialNumber ksn = new KeySerialNumber(ksnHex, 6, 5, 5);
```