### PR TITLE
Add dump overloads with default implementations to Loggeable interface

### DIFF
--- a/jpos/src/main/java/org/jpos/util/Loggeable.java
+++ b/jpos/src/main/java/org/jpos/util/Loggeable.java
@@ -26,5 +26,17 @@ import java.io.PrintStream;
  */
 public interface Loggeable {
     void dump(PrintStream p, String indent);
+    
+    default void dump() {
+        dump("");
+    }
+    
+    default void dump(PrintStream p) {
+        dump(p, "");
+    }
+    
+    default void dump(String indent) {
+        dump(System.out, indent);
+    }
 }
 


### PR DESCRIPTION
This is just a small PR to make it easier to just dump to `System.out` or without indentation. Providing overloads of `Loggeable.dump()` with reasonable defaults.