### PR TITLE
Allow setting of a higher `corePoolSize` while creating new `ScheduledThreadPoolExecutor`

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/QBeanSupport.java
+++ b/jpos/src/main/java/org/jpos/q2/QBeanSupport.java
@@ -255,8 +255,9 @@ public class QBeanSupport
     protected void destroyService() throws Exception {}
 
     protected synchronized ScheduledThreadPoolExecutor getScheduledThreadPoolExecutor() {
+        int corePoolSize = cfg.getInt("stpe-core-pool-size", 1);
         if (scheduledThreadPoolExecutor == null)
-            scheduledThreadPoolExecutor = ConcurrentUtil.newScheduledThreadPoolExecutor();
+            scheduledThreadPoolExecutor = ConcurrentUtil.newScheduledThreadPoolExecutor(corePoolSize);
         return scheduledThreadPoolExecutor;
     }
 

--- a/jpos/src/main/java/org/jpos/util/ConcurrentUtil.java
+++ b/jpos/src/main/java/org/jpos/util/ConcurrentUtil.java
@@ -23,7 +23,10 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 public class ConcurrentUtil {
     public static ScheduledThreadPoolExecutor newScheduledThreadPoolExecutor() {
-        ScheduledThreadPoolExecutor stpe = new ScheduledThreadPoolExecutor(1,
+        return newScheduledThreadPoolExecutor(1);
+    }
+    public static ScheduledThreadPoolExecutor newScheduledThreadPoolExecutor(int corePoolSize) {
+        ScheduledThreadPoolExecutor stpe = new ScheduledThreadPoolExecutor(corePoolSize,
           r -> {
               Thread t = Executors.defaultThreadFactory().newThread(r);
               t.setDaemon(true);


### PR DESCRIPTION
At present `ConcurrentUtil.newScheduledThreadPoolExecutor()`, which is called from `QBeanSupport.getScheduledThreadPoolExecutor()`, hard-codes `corePoolSize` to 1. This change allows us to set a higher value via a configuration property named `stpe-core-pool-size`