### PR TITLE
add padding to ARQC verification in JCESecurityModule

### DIFF
--- a/jpos/src/main/java/org/jpos/emv/IssuerApplicationData.java
+++ b/jpos/src/main/java/org/jpos/emv/IssuerApplicationData.java
@@ -57,7 +57,7 @@ public final class IssuerApplicationData implements Loggeable {
 
         Objects.requireNonNull(hexIAD, "IAD data cannot be null.");
 
-        iad = hexIAD.trim();
+        iad = hexIAD.trim().toUpperCase();
 
         if (iad.length() < 14)
             throw new IllegalArgumentException("Invalid IAD length.");

--- a/jpos/src/main/java/org/jpos/emv/IssuerApplicationData.java
+++ b/jpos/src/main/java/org/jpos/emv/IssuerApplicationData.java
@@ -57,7 +57,7 @@ public final class IssuerApplicationData implements Loggeable {
 
         Objects.requireNonNull(hexIAD, "IAD data cannot be null.");
 
-        iad = hexIAD.trim().toUpperCase();
+        iad = hexIAD.trim();
 
         if (iad.length() < 14)
             throw new IllegalArgumentException("Invalid IAD length.");

--- a/jpos/src/main/java/org/jpos/emv/IssuerApplicationData.java
+++ b/jpos/src/main/java/org/jpos/emv/IssuerApplicationData.java
@@ -70,7 +70,7 @@ public final class IssuerApplicationData implements Loggeable {
             //Therefore, the length of the Issuer Application Data is 18 bytes and for 
             // M/Chip Advance it may be 18, 20, 26, or 28.
             unpackMCHIP(iad);
-        } else if (len == 32 && iad.startsWith("0F") && iad.startsWith("0F", 32)) {
+        } else if (len == 32 && (iad.startsWith("0F") || iad.startsWith("0f")) && (iad.startsWith("0F", 32) || iad.startsWith("0f", 32))) {
             // EMV_v4.3_Book_3
             // C7.2 Issuer Application Data for Format Code 'A'
             unpackEMVFormatA(iad);

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -2035,7 +2035,7 @@ public class BaseSMAdapter<T>
      * @param atc
      * @param upn
      * @param txnData
-     * @return true if ARQC/TC/AAC is falid or false if not
+     * @return true if ARQC/TC/AAC is valid or false if not
      * @throws SMException
      */
     protected boolean verifyARQCImpl(MKDMethod mkdm, SKDMethod skdm, T imkac

--- a/jpos/src/main/java/org/jpos/security/SKDMethod.java
+++ b/jpos/src/main/java/org/jpos/security/SKDMethod.java
@@ -32,33 +32,34 @@ package org.jpos.security;
  */
 public enum SKDMethod {
 
-   /**
-    * Visa Smart Debit/Credit or UKIS in England
-    * <br>
-    * Described in Visa Integrated Circuit Card
-    * Specification (VIS) Version 1.5 - May 2009, section B.4
-    */
-   VSDC
+    /**
+     * Visa Smart Debit/Credit or UKIS in England
+     * <br>
+     * Described in Visa Integrated Circuit Card
+     * Specification (VIS) Version 1.5 - May 2009, section B.4
+     */
+    VSDC,
 
-   /**
-    * MasterCard Proprietary SKD method
-    */
-  ,MCHIP
-   /**
-    * American Express
-    */
-  ,AEPIS_V40
+    /**
+     * MasterCard Proprietary SKD method
+     */
+    MCHIP,
 
-   /**
-    * EMV Common Session Key Derivation Method
-    * Described in EMV v4.2 Book 2 - June 2008, Annex A1.3
-    */
-  ,EMV_CSKD
+    /**
+     * American Express
+     */
+    AEPIS_V40,
 
-   /**
-    * EMV2000 Session Key Method
-    * Described in EMV 2000 v4.0 Book 2 - December 2000, Annex A1.3
-    */
-  ,EMV2000_SKM
+    /**
+     * EMV Common Session Key Derivation Method
+     * Described in EMV v4.2 Book 2 - June 2008, Annex A1.3
+     */
+    EMV_CSKD,
+
+    /**
+     * EMV2000 Session Key Method
+     * Described in EMV 2000 v4.0 Book 2 - December 2000, Annex A1.3
+     */
+    EMV2000_SKM,
 
 }

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -969,8 +969,6 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
                 break;
             case EMV_CSKD:
                 skac = deriveCommonSK_AC(mkac, atc);
-                byte [] padded =  paddingISO9797Method2(transData);
-                transData = padded;
                 break;
             default:
                 throw new SMException("Session Key Derivation "+skdm+" not supported");
@@ -1044,8 +1042,6 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
             case EMV_CSKD:
                 skac = deriveSK_MK(mkac, atc, new byte[4]);
                 skarpc = skac;
-                byte [] padded =  paddingISO9797Method2(transData);
-                transData = padded;
                 break;
             default:
                 throw new SMException("Session Key Derivation "+skdm+" not supported");

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -969,6 +969,8 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
                 break;
             case EMV_CSKD:
                 skac = deriveCommonSK_AC(mkac, atc);
+                byte [] padded =  paddingISO9797Method2(transData);
+                transData = padded;
                 break;
             default:
                 throw new SMException("Session Key Derivation "+skdm+" not supported");
@@ -1042,6 +1044,8 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
             case EMV_CSKD:
                 skac = deriveSK_MK(mkac, atc, new byte[4]);
                 skarpc = skac;
+                byte [] padded =  paddingISO9797Method2(transData);
+                transData = padded;
                 break;
             default:
                 throw new SMException("Session Key Derivation "+skdm+" not supported");

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -675,7 +675,7 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
      * </ul>
      * @param pan application primary account number
      * @param psn PAN Sequence Number
-     * @return 8-bytes representing first 16 digits
+     * @return 8-bytes representing rightmost 16 digits
      */
     private static byte[] formatPANPSNOptionA(String pan, String psn){
         if ( pan.length() < 14 )

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -34,7 +34,16 @@ import org.jpos.core.ConfigurationException;
 import org.jpos.core.SimpleConfiguration;
 import org.jpos.core.SubConfiguration;
 import org.jpos.iso.ISOUtil;
-import org.jpos.security.*;
+import org.jpos.security.ARPCMethod;
+import org.jpos.security.CipherMode;
+import org.jpos.security.EncryptedPIN;
+import org.jpos.security.KeyScheme;
+import org.jpos.security.MKDMethod;
+import org.jpos.security.PaddingMethod;
+import org.jpos.security.SKDMethod;
+import org.jpos.security.SMAdapter;
+import org.jpos.security.SMException;
+import org.jpos.security.SecureDESKey;
 import org.jpos.util.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -154,7 +163,7 @@ public class JCESecurityModuleTest {
      * Card Sequence Number
      */
     static final String accountNoA_CSN = "00";
-
+    
     /**
      * 19 digits account number
      */
@@ -196,9 +205,9 @@ public class JCESecurityModuleTest {
     }
 
     static class EMVTxnData {
-
+ 
       Map<String, byte[]> dm;
-
+ 
       EMVTxnData() {
           dm = new HashMap<String, byte[]>();
           dm.put("AMMOUNT",           ISOUtil.hex2byte("000000010000"));
@@ -1826,53 +1835,6 @@ public class JCESecurityModuleTest {
             "E09B073B4007541FAB76B04370451031",
             "4CBF5D51EA8525EF045EFED6E386D9D9");
         assertArrayEquals(ISOUtil.hex2byte("40D522"), sdk.getKeyCheckValue(), "3: KeyCheck was " + ISOUtil.hexString(sdk.getKeyCheckValue()));
-    }
-
-
-    /**
-     *  Test Data is based of EMV Issuer and Application Security Guidelines v3.0  Annex A.3.3 - Example of ARQC Generation
-     */
-    @Test
-    public void TestARQCGeneration() throws Throwable {
-
-        String PAN = "5413339000006165";
-        String PANSeqNo = "00";
-        String amount = "000000010000";
-        String amount_other = "000000001000";
-        String terminalCountryCode = "0840";
-        String terminalVerificationResult = "0000001080";
-        String transactionCurrencyCode = "0840";
-        String transactionDate = "980704";
-        String transactionType = "00";
-        String unpredictableNumber = "11111111";
-        String applicationInterchangeProfile = "5800";
-        String applicationTransactionCounter = "3456";
-        String IssuerApplicationData = "0FA500A03800000000000000000000000F010000000000000000000000000000";
-
-        byte[] k = ISOUtil.hex2byte("9E15204313F7318ACB79B90BD986AD29");
-
-        SecureDESKey kek =  jcesecmod.generateKey(SMAdapter.LENGTH_DES, SMAdapter.TYPE_RSA_PK);
-        byte[] encKey = jcesecmod.encryptData(CipherMode.ECB, kek, k , new byte[8]);
-        SecureDESKey mkac =  jcesecmod.importKey((short) 128, SMAdapter.TYPE_MK_AC, encKey, kek, false);
-
-        byte[] d = ISOUtil.hex2byte(
-                amount
-                + amount_other
-                + terminalCountryCode
-                + terminalVerificationResult
-                + transactionCurrencyCode
-                + transactionDate
-                + transactionType
-                + unpredictableNumber
-                + applicationInterchangeProfile
-                + applicationTransactionCounter
-                + IssuerApplicationData
-        );
-
-        boolean result = jcesecmod.verifyARQC(MKDMethod.OPTION_A, SKDMethod.EMV_CSKD, mkac, PAN, PANSeqNo,ISOUtil.hex2byte("C20039270FE384D5") ,ISOUtil.hex2byte(applicationTransactionCounter), ISOUtil.hex2byte(unpredictableNumber), d);
-
-        assertTrue( result);
-
     }
 
 }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -34,16 +34,7 @@ import org.jpos.core.ConfigurationException;
 import org.jpos.core.SimpleConfiguration;
 import org.jpos.core.SubConfiguration;
 import org.jpos.iso.ISOUtil;
-import org.jpos.security.ARPCMethod;
-import org.jpos.security.CipherMode;
-import org.jpos.security.EncryptedPIN;
-import org.jpos.security.KeyScheme;
-import org.jpos.security.MKDMethod;
-import org.jpos.security.PaddingMethod;
-import org.jpos.security.SKDMethod;
-import org.jpos.security.SMAdapter;
-import org.jpos.security.SMException;
-import org.jpos.security.SecureDESKey;
+import org.jpos.security.*;
 import org.jpos.util.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -163,7 +154,7 @@ public class JCESecurityModuleTest {
      * Card Sequence Number
      */
     static final String accountNoA_CSN = "00";
-    
+
     /**
      * 19 digits account number
      */
@@ -205,9 +196,9 @@ public class JCESecurityModuleTest {
     }
 
     static class EMVTxnData {
- 
+
       Map<String, byte[]> dm;
- 
+
       EMVTxnData() {
           dm = new HashMap<String, byte[]>();
           dm.put("AMMOUNT",           ISOUtil.hex2byte("000000010000"));
@@ -1835,6 +1826,53 @@ public class JCESecurityModuleTest {
             "E09B073B4007541FAB76B04370451031",
             "4CBF5D51EA8525EF045EFED6E386D9D9");
         assertArrayEquals(ISOUtil.hex2byte("40D522"), sdk.getKeyCheckValue(), "3: KeyCheck was " + ISOUtil.hexString(sdk.getKeyCheckValue()));
+    }
+
+
+    /**
+     *  Test Data is based of EMV Issuer and Application Security Guidelines v3.0  Annex A.3.3 - Example of ARQC Generation
+     */
+    @Test
+    public void TestARQCGeneration() throws Throwable {
+
+        String PAN = "5413339000006165";
+        String PANSeqNo = "00";
+        String amount = "000000010000";
+        String amount_other = "000000001000";
+        String terminalCountryCode = "0840";
+        String terminalVerificationResult = "0000001080";
+        String transactionCurrencyCode = "0840";
+        String transactionDate = "980704";
+        String transactionType = "00";
+        String unpredictableNumber = "11111111";
+        String applicationInterchangeProfile = "5800";
+        String applicationTransactionCounter = "3456";
+        String IssuerApplicationData = "0FA500A03800000000000000000000000F010000000000000000000000000000";
+
+        byte[] k = ISOUtil.hex2byte("9E15204313F7318ACB79B90BD986AD29");
+
+        SecureDESKey kek =  jcesecmod.generateKey(SMAdapter.LENGTH_DES, SMAdapter.TYPE_RSA_PK);
+        byte[] encKey = jcesecmod.encryptData(CipherMode.ECB, kek, k , new byte[8]);
+        SecureDESKey mkac =  jcesecmod.importKey((short) 128, SMAdapter.TYPE_MK_AC, encKey, kek, false);
+
+        byte[] d = ISOUtil.hex2byte(
+                amount
+                + amount_other
+                + terminalCountryCode
+                + terminalVerificationResult
+                + transactionCurrencyCode
+                + transactionDate
+                + transactionType
+                + unpredictableNumber
+                + applicationInterchangeProfile
+                + applicationTransactionCounter
+                + IssuerApplicationData
+        );
+
+        boolean result = jcesecmod.verifyARQC(MKDMethod.OPTION_A, SKDMethod.EMV_CSKD, mkac, PAN, PANSeqNo,ISOUtil.hex2byte("C20039270FE384D5") ,ISOUtil.hex2byte(applicationTransactionCounter), ISOUtil.hex2byte(unpredictableNumber), d);
+
+        assertTrue( result);
+
     }
 
 }


### PR DESCRIPTION
this is related to issue #573.

according to EMV book 2 Application Cryptogram Generation,  the data should be padded  according to  ISO9797 method 2 .

I see that JCESecurityModule.java has a private implementation for the padding method but it is not used in ARQC verification , while it is being used in ARPC calculation and generateSM_MACImpl.  

i am not sure if Visa and and MasterCard  requires the same or different padding,  but at least  it is part of  common core definitions.  

i have added a Test unit for ARQC generation using data based on EMV®Issuer and Application Security Guidelines  v3.0 A.3.3 - ARQC Generation.

this pull request also include some text corrections and a fix for Issuer application data not matching if the hex string is lowercase.  