### PR TITLE
issue #568: fixed BERTLVAsciiHexPackager  getUninterpretLength always returns 0 with AsciiHex interpreter

### DIFF
--- a/jpos/src/main/java/org/jpos/tlv/packager/bertlv/BERTLVPackager.java
+++ b/jpos/src/main/java/org/jpos/tlv/packager/bertlv/BERTLVPackager.java
@@ -447,7 +447,7 @@ public abstract class BERTLVPackager extends GenericPackager {
     private int getUninterpretLength(int length, BinaryInterpreter interpreter) {
         if (length > 0) {
             int lengthAdjusted = length + length % 2;
-            return (int) (length * (lengthAdjusted / (double) interpreter.getPackedLength(lengthAdjusted)));
+            return (length * lengthAdjusted) / interpreter.getPackedLength(lengthAdjusted);
         }
         return 0;
     }
@@ -455,7 +455,7 @@ public abstract class BERTLVPackager extends GenericPackager {
     private int getUninterpretLength(int length, Interpreter interpreter) {
         if (length > 0) {
             int lengthAdjusted = length + length % 2;
-            return length * (lengthAdjusted / interpreter.getPackedLength(lengthAdjusted));
+            return (length * lengthAdjusted) / interpreter.getPackedLength(lengthAdjusted);
         }
         return 0;
     }

--- a/jpos/src/main/java/org/jpos/tlv/packager/bertlv/BERTLVPackager.java
+++ b/jpos/src/main/java/org/jpos/tlv/packager/bertlv/BERTLVPackager.java
@@ -447,7 +447,7 @@ public abstract class BERTLVPackager extends GenericPackager {
     private int getUninterpretLength(int length, BinaryInterpreter interpreter) {
         if (length > 0) {
             int lengthAdjusted = length + length % 2;
-            return length * (lengthAdjusted / interpreter.getPackedLength(lengthAdjusted));
+            return (int) (length * (lengthAdjusted / (double) interpreter.getPackedLength(lengthAdjusted)));
         }
         return 0;
     }

--- a/jpos/src/test/java/org/jpos/tlv/packager/bertlv/Bug568BERTLVAsciiHexPackager.java
+++ b/jpos/src/test/java/org/jpos/tlv/packager/bertlv/Bug568BERTLVAsciiHexPackager.java
@@ -2,12 +2,10 @@ package org.jpos.tlv.packager.bertlv;
 import org.bouncycastle.util.Arrays;
 import org.jpos.iso.*;
 import org.jpos.tlv.ISOTaggedField;
-import org.jpos.tlv.packager.bertlv.BERTLVAsciiHexPackager;
-import org.jpos.tlv.packager.bertlv.BERTLVBinaryPackager;
 
 import org.junit.jupiter.api.*;
 
-public class Bug_BERTLVAsciiPackager {
+public class Bug568BERTLVAsciiHexPackager {
 
     final String HEX_ASCII = "9f2610e18d2a69a45dd09a9f360401839f3708ab34b0bd";
 

--- a/jpos/src/test/java/org/jpos/tlv/packager/bertlv/Bug_BERTLVAsciiPackager.java
+++ b/jpos/src/test/java/org/jpos/tlv/packager/bertlv/Bug_BERTLVAsciiPackager.java
@@ -1,0 +1,44 @@
+package org.jpos.tlv.packager.bertlv;
+import org.bouncycastle.util.Arrays;
+import org.jpos.iso.*;
+import org.jpos.tlv.ISOTaggedField;
+import org.jpos.tlv.packager.bertlv.BERTLVAsciiHexPackager;
+import org.jpos.tlv.packager.bertlv.BERTLVBinaryPackager;
+
+import org.junit.jupiter.api.*;
+
+public class Bug_BERTLVAsciiPackager {
+
+    final String HEX_ASCII = "9f2610e18d2a69a45dd09a9f360401839f3708ab34b0bd";
+
+    @Test
+    public void testLenInterpretation() throws ISOException {
+        final ISOMsg ICC_DATA = new ISOMsg(55);
+        final BERTLVAsciiHexPackager packager = new BERTLVAsciiHexPackager();
+        final IFA_LLABINARY fieldPackager = new IFA_LLABINARY();
+
+
+        packager.setFieldPackager(new org.jpos.iso.ISOFieldPackager[]{fieldPackager});
+        ICC_DATA.setPackager(packager);
+
+        ICC_DATA.unpack(HEX_ASCII.getBytes());
+
+        ICC_DATA.getChildren().values().forEach
+                (e -> {
+                    try {
+                        ISOTaggedField field = (ISOTaggedField) e;
+                        final byte[] value = (byte[]) field.getValue();
+                        System.out.println("tag " + field.getTag() + " value " + ISOUtil.hexString(value));
+                        Assertions.
+                                assertFalse(Arrays.isNullOrEmpty(value));
+
+                    } catch (ISOException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                });
+
+
+    }
+
+}
+


### PR DESCRIPTION

The issue was due to The two operands  lengthAdjusted  and interpreter.getPackedLength(lengthAdjusted) are both Integers.

the result was calculated using Integer arithmetic resulting in a 0,5 that was always rounded down to 0.  

0.5 because AsciiHex packed len is double len 

solution is to cast one of the operands to a double to use double arithmetic, then cast result to integer.