### PR TITLE
Enable environment property replacement anywhere

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/Q2.java
+++ b/jpos/src/main/java/org/jpos/q2/Q2.java
@@ -49,7 +49,6 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import java.io.*;
@@ -526,9 +525,10 @@ public class Q2 implements FileFilter, Runnable {
                 }
             }
             if (QFactory.isEnabled(rootElement)) {
-                if (evt != null)
+                if (evt != null) {
                     evt.addMessage("deploy: " + f.getCanonicalPath());
-                Object obj = factory.instantiate (this, rootElement);
+                }
+                Object obj = factory.instantiate (this, factory.expandEnvProperties(rootElement));
                 qentry.setObject (obj);
 
                 ObjectInstance instance = factory.createQBean (

--- a/jpos/src/main/java/org/jpos/q2/QFactory.java
+++ b/jpos/src/main/java/org/jpos/q2/QFactory.java
@@ -499,8 +499,7 @@ public class QFactory {
         for (Content child : e.getContent()) {
             if (child instanceof Element) {
                 replaceEnvProperties((Element) child, env);
-            } else if (child instanceof Text) {
-                Text text = (Text) child;
+            } else if (child instanceof Text text) {
                 String textValue = text.getText();
                 text.setText(env.getProperty(textValue, textValue));
             }

--- a/jpos/src/main/java/org/jpos/q2/QFactory.java
+++ b/jpos/src/main/java/org/jpos/q2/QFactory.java
@@ -65,8 +65,6 @@ public class QFactory {
                MBeanException,
                InstanceNotFoundException
     {
-        replaceEnvProperties(e);
-
         String clazz  = getAttributeValue (e, "class");
         if (clazz == null) {
             try {
@@ -486,11 +484,24 @@ public class QFactory {
             cc = cc.getSuperclass();
         } while (!cc.equals(Object.class));
     }
-    
-    public static void replaceEnvProperties(Element e) {
-       replaceEnvProperties(e, Environment.getEnvironment());
+
+    /**
+     * Decorates an {@link Element} by replacing its attributes, and content {@link Environment} properties references.
+     * @param e The element being decorated.
+     * @return The modified element, it is modified in place, but it is returned to ease method chaining or call composition.
+     */
+    public static Element expandEnvProperties(Element e) {
+       expandEnvProperties(e, Environment.getEnvironment());
+       return e;
     }
-    public static void replaceEnvProperties(Element e, Environment env) {
+
+    /**
+     * Recursively replaces {@link Environment} properties in an element's attributes, its content and its children.
+     * Properties are replaced in place.
+     * @param e The element in which properties are being replaced.
+     * @param env The {@link Environment}'s singleton instance.
+     */
+    private static void expandEnvProperties(Element e, Environment env) {
         if (Boolean.parseBoolean(e.getAttributeValue("verbatim"))) return;
         for (org.jdom2.Attribute attr : e.getAttributes()) {
             String value = attr.getValue();
@@ -498,7 +509,7 @@ public class QFactory {
         }
         for (Content child : e.getContent()) {
             if (child instanceof Element) {
-                replaceEnvProperties((Element) child, env);
+                expandEnvProperties((Element) child, env);
             } else if (child instanceof Text text) {
                 String textValue = text.getText();
                 text.setText(env.getProperty(textValue, textValue));

--- a/jpos/src/main/java/org/jpos/q2/QFactory.java
+++ b/jpos/src/main/java/org/jpos/q2/QFactory.java
@@ -19,7 +19,9 @@
 package org.jpos.q2;
 
 
+import org.jdom2.Content;
 import org.jdom2.Element;
+import org.jdom2.Text;
 import org.jpos.core.*;
 import org.jpos.core.annotation.Config;
 import org.jpos.q2.qbean.QConfig;
@@ -63,6 +65,8 @@ public class QFactory {
                MBeanException,
                InstanceNotFoundException
     {
+        replaceEnvProperties(e);
+
         String clazz  = getAttributeValue (e, "class");
         if (clazz == null) {
             try {
@@ -482,4 +486,25 @@ public class QFactory {
             cc = cc.getSuperclass();
         } while (!cc.equals(Object.class));
     }
+    
+    public static void replaceEnvProperties(Element e) {
+       replaceEnvProperties(e, Environment.getEnvironment());
+    }
+    public static void replaceEnvProperties(Element e, Environment env) {
+        if (Boolean.parseBoolean(e.getAttributeValue("verbatim"))) return;
+        for (org.jdom2.Attribute attr : e.getAttributes()) {
+            String value = attr.getValue();
+            attr.setValue(env.getProperty(value, value));
+        }
+        for (Content child : e.getContent()) {
+            if (child instanceof Element) {
+                replaceEnvProperties((Element) child, env);
+            } else if (child instanceof Text) {
+                Text text = (Text) child;
+                String textValue = text.getText();
+                text.setText(env.getProperty(textValue, textValue));
+            }
+        }
+    }
+            
 }

--- a/jpos/src/test/java/org/jpos/q2/QFactory2Test.java
+++ b/jpos/src/test/java/org/jpos/q2/QFactory2Test.java
@@ -34,9 +34,7 @@ import javax.management.ObjectName;
 import javax.management.ReflectionException;
 
 import org.jdom2.Attribute;
-import org.jdom2.AttributeType;
 import org.jdom2.Element;
-import org.jdom2.Namespace;
 import org.jdom2.Text;
 import org.jpos.iso.ISOFieldValidator;
 import org.jpos.iso.IVA_ALPHANUM;
@@ -319,7 +317,7 @@ public class QFactory2Test {
         final String ATTRIBUTE = "attribute-with-no-property";
         final String VALUE  = "value-with-no-property";
         e.setAttribute(ATTRIBUTE, VALUE);
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals(VALUE, e.getAttributeValue(ATTRIBUTE), "value should not have changed");
     }
     
@@ -329,7 +327,7 @@ public class QFactory2Test {
         final String ATTRIBUTE = "attribute-with-no-property";
         final String VALUE  = "value-with-${property-with-no-default}";
         e.setAttribute(ATTRIBUTE, VALUE);
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals(VALUE, e.getAttributeValue(ATTRIBUTE), "value should not have changed");
     }
 
@@ -339,7 +337,7 @@ public class QFactory2Test {
         final String ATTRIBUTE = "attribute-with-no-property";
         final String VALUE  = "value-with-${property-with-default:default}";
         e.setAttribute(ATTRIBUTE, VALUE);
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals("value-with-default", e.getAttributeValue(ATTRIBUTE), "property should have been replaced by default value");
     }
 
@@ -351,7 +349,7 @@ public class QFactory2Test {
         final String TEXT = "text with no property";
         e.setAttribute(ATTRIBUTE, VALUE);
         e.addContent(new Text(TEXT));
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals(TEXT, e.getText(), "text content should not have changed");
         assertEquals(VALUE, e.getAttributeValue(ATTRIBUTE), "value should not have changed");
     }
@@ -364,7 +362,7 @@ public class QFactory2Test {
         final String TEXT = "text with ${property-with-no-default}";
         e.setAttribute(ATTRIBUTE, VALUE);
         e.addContent(new Text(TEXT));
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals(TEXT, e.getText(), "text content should not have changed");
         assertEquals(VALUE, e.getAttributeValue(ATTRIBUTE), "value should not have changed");
     }
@@ -378,13 +376,13 @@ public class QFactory2Test {
         final String TEXT = "text with ${property-with-default:default}";
         e.setAttribute(ATTRIBUTE, VALUE);
         e.addContent(new Text(TEXT));
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals(TEXT, e.getText(), "text content should not have changed");
         assertEquals(VALUE, e.getAttributeValue(ATTRIBUTE), "value should not have changed");
 
         //next assert are to validate the reason for not changing was the verbatim value.
         e.setAttribute("verbatim", "false");
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals("text with default", e.getText(), "now text should have changed");
         assertEquals("value with default", e.getAttributeValue(ATTRIBUTE), "now value should have changed");
 
@@ -405,7 +403,7 @@ public class QFactory2Test {
         child.addContent(new Text(TEXT));
         e.addContent(child);
 
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals("text with default", e.getText(), "text in root should have changed");
         assertEquals("value with default", e.getAttributeValue(ATTRIBUTE), "value in root should have changed");
 
@@ -414,7 +412,7 @@ public class QFactory2Test {
 
         //next assert are to validate the reason for not changing was the verbatim value.
         child.setAttribute("verbatim", "false");
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals("text with default", child.getText(), "now text in child should have changed");
         assertEquals("value with default", child.getAttributeValue(ATTRIBUTE), "value should have changed");
 
@@ -428,7 +426,7 @@ public class QFactory2Test {
         final String TEXT  = "text with ${property-with-default:property with default}";
         e.setAttribute(ATTRIBUTE, VALUE);
         e.addContent(new Text(TEXT));
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals("text with property with default", e.getText(), "text content should not have changed");
         assertEquals("value-with-default", e.getAttributeValue(ATTRIBUTE), "property should have been replaced by default value");
     }
@@ -443,7 +441,7 @@ public class QFactory2Test {
         final String TEXT  = "text with ${property-with-default:property with default}";
         child.setAttribute(ATTRIBUTE, VALUE);
         child.addContent(new Text(TEXT));
-        QFactory.replaceEnvProperties(e);
+        QFactory.expandEnvProperties(e);
         assertEquals("text with property with default", child.getText(), "text content should not have changed");
         assertEquals("value-with-default", child.getAttributeValue(ATTRIBUTE), "property should have been replaced by default value");
     }
@@ -467,7 +465,7 @@ public class QFactory2Test {
         element.addContent(child);
 
         QFactory qFactory = new QFactory(null, q2);
-        Object created = qFactory.instantiate(q2, element);
+        Object created = qFactory.instantiate(q2, QFactory.expandEnvProperties(element));
         assertEquals(created.getClass(), String.class, "instantiate should have created a String");
         assertEquals("text with property with default", child.getText(), "text content should not have changed");
         assertEquals("value-with-default", child.getAttributeValue(ATTRIBUTE), "property should have been replaced by default value");
@@ -494,7 +492,7 @@ public class QFactory2Test {
         element.addContent(child);
 
         QFactory qFactory = new QFactory(null, q2);
-        Object created = qFactory.instantiate(q2, element);
+        Object created = qFactory.instantiate(q2, QFactory.expandEnvProperties(element));
         assertEquals(created.getClass(), String.class, "instantiate should have created a String");
         assertEquals(TEXT, child.getText(), "text content should not have changed");
         assertEquals(VALUE, child.getAttributeValue(ATTRIBUTE), "property should have been replaced by default value");

--- a/jpos/src/test/java/org/jpos/q2/QFactory2Test.java
+++ b/jpos/src/test/java/org/jpos/q2/QFactory2Test.java
@@ -33,7 +33,6 @@ import javax.management.ObjectName;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
 import org.jdom2.Text;
-import org.jpos.core.ConfigurationException;
 import org.jpos.iso.ISOFieldValidator;
 import org.jpos.iso.IVA_ALPHANUM;
 import org.jpos.q2.iso.ChannelAdaptor;
@@ -45,7 +44,6 @@ public class QFactory2Test {
     @Test
     public void testConstructor() throws Throwable {
         ObjectName loaderName = new ObjectName("");
-        String[] args = new String[0];
         Q2 q2 = mock(Q2.class);
         QFactory qFactory = new QFactory(loaderName, q2);
         assertTrue(qFactory.classMapping.getKeys().hasMoreElements(),
@@ -183,7 +181,7 @@ public class QFactory2Test {
         Q2 q2 = new Q2(args);
         Element element = new Element("testQFactoryName", "testQFactoryUri");
         element.setAttribute(new Attribute("testQFactoryName", "testQFactoryValue", 0));
-        Element e = (Element) element.clone();
+        Element e = element.clone();
         QFactory qFactory = new QFactory(new ObjectName("testQFactoryParam1", "testQFactoryParam2", "testQFactoryParam3"), q2);
         e.setName("testQFactoryName");
         String[] args2 = new String[2];

--- a/jpos/src/test/java/org/jpos/q2/QFactory2Test.java
+++ b/jpos/src/test/java/org/jpos/q2/QFactory2Test.java
@@ -32,6 +32,7 @@ import javax.management.ObjectName;
 
 import org.jdom2.Attribute;
 import org.jdom2.Element;
+import org.jdom2.Text;
 import org.jpos.core.ConfigurationException;
 import org.jpos.iso.ISOFieldValidator;
 import org.jpos.iso.IVA_ALPHANUM;
@@ -307,5 +308,89 @@ public class QFactory2Test {
         } finally {
             q2.stop();
         }
+    }
+    
+    @Test
+    public void testReplaceEnvPropertiesAttributeWithoutProperty() {
+        Element e = new Element("testQFactoryName");
+        final String ATTRIBUTE = "attribute-with-no-property";
+        final String VALUE  = "value-with-no-property";
+        e.setAttribute(ATTRIBUTE, VALUE);
+        QFactory.replaceEnvProperties(e);
+        assertEquals(VALUE, e.getAttributeValue(ATTRIBUTE), "value should not have changed");
+    }
+    
+    @Test
+    public void testReplaceEnvPropertiesAttributeWithNoDefaultProperty() {
+        Element e = new Element("testQFactoryName");
+        final String ATTRIBUTE = "attribute-with-no-property";
+        final String VALUE  = "value-with-${property-with-no-default}";
+        e.setAttribute(ATTRIBUTE, VALUE);
+        QFactory.replaceEnvProperties(e);
+        assertEquals(VALUE, e.getAttributeValue(ATTRIBUTE), "value should not have changed");
+    }
+
+    @Test
+    public void testReplaceEnvPropertiesAttributeWithPropertyWithDefaultValue() {
+        Element e = new Element("testQFactoryName");
+        final String ATTRIBUTE = "attribute-with-no-property";
+        final String VALUE  = "value-with-${property-with-default:default}";
+        e.setAttribute(ATTRIBUTE, VALUE);
+        QFactory.replaceEnvProperties(e);
+        assertEquals("value-with-default", e.getAttributeValue(ATTRIBUTE), "property should have been replaced by default value");
+    }
+
+    @Test
+    public void testReplaceEnvPropertiesTextWithoutProperty() {
+        Element e = new Element("testQFactoryName");
+        final String ATTRIBUTE = "attribute-with-no-property";
+        final String VALUE  = "value-with-no-property";
+        final String TEXT = "text with no property";
+        e.setAttribute(ATTRIBUTE, VALUE);
+        e.addContent(new Text(TEXT));
+        QFactory.replaceEnvProperties(e);
+        assertEquals(TEXT, e.getText(), "text content should not have changed");
+        assertEquals(VALUE, e.getAttributeValue(ATTRIBUTE), "value should not have changed");
+    }
+
+    @Test
+    public void testReplaceEnvPropertiesTextWithNoDefaultProperty() {
+        Element e = new Element("testQFactoryName");
+        final String ATTRIBUTE = "attribute-with-no-property";
+        final String VALUE  = "value-with-${property-with-no-default}";
+        final String TEXT = "text with property with no default";
+        e.setAttribute(ATTRIBUTE, VALUE);
+        e.addContent(new Text(TEXT));
+        QFactory.replaceEnvProperties(e);
+        assertEquals(TEXT, e.getText(), "text content should not have changed");
+        assertEquals(VALUE, e.getAttributeValue(ATTRIBUTE), "value should not have changed");
+    }
+
+    @Test
+    public void testReplaceEnvPropertiesTextWithPropertyWithDefaultValue() {
+        Element e = new Element("testQFactoryName");
+        final String ATTRIBUTE = "attribute-with-no-property";
+        final String VALUE  = "value-with-${property-with-default:default}";
+        final String TEXT  = "text with ${property-with-default:property with default}";
+        e.setAttribute(ATTRIBUTE, VALUE);
+        e.addContent(new Text(TEXT));
+        QFactory.replaceEnvProperties(e);
+        assertEquals("text with property with default", e.getText(), "text content should not have changed");
+        assertEquals("value-with-default", e.getAttributeValue(ATTRIBUTE), "property should have been replaced by default value");
+    }
+
+    @Test
+    public void testReplaceEnvPropertiesInInnerElement() {
+        Element e = new Element("testQFactoryName");
+        Element child = new Element("child"); 
+        e.addContent(child);
+        final String ATTRIBUTE = "attribute-with-no-property";
+        final String VALUE  = "value-with-${property-with-default:default}";
+        final String TEXT  = "text with ${property-with-default:property with default}";
+        child.setAttribute(ATTRIBUTE, VALUE);
+        child.addContent(new Text(TEXT));
+        QFactory.replaceEnvProperties(e);
+        assertEquals("text with property with default", child.getText(), "text content should not have changed");
+        assertEquals("value-with-default", child.getAttributeValue(ATTRIBUTE), "property should have been replaced by default value");
     }
 }


### PR DESCRIPTION
This draft PR is a possible implementation of what's discussed in #546.

When an element is instantiated via `QFactory.instantiate` the element is passed to the added `replaceEnvProperties` method, which replaces all environment properties recursively on its children and its attributes.

If an element has the `verbatim` attribute set to `true` it will not process it or its children, I'm inclined to think this should be the correct behavior because it also acts as a performance hint to not recursively process its children. However, one may expect to override the parent's option in a child, so this is debatable. This also simplifies the code, by not having to track changes in the attribute down the line in the recursion. 

It may be necessary to remark that the `verbatim` option does not apply to the `Configuration` elements or other classes that call `Environment.getProperty` on its own. This may sound obvious, but some may get confused about that.

