### PR TITLE
Changes ISOServer channels map implementation to ConcurrentHashMap

### DIFF
--- a/jpos/src/test/java/org/jpos/iso/ISOServerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/ISOServerTest.java
@@ -25,7 +25,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.jpos.util.NameRegistrar;
+import org.jpos.util.ThreadPool;
 import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.ServerSocket;
 
 public class ISOServerTest {
 
@@ -51,5 +57,17 @@ public class ISOServerTest {
         } catch (NameRegistrar.NotFoundException ex) {
             assertEquals("server.testISOServerName", ex.getMessage(), "ex.getMessage()");
         }
+    }
+
+
+    @Test
+    public void testDump() throws Throwable {
+        ISOServer server = new ISOServer(80, new BaseChannel() {}, new ThreadPool());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(os);
+
+        server.dump(ps, "");
+
+        assertEquals("connected=0, rx=0, tx=0, last=0\n", os.toString("UTF8"));
     }
 }


### PR DESCRIPTION
Should fix #508 by using a ConcurrentHashMap. Also refactored dump a bit. Functionally it is exactly the same.

About the issue ConcurrentHashMap has weak consistency guarantees but will handle mid iteration insertions transparently. Could still potentially dump inconsistent data if an insertion happens mid iteration as in there's no guarantee the iterator is actually updated with new entries but it's a tradeoff.

The alternative would be to lock any access to the map but seems overkill for a SystemMonitor dump and would probably perform worse as we would have to lock on get() which ConcurrentHashMap tries to avoid. Collections.synchronizedMap() does not solve this issue either.

On another note, to be honest I couldn't find where exactly someone might put a channel mid iteration. ISOServer seems to only support a single channel at a time.
