### PR TITLE
Tspace monotonic

### DIFF
--- a/jpos/src/main/java/org/jpos/space/TSpace.java
+++ b/jpos/src/main/java/org/jpos/space/TSpace.java
@@ -1,6 +1,6 @@
 /*
  * jPOS Project [http://jpos.org]
- * Copyright (C) 2000-2021 jPOS Software SRL
+ * Copyright (C) 2000-2023 jPOS Software SRL
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,11 +17,10 @@
  */
 
 package org.jpos.space;
-import org.jpos.util.Loggeable;
 
+import org.jpos.util.Loggeable;
 import java.io.PrintStream;
 import java.io.Serializable;
-import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -40,8 +39,9 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
     private static final long GCLONG = 60*1000;
     private static final long NRD_RESOLUTION = 500L;
     private static final int MAX_ENTRIES_IN_DUMP = 1000;
+    private static final long ONE_MILLION = 1_000_000L;         // multiplier millis --> nanos
     private final Set[] expirables;
-    private Duration lastLongGC = Duration.ofNanos(System.nanoTime());
+    private long lastLongGC = System.nanoTime();
 
     public TSpace () {
         super();
@@ -70,7 +70,7 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
             throw new NullPointerException ("key=" + key + ", value=" + value);
         Object v = value;
         if (timeout > 0) {
-            v = new Expirable (value, Duration.ofNanos(System.nanoTime()).plus(Duration.ofMillis(timeout)));
+            v = new Expirable (value, System.nanoTime() + (timeout * ONE_MILLION));
         }
         synchronized (this) {
             List l = getList(key);
@@ -112,18 +112,18 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
 
     @Override
     public synchronized V in  (Object key, long timeout) {
-        Object obj;
-        Duration to = Duration.ofMillis(timeout);
-        Duration now = Duration.ofNanos(System.nanoTime());
-        Duration duration;
-        while ((obj = inp (key)) == null &&
-                to.compareTo(duration = Duration.ofNanos(System.nanoTime()).minus(now)) > 0)
+        V obj;
+        long now = System.nanoTime();
+        long to = now + timeout * ONE_MILLION;
+        long waitFor;
+        while ( (obj = inp (key)) == null &&
+                (waitFor = (to - System.nanoTime())) >= 0 )
         {
             try {
-                this.wait (Math.max(to.minus(duration).toMillis(), 1L));
+                this.wait(Math.max(waitFor / ONE_MILLION, 1L));
             } catch (InterruptedException e) { }
         }
-        return (V) obj;
+        return obj;
     }
 
     @Override
@@ -139,18 +139,18 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
 
     @Override
     public synchronized V rd  (Object key, long timeout) {
-        Object obj;
-        Duration to = Duration.ofMillis(timeout);
-        Duration now = Duration.ofNanos(System.nanoTime());
-        Duration duration;
-        while ((obj = rdp (key)) == null &&
-                to.compareTo(duration = Duration.ofNanos(System.nanoTime()).minus(now)) > 0)
+        V obj;
+        long now = System.nanoTime();
+        long to = now + (timeout * ONE_MILLION);
+        long waitFor;
+        while ( (obj = rdp (key)) == null &&
+                (waitFor = (to - System.nanoTime())) >= 0 )
         {
             try {
-                this.wait (Math.max(to.minus(duration).toMillis(), 1L));
+                this.wait(Math.max(waitFor / ONE_MILLION, 1L));
             } catch (InterruptedException e) { }
         }
-        return (V) obj;
+        return obj;
     }
 
     @Override
@@ -164,18 +164,19 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
 
     @Override
     public synchronized V nrd  (Object key, long timeout) {
-        Object obj;
-        Duration to = Duration.ofMillis(timeout);
-        Duration now = Duration.ofNanos(System.nanoTime());
-        Duration duration;
-        while ((obj = rdp (key)) != null &&
-                to.compareTo(duration = Duration.ofNanos(System.nanoTime()).minus(now)) > 0)
+        V obj;
+        long now = System.nanoTime();
+        long to = now + (timeout * ONE_MILLION);
+        long waitFor;
+        while ( (obj = rdp (key)) != null &&
+                (waitFor = (to - System.nanoTime())) >= 0 )
         {
             try {
-                this.wait (Math.min(NRD_RESOLUTION, Math.max(to.minus(duration).toMillis(), 1L)));
+                this.wait(Math.min(NRD_RESOLUTION,
+                                   Math.max(waitFor / ONE_MILLION, 1L)));
             } catch (InterruptedException ignored) { }
         }
-        return (V) obj;
+        return obj;
     }
 
     @Override
@@ -189,9 +190,9 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
 
     public void gc () {
         gc(0);
-        if (Duration.ofMillis(GCLONG).compareTo(Duration.ofNanos(System.nanoTime()).minus(lastLongGC)) > 0) {
+        if (System.nanoTime() - lastLongGC > GCLONG) {
             gc(1);
-            lastLongGC = Duration.ofNanos(System.nanoTime());
+            lastLongGC = System.nanoTime();
         }
     }
 
@@ -339,7 +340,7 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
             throw new NullPointerException ("key=" + key + ", value=" + value);
         Object v = value;
         if (timeout > 0) {
-            v = new Expirable (value, Duration.ofNanos(System.nanoTime()).plus(Duration.ofMillis(timeout)));
+            v = new Expirable (value, System.nanoTime() + (timeout * ONE_MILLION));
         }
         synchronized (this) {
             List l = getList(key);
@@ -376,7 +377,7 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
             throw new NullPointerException ("key=" + key + ", value=" + value);
         Object v = value;
         if (timeout > 0) {
-            v = new Expirable (value, Duration.ofNanos(System.nanoTime()).plus(Duration.ofMillis(timeout)));
+            v = new Expirable (value, System.nanoTime() + (timeout * ONE_MILLION));
         }
         synchronized (this) {
             List l = new LinkedList();
@@ -402,15 +403,15 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
 
     @Override
     public boolean existAny (K[] keys, long timeout) {
-        Duration to = Duration.ofMillis(timeout);
-        Duration now = Duration.ofNanos(System.nanoTime());
-        Duration duration;
-        while (to.compareTo(duration = Duration.ofNanos(System.nanoTime()).minus(now)) > 0) {
+        long now = System.nanoTime();
+        long to = now + (timeout * ONE_MILLION);
+        long waitFor;
+        while ((waitFor = (to - System.nanoTime())) >= 0) {
             if (existAny (keys))
                 return true;
             synchronized (this) {
                 try {
-                    wait (Math.max(to.minus(duration).toMillis(), 1L));
+                    this.wait(Math.max(waitFor / ONE_MILLION, 1L));
                 } catch (InterruptedException e) { }
             }
         }
@@ -521,19 +522,24 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
 
     static class Expirable implements Comparable, Serializable {
 
-        static final long serialVersionUID = 0xA7F22BF5;
+        private static final long serialVersionUID = 0xA7F22BF5;
 
         Object value;
-        Duration expires;
 
-        public Expirable (Object value, Duration expires) {
+        /**
+         *  When to expire, in the future, as given by monotonic System.nanoTime().<br>
+         *  IMPORTANT: always use a nanosec offset from System.nanoTime()!
+         */
+        long expires;
+
+        Expirable (Object value, long expires) {
             super();
             this.value = value;
             this.expires = expires;
         }
 
-        public boolean isExpired () {
-            return expires.compareTo(Duration.ofNanos(System.nanoTime())) < 0;
+        boolean isExpired () {
+            return (System.nanoTime() - expires) > 0;
         }
 
         @Override
@@ -544,20 +550,16 @@ public class TSpace<K,V> implements LocalSpace<K,V>, Loggeable, Runnable {
                 + ",expired=" + isExpired ();
         }
 
-        public Object getValue() {
+        Object getValue() {
             return isExpired() ? null : value;
         }
 
         @Override
-        public int compareTo (Object obj) {
-            Expirable other = (Expirable) obj;
-            Duration otherExpires = other.expires;
-            if (otherExpires.equals(expires))
-                return 0;
-            else if (expires.compareTo(otherExpires) < 0)
-                return -1;
-            else 
-                return 1;
+        public int compareTo (Object other) {
+            long diff = this.expires - ((Expirable)other).expires;
+            return  diff > 0 ?  1 :
+                    diff < 0 ? -1 :
+                    0;
         }
     }
 

--- a/jpos/src/test/java/org/jpos/space/TSpacePerformanceTest.java
+++ b/jpos/src/test/java/org/jpos/space/TSpacePerformanceTest.java
@@ -19,7 +19,6 @@
 package org.jpos.space;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -184,9 +183,9 @@ public class TSpacePerformanceTest  {
         for (int i=0; i<size; i++)
           es.execute(new WriteSpaceWithNotifyTask("WriteTask2-"+i,sp2,sp1));
 
-        Instant stamp = Instant.now();
+        Duration stamp = Duration.ofNanos(System.nanoTime());
         while (((ThreadPoolExecutor)es).getActiveCount() > 0) {
-          if (Duration.between(stamp, Instant.now()).toMillis() < 10000){
+          if (Duration.ofNanos(System.nanoTime()).minus(stamp).toMillis() < 10000){
             ISOUtil.sleep(100);
             continue;
           }

--- a/jpos/src/test/java/org/jpos/space/TSpaceTest.java
+++ b/jpos/src/test/java/org/jpos/space/TSpaceTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.time.Duration;
 import java.util.AbstractSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -62,27 +63,27 @@ public class TSpaceTest {
 
     @Test
     public void testExpirableCompareTo() throws Throwable {
-        int result = new TSpace.Expirable(Integer.valueOf(0), 1L).compareTo(new TSpace.Expirable(new Object(), 0L));
+        int result = new TSpace.Expirable(Integer.valueOf(0), Duration.ofMillis(1L)).compareTo(new TSpace.Expirable(new Object(), Duration.ofMillis(0L)));
         assertEquals(1, result, "result");
     }
 
     @Test
     public void testExpirableCompareTo1() throws Throwable {
-        TSpace.Expirable obj = new TSpace.Expirable(new Object(), 0L);
-        int result = new TSpace.Expirable(new Object(), 0L).compareTo(obj);
+        TSpace.Expirable obj = new TSpace.Expirable(new Object(), Duration.ofMillis(0L));
+        int result = new TSpace.Expirable(new Object(), Duration.ofMillis(0L)).compareTo(obj);
         assertEquals(0, result, "result");
     }
 
     @Test
     public void testExpirableCompareTo2() throws Throwable {
-        int result = new TSpace.Expirable(null, 0L).compareTo(new TSpace.Expirable(new Object(), 1L));
+        int result = new TSpace.Expirable(null, Duration.ofMillis(0L)).compareTo(new TSpace.Expirable(new Object(), Duration.ofMillis(1L)));
         assertEquals(-1, result, "result");
     }
 
     @Test
     public void testExpirableCompareToThrowsNullPointerException() throws Throwable {
         try {
-            new TSpace.Expirable(new Object(), 100L).compareTo(null);
+            new TSpace.Expirable(new Object(), Duration.ofMillis(100L)).compareTo(null);
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
             if (isJavaVersionAtMost(JAVA_14)) {
@@ -96,51 +97,51 @@ public class TSpaceTest {
     @Test
     public void testExpirableConstructor() throws Throwable {
         Object value = new Object();
-        TSpace.Expirable expirable = new TSpace.Expirable(value, 100L);
-        assertEquals(100L, expirable.expires, "expirable.expires");
+        TSpace.Expirable expirable = new TSpace.Expirable(value, Duration.ofMillis(100L));
+        assertEquals(Duration.ofMillis(100L), expirable.expires, "expirable.expires");
         assertSame(value, expirable.value, "expirable.value");
     }
 
     @Test
     public void testExpirableGetValue() throws Throwable {
-        String result = (String) new TSpace.Expirable("", 9184833384926L).getValue();
+        String result = (String) new TSpace.Expirable("", Duration.ofNanos(System.nanoTime()).plus(Duration.ofMillis(9184833384926L))).getValue();
         assertEquals("", result, "result");
     }
 
     @Test
     public void testExpirableGetValue1() throws Throwable {
-        Object result = new TSpace.Expirable(null, 9184833384926L).getValue();
+        Object result = new TSpace.Expirable(null, Duration.ofMillis(9184833384926L)).getValue();
         assertNull(result, "result");
     }
 
     @Test
     public void testExpirableGetValue2() throws Throwable {
-        Object result = new TSpace.Expirable(new Object(), 100L).getValue();
+        Object result = new TSpace.Expirable(new Object(), Duration.ofNanos(System.nanoTime()).minus(Duration.ofMillis(100L))).getValue();
         assertNull(result, "result");
     }
 
     @Test
     public void testExpirableIsExpired() throws Throwable {
-        boolean result = new TSpace.Expirable("", 9184833384926L).isExpired();
+        boolean result = new TSpace.Expirable("", Duration.ofNanos(System.nanoTime()).plus(Duration.ofMillis(9184833384926L))).isExpired();
         assertFalse(result, "result");
     }
 
     @Test
     public void testExpirableIsExpired1() throws Throwable {
-        boolean result = new TSpace.Expirable(new Object(), 100L).isExpired();
+        boolean result = new TSpace.Expirable(new Object(), Duration.ofNanos(System.nanoTime()).minus(Duration.ofMillis(100L))).isExpired();
         assertTrue(result, "result");
     }
 
     @Test
     public void testExpirableToString() throws Throwable {
-        new TSpace.Expirable(";\"i", 100L).toString();
+        new TSpace.Expirable(";\"i", Duration.ofMillis(100L)).toString();
         assertTrue(true, "Test completed without Exception");
     }
 
     @Test
     public void testExpirableToStringThrowsNullPointerException() throws Throwable {
         try {
-            new TSpace.Expirable(null, 100L).toString();
+            new TSpace.Expirable(null, Duration.ofMillis(100L)).toString();
             fail("Expected NullPointerException to be thrown");
         } catch (NullPointerException ex) {
             if (isJavaVersionAtMost(JAVA_14)) {

--- a/jpos/src/test/java/org/jpos/space/TSpaceTestCase.java
+++ b/jpos/src/test/java/org/jpos/space/TSpaceTestCase.java
@@ -19,7 +19,6 @@
 package org.jpos.space;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -289,28 +288,28 @@ public class TSpaceTestCase implements SpaceListener {
                 sp.out("KA", Boolean.TRUE);
             }
         }.start();
-        Instant now = Instant.now();
+        Duration now = Duration.ofNanos(System.nanoTime());
         assertTrue(sp.existAny(new String[] { "KA", "KB" }, 2000L), "existAnyWithTimeout ([KA,KB], delay)");
-        long elapsed = Duration.between(now, Instant.now()).toMillis();
+        long elapsed = Duration.ofNanos(System.nanoTime()).minus(now).toMillis();
         assertTrue(elapsed > 900L, "delay was > 1000");
     }
 
     @Test
     public void testNRD() {
-        Instant now = Instant.now();
+        Duration now = Duration.ofNanos(System.nanoTime());
         sp.out("NRD", "NRDTEST", 1000L);
         sp.nrd("NRD");
-        long elapsed = Duration.between(now, Instant.now()).toMillis();
+        long elapsed = Duration.ofNanos(System.nanoTime()).minus(now).toMillis();
         assertTrue(elapsed >= 1000L, "Invalid elapsed time " + elapsed);
     }
     @Test
     public void testNRDWithDelay() {
-        Instant now = Instant.now();
+        Duration now = Duration.ofNanos(System.nanoTime());
         sp.out("NRD", "NRDTEST", 1000L);
         Object obj = sp.nrd("NRD", 500L);
         assertNotNull(obj, "Object should not be null");
         obj = sp.nrd("NRD", 5000L);
-        long elapsed = Duration.between(now, Instant.now()).toMillis();
+        long elapsed = Duration.ofNanos(System.nanoTime()).minus(now).toMillis();
         assertTrue(elapsed >= 1000L && elapsed <= 2000L, "Invalid elapsed time " + elapsed);
         assertNull(obj, "Object should be null");
     }


### PR DESCRIPTION
This is a resurrection of an old PR  https://github.com/jpos/jPOS/pull/418/ by James Hilliard.

James' solution is based on `System.nanoTime()` which has a **monotonical increasing** behavior.
There's really no need for nano precision or resolution, and its value bears no relation to any actual calendar time or epoch. However, it's perfect to measure **monotonically increasing elapsed time** in order to expire space entries, for example.

His fix was important to avoid bugs in cases where the system clock (as typically given by `System.currentTimeMillis()` in the older implementation) may run **backward** because of daylight saving adjustments, or other weird NTP behavior.

However, I found the implementation a bit confusing, with unneeded usage of `Duration` to store "points in time" and complicated `Duration` operations. The complexity may have prevented the original merge of the PR, but it's still an **important fix**.

I attempted to go simpler, using naked `System.nanoTime()` and basic arithmetic as much as I could.

(there are other similar PRs for other classes that mesure elapsed time that will get fixed soon, if this is accepted)