### PR TITLE
QueryHost: timeout override through ctx entry

### DIFF
--- a/jpos/src/main/java/org/jpos/transaction/participant/QueryHost.java
+++ b/jpos/src/main/java/org/jpos/transaction/participant/QueryHost.java
@@ -34,12 +34,14 @@ import org.jpos.util.NameRegistrar;
 import org.jpos.transaction.Context;
 
 public class QueryHost implements TransactionParticipant, ISOResponseListener, Configurable {
+    public static final String TIMEOUT_NAME = "QUERYHOST_TIMEOUT";
+
     private static final long DEFAULT_TIMEOUT = 30000L;
     private static final long DEFAULT_WAIT_TIMEOUT = 1000L;
 
     private long timeout;
     private long waitTimeout;
-    private String timeoutName = "QUERYHOST_TIMEOUT";         // default ctx name
+    private String timeoutName = TIMEOUT_NAME;                  // default ctx name
     private String requestName;
     private String responseName;
     private String destination;

--- a/jpos/src/main/java/org/jpos/transaction/participant/QueryHost.java
+++ b/jpos/src/main/java/org/jpos/transaction/participant/QueryHost.java
@@ -33,7 +33,6 @@ import org.jpos.util.Chronometer;
 import org.jpos.util.NameRegistrar;
 import org.jpos.transaction.Context;
 
-@SuppressWarnings("unused")
 public class QueryHost implements TransactionParticipant, ISOResponseListener, Configurable {
     private static final long DEFAULT_TIMEOUT = 30000L;
     private static final long DEFAULT_WAIT_TIMEOUT = 1000L;
@@ -45,7 +44,6 @@ public class QueryHost implements TransactionParticipant, ISOResponseListener, C
     private String destination;
     private boolean continuations;
     private Configuration cfg;
-    private String request;
     private boolean ignoreUnreachable;
     private boolean checkConnected= true;
 

--- a/jpos/src/test/java/org/jpos/transaction/participant/QueryHostTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/participant/QueryHostTest.java
@@ -100,6 +100,34 @@ public class QueryHostTest implements TransactionConstants, MUX {
         assertTrue (ctx.getResult().failure().getIrc() == CMF.MISCONFIGURED_ENDPOINT);
     }
 
+
+    @Test
+    public void testResolveTimeout_NoCtxEntry() throws Exception {
+        Context ctx = new Context();
+        cfg.put("timeout", "5678");
+        queryHost.setConfiguration(cfg);
+        assertEquals(5678, queryHost.resolveTimeout(ctx));
+    }
+
+    @Test
+    public void testResolveTimeout_DefaultCtxName() throws Exception {
+        Context ctx = new Context();
+        ctx.put("QUERYHOST_TIMEOUT", 8877);     // this one should take priority...
+        cfg.put("timeout", "5678");             // ...over this one
+        queryHost.setConfiguration(cfg);
+        assertEquals(8877, queryHost.resolveTimeout(ctx));
+    }
+
+    @Test
+    public void testResolveTimeout_CustomCtxName() throws Exception {
+        Context ctx = new Context();
+        ctx.put("MY_TIMEOUT", 8877);            // this one should take priority...
+        cfg.put("timeout", "5678");             // ...over this one
+        cfg.put("timeout-name", "MY_TIMEOUT");
+        queryHost.setConfiguration(cfg);
+        assertEquals(8877, queryHost.resolveTimeout(ctx));
+    }
+
     @Override
     public ISOMsg request(ISOMsg m, long timeout) throws ISOException {
         ISOMsg r = (ISOMsg) m.clone();


### PR DESCRIPTION
#### WHAT 
Add a timeout override to `QueryHost` by means of context entry.
A use case of this feature could be to dynamically change (in a previous participant) the timeout, depending on destination mux.


#### USAGE

If the ctx contains an entry called `QUERYHOST_TIMEOUT` (for example, computed by a previous participant), it will take priority over the static `timeout` (or the internal default if `timeout` hasn't been configured).

ATTN: The ctx value should be castable or parsable as a `long`

The default entry name `QUERYHOST_TIMEOUT` can be configured to some other name:
```xml
<participant class="org.jpos.transaction.participant.QueryHost">
    <!-- If MY_TIMEOUT doesn't exist in the context, the static 12000 will be used -->
    <property name="timeout-name" value="MY_TIMEOUT" />
    <property name="timeout" value="12000" />
</participant>
```

#### COMPATIBILITY

Some test cases have been added to `QueryHostTest`.
This new feature shouldn't break any existent code, as it only works if the ctx entry exists, and fallbacks to older behaviour if it doesn't.
The only situation could be an existing system that **already uses a ctx entry `QUERYHOST_TIMEOUT`** for some other purpose. In this case, it can be easily fixed by using a different `timeout-name`.