### PR TITLE
`ISOMsg`: add helper methods to identify the message class.

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOMsg.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOMsg.java
@@ -964,6 +964,69 @@ public class ISOMsg extends ISOComponent
         return !isRequest();
     }
     /**
+     * @return true if message class is "authorization"
+     * @exception ISOException on MTI not set
+     */
+    public boolean isAuthorization() throws ISOException {
+        return hasMTI() && getMTI().charAt(1) == '1';
+    }
+    /**
+     * @return true if message class is "financial"
+     * @exception ISOException on MTI not set
+     */
+    public boolean isFinancial() throws ISOException {
+        return hasMTI() && getMTI().charAt(1) == '2';
+    }
+    /**
+     * @return true if message class is "file action"
+     * @exception ISOException on MTI not set
+     */
+    public boolean isFileAction() throws ISOException {
+        return hasMTI() && getMTI().charAt(1) == '3';
+    }
+    /**
+     * @return true if message class is "reversal"
+     * @exception ISOException on MTI not set
+     */
+    public boolean isReversal() throws ISOException {
+        return hasMTI() && getMTI().charAt(1) == '4' && (getMTI().charAt(3) == '0' || getMTI().charAt(3) == '1');
+    }
+    /**
+     * @return true if message class is "chargeback"
+     * @exception ISOException on MTI not set
+     */
+    public boolean isChargeback() throws ISOException {
+        return hasMTI() && getMTI().charAt(1) == '4' && (getMTI().charAt(3) == '2' || getMTI().charAt(3) == '3');
+    }
+    /**
+     * @return true if message class is "reconciliation"
+     * @exception ISOException on MTI not set
+     */
+    public boolean isReconciliation() throws ISOException {
+        return hasMTI() && getMTI().charAt(1) == '5';
+    }
+    /**
+     * @return true if message class is "administrative"
+     * @exception ISOException on MTI not set
+     */
+    public boolean isAdministrative() throws ISOException {
+        return hasMTI() && getMTI().charAt(1) == '6';
+    }
+    /**
+     * @return true if message class is "fee collection"
+     * @exception ISOException on MTI not set
+     */
+    public boolean isFeeCollection() throws ISOException {
+        return hasMTI() && getMTI().charAt(1) == '7';
+    }
+    /**
+     * @return true if message class is "fee collection"
+     * @exception ISOException on MTI not set
+     */
+    public boolean isNetworkManagement() throws ISOException {
+        return hasMTI() && getMTI().charAt(1) == '8';
+    }
+    /**
      * @return true if message is Retransmission
      * @exception ISOException on MTI not set
      */

--- a/jpos/src/main/java/org/jpos/iso/ISOMsg.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOMsg.java
@@ -412,7 +412,7 @@ public class ISOMsg extends ISOComponent
     }
 
     /**
-     * Unset a a set of fields referenced by fpaths if any ot them exist, otherwise ignore.
+     * Unset a set of fields referenced by fpaths, if any of them exist. Otherwise, ignore.
      *
      * @param fpaths dot-separated field paths (i.e. 63.2)
      */

--- a/jpos/src/test/java/org/jpos/iso/ISOMsgTest.java
+++ b/jpos/src/test/java/org/jpos/iso/ISOMsgTest.java
@@ -98,8 +98,6 @@ public class ISOMsgTest {
         assertFalse(m.hasField("100.100"));
         assertFalse(m.hasField("100"));  // Not added unnecessarily
         assertFalse(m.hasField(100));  // Still not added unnecessarily
-
-
     }
 
     @Test
@@ -289,5 +287,109 @@ public class ISOMsgTest {
         assertFalse(copyMsg.hasField(102));
         assertFalse(copyMsg.hasField("102.1"));
         assertFalse(copyMsg.hasField("102.2"));
+    }
+
+    @Test
+    public void testIsAuthorization() throws ISOException {
+        ISOMsg msg = new ISOMsg("2100"); 
+        assertTrue(msg.isAuthorization());
+        assertFalse(msg.isFinancial());
+        assertFalse(msg.isReversal());
+        assertFalse(msg.isChargeback());
+        assertFalse(msg.isReconciliation());
+        assertFalse(msg.isAdministrative());
+        assertFalse(msg.isNetworkManagement());
+        assertFalse(msg.isFeeCollection());
+    }
+
+    @Test
+    public void testIsFinancial() throws ISOException {
+        ISOMsg msg = new ISOMsg("2200"); 
+        assertFalse(msg.isAuthorization());
+        assertTrue(msg.isFinancial());
+        assertFalse(msg.isReversal());
+        assertFalse(msg.isChargeback());
+        assertFalse(msg.isReconciliation());
+        assertFalse(msg.isAdministrative());
+        assertFalse(msg.isNetworkManagement());
+        assertFalse(msg.isFeeCollection());
+    }
+
+    @Test
+    public void testIsReversal() throws ISOException {
+        ISOMsg msg = new ISOMsg("2400"); 
+        assertFalse(msg.isAuthorization());
+        assertFalse(msg.isFinancial());
+        assertTrue(msg.isReversal());
+        assertFalse(msg.isChargeback());
+        assertFalse(msg.isReconciliation());
+        assertFalse(msg.isAdministrative());
+        assertFalse(msg.isNetworkManagement());
+        assertFalse(msg.isFeeCollection());
+    }
+
+    @Test
+    public void testIsChargeback() throws ISOException {
+        ISOMsg msg = new ISOMsg("2402"); 
+        assertFalse(msg.isAuthorization());
+        assertFalse(msg.isFinancial());
+        assertFalse(msg.isReversal());
+        assertTrue(msg.isChargeback());
+        assertFalse(msg.isReconciliation());
+        assertFalse(msg.isAdministrative());
+        assertFalse(msg.isNetworkManagement());
+        assertFalse(msg.isFeeCollection());
+    }
+
+    @Test
+    public void testIsReconciliation() throws ISOException {
+        ISOMsg msg = new ISOMsg("2500"); 
+        assertFalse(msg.isAuthorization());
+        assertFalse(msg.isFinancial());
+        assertFalse(msg.isReversal());
+        assertFalse(msg.isChargeback());
+        assertTrue(msg.isReconciliation());
+        assertFalse(msg.isAdministrative());
+        assertFalse(msg.isNetworkManagement());
+        assertFalse(msg.isFeeCollection());
+    }
+
+    @Test
+    public void testIsAdministrative() throws ISOException {
+        ISOMsg msg = new ISOMsg("2600"); 
+        assertFalse(msg.isAuthorization());
+        assertFalse(msg.isFinancial());
+        assertFalse(msg.isReversal());
+        assertFalse(msg.isChargeback());
+        assertFalse(msg.isReconciliation());
+        assertTrue(msg.isAdministrative());
+        assertFalse(msg.isNetworkManagement());
+        assertFalse(msg.isFeeCollection());
+    }
+
+    @Test
+    public void testIsNetworkManagement() throws ISOException {
+        ISOMsg msg = new ISOMsg("2800"); 
+        assertFalse(msg.isAuthorization());
+        assertFalse(msg.isFinancial());
+        assertFalse(msg.isReversal());
+        assertFalse(msg.isChargeback());
+        assertFalse(msg.isReconciliation());
+        assertFalse(msg.isAdministrative());
+        assertTrue(msg.isNetworkManagement());
+        assertFalse(msg.isFeeCollection());
+    }
+
+    @Test
+    public void testIsFeeCollection() throws ISOException {
+        ISOMsg msg = new ISOMsg("2700"); 
+        assertFalse(msg.isAuthorization());
+        assertFalse(msg.isFinancial());
+        assertFalse(msg.isReversal());
+        assertFalse(msg.isChargeback());
+        assertFalse(msg.isReconciliation());
+        assertFalse(msg.isAdministrative());
+        assertFalse(msg.isNetworkManagement());
+        assertTrue(msg.isFeeCollection());
     }
 }


### PR DESCRIPTION
This PR adds the following methods to `ISOMsg`, aimed to help identify the message class:
- `isAuthorization`
- `isFinancial`
- `isAdministrative`
- `isReversal`
- `isCashback`
- `isReconciliation`
- `isFeeCollection`
- `isNetworkManagement`

Example:

```java
ISOMsg msg = new ISOMsg("2100"); 
assertTrue(msg.isAuthorization());
```

Unit test cases were added to cover all those new methods.