### PR TITLE
Better handling of multi-level nested isomsgs in non-bitmapped tagged sequences

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOMsgFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOMsgFieldPackager.java
@@ -18,10 +18,8 @@
 
 package org.jpos.iso;
 
-
 import java.io.IOException;
 import java.io.InputStream;
-
 
 /**
  * ISOMsgFieldPackager is a packager able to pack compound ISOMsgs
@@ -57,12 +55,27 @@ public class ISOMsgFieldPackager extends ISOFieldPackager {
         if (c instanceof ISOMsg) {
             ISOMsg m = (ISOMsg) c;
             m.recalcBitMap();
-            ISOBinaryField f = new ISOBinaryField(0, msgPackager.pack(m));
-            if(fieldPackager instanceof TaggedFieldPackagerBase &&
-               msgPackager   instanceof ISOSubFieldPackager) {
+
+            // honor ISOMsg's current position in hierarchy
+            int mfn = m.getFieldNumber() >= 0 ? m.getFieldNumber() : 0;
+            ISOBinaryField f = new ISOBinaryField(mfn, msgPackager.pack(m));
+
+            if (msgPackager instanceof ISOSubFieldPackager) {
                 ISOSubFieldPackager sfp = (ISOSubFieldPackager) msgPackager;
-                f.setFieldNumber(sfp.getFieldNumber());
+
+                // If this ISOMsg needs to be packed as part of some non-bitmapped tagged format
+                // (not all types covered here), or if the ISOSubFieldPackager has been configured
+                // with a specific field number, overriding the one in the ISOMsg.
+                if (fieldPackager instanceof TaggedFieldPackagerBase    ||
+                    fieldPackager instanceof TaggedFieldPackager        ||
+                    fieldPackager instanceof ISOTagStringFieldPackager  ||
+                    fieldPackager instanceof ISOTagBinaryFieldPackager  ||
+                    sfp.getFieldNumber() > -1)
+                {
+                    f.setFieldNumber(sfp.getFieldNumber());
+                }
             }
+
             return fieldPackager.pack(f);
         }
         return fieldPackager.pack(c);
@@ -97,7 +110,7 @@ public class ISOMsgFieldPackager extends ISOFieldPackager {
      * @throws java.io.IOException
      */
     @Override
-    public void unpack (ISOComponent c, InputStream in) 
+    public void unpack (ISOComponent c, InputStream in)
         throws IOException, ISOException
     {
         ISOBinaryField f = new ISOBinaryField(0);

--- a/jpos/src/main/java/org/jpos/iso/packager/EuroSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/EuroSubFieldPackager.java
@@ -22,6 +22,7 @@ import org.jpos.iso.*;
 import org.jpos.util.LogEvent;
 import org.jpos.util.LogSource;
 import org.jpos.util.Logger;
+import org.xml.sax.Attributes;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Map;
@@ -40,9 +41,25 @@ import java.util.Set;
  * such as field 48.
  */
 @SuppressWarnings("unchecked")
-public class EuroSubFieldPackager extends ISOBasePackager
+public class EuroSubFieldPackager extends ISOBasePackager implements GenericPackagerParams, ISOSubFieldPackager
 {
     protected static Prefixer tagPrefixer = AsciiPrefixer.LL;
+
+    // fieldId is read from "id" XML attribute (because this class is GenericPackagerParams).
+    // Useful for cases where we embed an EuroSubFieldPackager inside a non-bitmapped
+    // field (such as another EuroSubFieldPackager), and the wrapping packager needs to know
+    // this object's field position (i.e., outer tag)
+    protected Integer fieldId = -1;
+
+    @Override
+    public void setGenericPackagerParams(Attributes atts) {
+        fieldId = Integer.parseInt(atts.getValue("id"));
+    }
+
+    @Override
+    public int getFieldNumber() {
+        return fieldId;
+    }
 
     /**
      * Always return false


### PR DESCRIPTION
Fixing a problem when packing **multi-level** nested `ISOMsg`s that should be serialized as a tagged sequence (e.g., TLV) inside another non-bitmapped tagged sequence.

An example could be a tagged sequence of `EuroSubFieldPackager` within an outer `EuroSubFieldPackager`.
In memory, they may be represented as nested `ISOMsg`s, but when serialized, the inner `EuroSubFieldPackager` will now use its declared `fieldNumber` as the TAG part of the value  (falling back to the `ISOMsg`'s own `fieldNumber`).

This problem was partially solved for the `TaggedFieldPackagerBase`  case, but this fix generalizes de solution somewhat more.