### PR TITLE
Only reply keep-alive if expecting it

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/BaseChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/BaseChannel.java
@@ -662,6 +662,11 @@ public abstract class BaseChannel extends Observable
         }
 
     }
+
+    public boolean isExpectKeepAlive() {
+        return expectKeepAlive;
+    }
+
     protected boolean isRejected(byte[] b) {
         // VAP Header support - see VAPChannel
         return false;

--- a/jpos/src/main/java/org/jpos/iso/channel/ASCIIChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/ASCIIChannel.java
@@ -76,7 +76,7 @@ public class ASCIIChannel extends BaseChannel {
      * @exception IOException
      * @see ISOPackager
      */
-    public ASCIIChannel (ISOPackager p, ServerSocket serverSocket) 
+    public ASCIIChannel (ISOPackager p, ServerSocket serverSocket)
         throws IOException
     {
         super(p, serverSocket);
@@ -110,11 +110,15 @@ public class ASCIIChannel extends BaseChannel {
         while (l == 0) {
             serverIn.readFully(b, 0, lengthDigits);
             try {
-                if ((l=Integer.parseInt(new String(b))) == 0) {
-                    serverOut.write(b);
-                    serverOut.flush();
+                if ((l=Integer.parseInt(new String(b))) == 0 &&
+                    isExpectKeepAlive()) {
+
+                    synchronized (serverOutLock) {
+                        serverOut.write(b);
+                        serverOut.flush();
+                    }
                 }
-            } catch (NumberFormatException e) { 
+            } catch (NumberFormatException e) {
                 throw new ISOException ("Invalid message length "+new String(b));
             }
         }


### PR DESCRIPTION
- Adds an `isExpectKeepAlive()` getter to `BaseChannel`

- `ASCIIChannel` fixes two things:
  1. It protects the replying of the zero-length keep alive with a `syncrhonized(serverOutLock)` to avoid mixing bytes in between a real message.
  2. It only replies the keep alive if we are expecting it (usually the client `ChannelAdaptor` **sends** the zero-length keep-alive, and the `QServer` side **expects** it).  This avoids entering into a "ping-point" state where both sides were sending and replying non-stop.

This was making the native zero-length keep alive feature unusable with `ASCIIChannel`, but now it works as expected.

**ATTN!**  Both problems still persist in many of the channel classes, which could be fixed if this PR is considered good.  (At least the synch problem should be fixed, as it doesn't have any bad side effects)