### PR TITLE
Add protected method to connect channel to streams

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/BaseChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/BaseChannel.java
@@ -291,6 +291,20 @@ public abstract class BaseChannel extends Observable
         setChanged();
         notifyObservers();
     }
+
+    /**
+     * Allow the channel to be connected to a pair of input and output streams.
+     * <p> 
+     * For instance for taking input from or outputting to a file or standard input/ouput.  
+     * 
+     * @param in Where to read from.
+     * @param out Where to write to.
+     */
+    protected void connect(InputStream in, OutputStream out) {
+        usable = in != null || out != null; //at least one of them has to be not null
+        if (in != null) serverIn = new DataInputStream(in);
+        if (out != null) serverOut = new DataOutputStream(out);
+    }
     protected void postConnectHook() throws IOException {
         // do nothing
     }

--- a/jpos/src/main/java/org/jpos/iso/channel/XMLChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/XMLChannel.java
@@ -22,9 +22,12 @@ import org.jpos.iso.*;
 import org.jpos.iso.packager.XMLPackager;
 
 import java.io.BufferedReader;
+import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 
@@ -116,5 +119,10 @@ public class XMLChannel extends BaseChannel {
         if (reader != null)
             reader.close ();
         reader = null;
+    }
+
+    protected void connect(InputStream in, OutputStream out) {
+        super.connect(in, out);
+        reader = new BufferedReader(new InputStreamReader(in));
     }
 }


### PR DESCRIPTION
These methods can be overridden by subclasses of existing channels to write to/read from streams,
for example, to replay some captured stream,
or just to do some tests based on ByteArrayInputStream.

Sometimes, we may want to use the existing channels,
but not necessarily to connect them to a TCP/IP endpoint,
for instance, we may want to input data from a file directly as an input of the channel.

Here, there is an example I'm using to read XML messages from a file or standard input:

```java
public class XMLInputFileChannel extends XMLChannel implements AutoCloseable{
    public XMLInputFileChannel() throws ISOException {
        this(System.in);
    }
    public XMLInputFileChannel(InputStream in) throws ISOException {
        this(in, new XMLPackager());
    }

    public XMLInputFileChannel(XMLPackager packager){
        this(System.in, packager);
    }

    public XMLInputFileChannel(InputStream in, XMLPackager packager) {
        connect(in, null);
        setPackager(packager);
        
    }

    @Override
    public void close() throws IOException {
        disconnect();
    }

    @Override
    public boolean isConnected() {
        return super.isConnected() || (usable && serverIn != null);
    }
}
```