### PR TITLE
`SMAdapter`: add new operation to encrypt clear PIN under PEK.

### DIFF
--- a/jpos/src/main/java/org/jpos/security/SMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/SMAdapter.java
@@ -384,7 +384,7 @@ public interface SMAdapter<T> {
      * Encrypts a clear pin under LMK.
      *
      * <p>CAUTION: The use of clear pin presents a significant security risk
-     * @param pin clear pin as entered by card holder
+     * @param pin clear pin as entered by cardholder
      * @param accountNumber if <code>extract</code> is false then account number, including BIN and the check digit
      *        or if parameter <code>extract</code> is true then 12 right-most digits of the account number, excluding the check digit
      * @param extract true to extract 12 right-most digits off the account number
@@ -392,6 +392,18 @@ public interface SMAdapter<T> {
      * @throws SMException
      */
     EncryptedPIN encryptPIN(String pin, String accountNumber, boolean extract) throws SMException;
+
+    /**
+     * Encrypts a clear PIN under PEK.
+     *
+     * <p>CAUTION: The use of clear PIN presents a significant security risk.
+     * @param pin Clear PIN as entered by cardholder.
+     * @param accountNumber account number, including BIN and the check digit.
+     * @param pek PIN encryption key.
+     * @return Return PIN under PEK.
+     * @throws SMException
+     */
+    EncryptedPIN encryptPIN(String pin, String accountNumber, T pek) throws SMException;
 
     /**
      * Decrypts an Encrypted PIN (under LMK).

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -275,6 +275,14 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     @Override
+    protected EncryptedPIN encryptPINImpl(String pin, String accountNumber, SecureDESKey pek) throws SMException {
+        byte[] clearPINBlock = calculatePINBlock(pin, FORMAT00, accountNumber);
+        Key clearPEK = decryptFromLMK(pek);
+        byte[] translatedPINBlock = jceHandler.encryptData(clearPINBlock, clearPEK);
+        return new EncryptedPIN(translatedPINBlock, FORMAT00, accountNumber, false);
+    }
+
+    @Override
     public String decryptPINImpl (EncryptedPIN pinUnderLmk) throws SMException {
         byte[] clearPINBlock = jceHandler.decryptData(pinUnderLmk.getPINBlock(),
                 getLMK(PINLMKIndex));

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -957,6 +957,8 @@ public class JCESecurityModuleTest {
             jcesecmod.verifydCVV(accountNo, imkac, dcvv, expDate
                         ,serviceCode, atc, MKDMethod.OPTION_A);
             fail("Expected SMException to be thrown");
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("Account"));
         } catch (SMException ex){
             if (isJavaVersionAtMost(JAVA_13)) {
                 assertEquals("String index out of range: -4", ex.getNested().getMessage(), "ex.getMessage()");

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -979,6 +979,8 @@ public class JCESecurityModuleTest {
             jcesecmod.verifydCVV(accountNo, imkac, dcvv, expDate
                         ,serviceCode, atc, MKDMethod.OPTION_A);
             fail("Expected SMException to be thrown");
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("Account"));
         } catch (SMException ex){
             if (isJavaVersionAtMost(JAVA_14)) {
                 assertNull(ex.getNested().getMessage(), "ex.getNested().getMessage()");


### PR DESCRIPTION
This PR adds a new method to the `SMAdapter` interface that encrypts a clear PIN under the given PIN encryption key (PEK).

Also, this new method has been added to the `JESecurityModule` implementation.