### PR TITLE
Allow property expansion for mux keys.

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/iso/QMUX.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QMUX.java
@@ -470,10 +470,9 @@ public class QMUX
         metrics.dump (p, indent);
     }
     private String[] toStringArray(String s, String delimiter, String def) {
-        if (s == null)
-            s = def;
+        s = (s != null) ? Environment.get(s) : def; 
         String[] arr = null;
-        if (s != null && s.length() > 0) {
+        if (s != null && !s.isEmpty()) {
             StringTokenizer st;
             if (delimiter != null)
                 st = new StringTokenizer(s, delimiter);

--- a/jpos/src/main/java/org/jpos/q2/iso/QMUX.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QMUX.java
@@ -75,14 +75,12 @@ public class QMUX
             throw new ConfigurationException ("Misconfigured QMUX. Please verify in/out queues");
         }
         ignorerc  = Environment.get(e.getChildTextTrim ("ignore-rc"));
-        key = toStringArray(DEFAULT_KEY, ", ", null);
+        key = toStringArray(e.getChildTextTrim("key"), ", ", DEFAULT_KEY);
         returnRejects = cfg.getBoolean("return-rejects", false);
         for (Element keyElement : e.getChildren("key")) {
             String mtiOverride = QFactory.getAttributeValue(keyElement, "mti");
             if (mtiOverride != null && mtiOverride.length() >= 2) {
                 mtiKey.put (mtiOverride.substring(0,2), toStringArray(keyElement.getTextTrim(), ", ", null));
-            } else {
-                key = toStringArray(e.getChildTextTrim("key"), ", ", DEFAULT_KEY);
             }
         }
         ready     = toStringArray(Environment.get(e.getChildTextTrim ("ready")));


### PR DESCRIPTION
Property expansion is made in `toStringArray` to avoid repetitive code. But it could be explicit in the method call if preferred.

Also, set default key only once. This could be undone, but it was getting a child of the parent in the loop instead of using the content of the child, so the effect is the same.

Basically, I want to be able to do this:
```xml
<mux name="probe-mux" class="org.jpos.q2.iso.QMUX"
     enabled="${probe.enabled:true}"
     logger="${probe.logger:Q2}" realm="probe-mux">
  <key>${probe.mux.key:11,41}</key>
  <in>probe-receive</in>
  <out>probe-send</out>

  <ready>probe-channel.ready</ready>
</mux>
```