### PR TITLE
master: Add annotation functionality to jPos participant.

### DIFF
--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation libraries.sleepycat_je
     implementation libraries.sshd
     implementation libraries.eddsa
+    implementation libraries.bytebuddy
+    implementation libraries.commons_lang3
 
     testImplementation libraries.commons_lang3
     testImplementation libraries.hamcrest

--- a/jpos/libraries.gradle
+++ b/jpos/libraries.gradle
@@ -25,7 +25,8 @@ ext {
         slf4j_api: "org.slf4j:slf4j-api:1.7.32",
         slf4j_nop: "org.slf4j:slf4j-nop:1.7.32",
         hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.12',
-        yaml: "org.yaml:snakeyaml:2.0"
+        yaml: "org.yaml:snakeyaml:2.0",
+        bytebuddy: "net.bytebuddy:byte-buddy:1.14.10"
     ]
 }
 

--- a/jpos/src/main/java/org/jpos/annotation/AnnotatedParticipant.java
+++ b/jpos/src/main/java/org/jpos/annotation/AnnotatedParticipant.java
@@ -1,0 +1,12 @@
+package org.jpos.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface AnnotatedParticipant{
+
+}

--- a/jpos/src/main/java/org/jpos/annotation/ContextKey.java
+++ b/jpos/src/main/java/org/jpos/annotation/ContextKey.java
@@ -1,0 +1,12 @@
+package org.jpos.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface ContextKey {
+    public String value();
+}

--- a/jpos/src/main/java/org/jpos/annotation/Prepare.java
+++ b/jpos/src/main/java/org/jpos/annotation/Prepare.java
@@ -1,0 +1,14 @@
+package org.jpos.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jpos.transaction.TransactionConstants;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Prepare {
+    public int result() default TransactionConstants.PREPARED;
+}

--- a/jpos/src/main/java/org/jpos/annotation/Registry.java
+++ b/jpos/src/main/java/org/jpos/annotation/Registry.java
@@ -1,0 +1,12 @@
+package org.jpos.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Registry {
+    public String value() default "";
+}

--- a/jpos/src/main/java/org/jpos/annotation/Return.java
+++ b/jpos/src/main/java/org/jpos/annotation/Return.java
@@ -1,0 +1,12 @@
+package org.jpos.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Return {
+    String[] value();
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/Priority.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/Priority.java
@@ -1,0 +1,7 @@
+package org.jpos.annotation.resolvers;
+
+public interface Priority {    
+    default int getPriority() {
+        return 10;
+    }
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/ResolverFactory.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/ResolverFactory.java
@@ -1,0 +1,63 @@
+package org.jpos.annotation.resolvers;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jpos.annotation.resolvers.exception.ReturnExceptionHandler;
+import org.jpos.annotation.resolvers.exception.ReturnExceptionHandlerProvider;
+import org.jpos.annotation.resolvers.parameters.Resolver;
+import org.jpos.annotation.resolvers.parameters.ResolverServiceProvider;
+import org.jpos.annotation.resolvers.response.ReturnHandler;
+import org.jpos.annotation.resolvers.response.ReturnHandlerProvider;
+import org.jpos.core.ConfigurationException;
+
+public class ResolverFactory {
+    public static final ResolverFactory INSTANCE = new ResolverFactory();
+    
+    protected final ResolverProviderList resolvers = new ResolverProviderList();
+    
+    private ResolverFactory() {}
+    
+    public Resolver getResolver(Parameter p) throws ConfigurationException {
+        Resolver r = null;
+        for (ResolverServiceProvider f: resolvers.getResolvers()) {
+            if (f.isMatch(p)) {
+                r = f.resolve(p);
+                r.configure(p);
+                break;
+            }
+        }
+        if (r == null) {
+            throw new ConfigurationException("Prepare parameter " + p.getName() + " does not have the required annotation.");                            
+        }
+        return r;
+    }
+    
+    public ReturnHandler getReturnHandler(Method m) throws ConfigurationException {
+        ReturnHandler r = null;
+        for (ReturnHandlerProvider f: resolvers.getReturnHandlers()) {
+            if (f.isMatch(m)) {
+                r = f.resolve(m);
+                r.configure(m);
+                break;
+            }
+        }
+        if (r == null) {
+            throw new ConfigurationException("Could not find a valid provider for return " + m.getName());                            
+        }
+        return r;
+    }
+    
+    public List<ReturnExceptionHandler> getExceptionHandlers(Method m) {
+        List<ReturnExceptionHandler> exceptionHandlers = new ArrayList<>();
+        for(ReturnExceptionHandlerProvider p: resolvers.getExceptionResolvers()) {
+            ReturnExceptionHandler r = p.resolve(m);
+            r.configure(m);
+            exceptionHandlers.add(r);
+        }
+        return exceptionHandlers;
+    }
+
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/ResolverProviderList.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/ResolverProviderList.java
@@ -1,0 +1,41 @@
+package org.jpos.annotation.resolvers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.jpos.annotation.resolvers.exception.ReturnExceptionHandlerProvider;
+import org.jpos.annotation.resolvers.parameters.ResolverServiceProvider;
+import org.jpos.annotation.resolvers.response.ReturnHandlerProvider;
+
+public class ResolverProviderList {
+    protected final List<ResolverServiceProvider> resolvers = new ArrayList<>();
+    protected final List<ReturnHandlerProvider> resultHandlers = new ArrayList<>();
+    protected final List<ReturnExceptionHandlerProvider> exceptionHandlers = new ArrayList<>();
+
+    ResolverProviderList() {
+        loadServiceProviders(resolvers, ResolverServiceProvider.class);
+        loadServiceProviders(resultHandlers, ReturnHandlerProvider.class);
+        loadServiceProviders(exceptionHandlers, ReturnExceptionHandlerProvider.class);
+    }
+    
+    protected <T extends Priority> void loadServiceProviders(List<T> list, Class<T> svcClass) {
+        ServiceLoader<T> svcLoader = ServiceLoader.load(svcClass);
+        for(T serviceImp: svcLoader) {
+            list.add(serviceImp);
+        }
+        list.sort((o1, o2) -> Integer.compare(o1.getPriority(), o2.getPriority()));
+    }
+    
+
+    public List<ReturnHandlerProvider> getReturnHandlers() {
+        return resultHandlers;
+    }
+    public List<ReturnExceptionHandlerProvider> getExceptionResolvers() {
+        return exceptionHandlers;
+    }
+
+    public List<ResolverServiceProvider> getResolvers() {
+        return resolvers;
+    }
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/exception/GenericExceptionHandlerProvider.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/exception/GenericExceptionHandlerProvider.java
@@ -1,0 +1,39 @@
+package org.jpos.annotation.resolvers.exception;
+
+import java.lang.reflect.Method;
+
+import org.jpos.rc.CMF;
+import org.jpos.transaction.Context;
+import org.jpos.transaction.TransactionConstants;
+import org.jpos.transaction.TransactionParticipant;
+
+public class GenericExceptionHandlerProvider implements ReturnExceptionHandlerProvider {
+    static class GenericExceptionHandler implements ReturnExceptionHandler {
+
+        @Override
+        public boolean isMatch(Throwable e) {
+            return getException(e, Exception.class) != null;
+        }
+
+        @Override
+        public int doReturn(TransactionParticipant p, Context ctx, Throwable t) {
+            ctx.log("prepare exception in " + this.getClass().getName());
+            ctx.log(t);
+            setResultCode(ctx, CMF.INTERNAL_ERROR);
+
+            return TransactionConstants.ABORTED;
+        }
+        
+    }
+
+    @Override
+    public ReturnExceptionHandler resolve(Method m) {
+        return new GenericExceptionHandler();
+    }
+    
+    @Override
+    public int getPriority() {
+        return Integer.MAX_VALUE;
+    }
+    
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/exception/ReturnExceptionHandler.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/exception/ReturnExceptionHandler.java
@@ -1,0 +1,27 @@
+package org.jpos.annotation.resolvers.exception;
+
+import java.lang.reflect.Method;
+
+import org.jpos.rc.IRC;
+import org.jpos.transaction.Context;
+import org.jpos.transaction.ContextConstants;
+import org.jpos.transaction.TransactionParticipant;
+
+public interface ReturnExceptionHandler {
+    boolean isMatch(Throwable e);
+    int doReturn(TransactionParticipant p, Context ctx, Throwable obj);
+
+    default void configure(Method m) {}
+    
+    default void setResultCode(Context ctx, IRC irc) {
+        ctx.put(ContextConstants.IRC, irc);
+    }
+    
+    default <T> T getException(Throwable e, Class<T> type) {
+        int stackDepth= 10;
+        do {
+            if (type.isAssignableFrom(e.getClass())) return (T) e;
+        } while (null != (e = e.getCause()) && stackDepth-- > 0);
+        return null;
+    }
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/exception/ReturnExceptionHandlerProvider.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/exception/ReturnExceptionHandlerProvider.java
@@ -1,0 +1,9 @@
+package org.jpos.annotation.resolvers.exception;
+
+import java.lang.reflect.Method;
+
+import org.jpos.annotation.resolvers.Priority;
+
+public interface ReturnExceptionHandlerProvider extends Priority {
+    ReturnExceptionHandler resolve(Method m);    
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/parameters/ContextPassThruResolver.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/parameters/ContextPassThruResolver.java
@@ -1,0 +1,29 @@
+package org.jpos.annotation.resolvers.parameters;
+
+import java.lang.reflect.Parameter;
+
+import org.jpos.transaction.Context;
+import org.jpos.transaction.TransactionParticipant;
+
+public class ContextPassThruResolver implements ResolverServiceProvider {
+
+    @Override
+    public boolean isMatch(Parameter p) {
+        return Context.class.isAssignableFrom(p.getType());
+    }
+    
+    @Override
+    public int getPriority() {
+        return 1000;
+    }
+
+    @Override
+    public Resolver resolve(Parameter p) {
+        return new Resolver() {
+            @Override
+            public <T> T getValue(TransactionParticipant participant, Context ctx) {
+                return (T) ctx;
+            }
+        };
+    }
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/parameters/ContextResolver.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/parameters/ContextResolver.java
@@ -1,0 +1,33 @@
+package org.jpos.annotation.resolvers.parameters;
+
+import java.lang.reflect.Parameter;
+
+import org.jpos.annotation.ContextKey;
+import org.jpos.transaction.Context;
+import org.jpos.transaction.TransactionParticipant;
+
+public class ContextResolver implements ResolverServiceProvider {
+
+    @Override
+    public boolean isMatch(Parameter p) {
+        return p.isAnnotationPresent(ContextKey.class);
+    }
+
+    @Override
+    public Resolver resolve(Parameter p) {
+        return new Resolver() {
+            String ctxKey;
+
+            @Override
+            public void configure(Parameter f) {
+                ContextKey annotation = f.getAnnotation(ContextKey.class);
+                ctxKey = annotation.value();
+            }
+
+            @Override
+            public <T> T getValue(TransactionParticipant participant, Context ctx) {
+                return ctx.get(ctxKey);
+            }
+        };
+    }
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/parameters/RegistryResolver.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/parameters/RegistryResolver.java
@@ -1,0 +1,85 @@
+package org.jpos.annotation.resolvers.parameters;
+
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jpos.annotation.Registry;
+import org.jpos.core.ConfigurationException;
+import org.jpos.transaction.Context;
+import org.jpos.transaction.TransactionParticipant;
+import org.jpos.util.NameRegistrar;
+
+
+public class RegistryResolver implements ResolverServiceProvider {
+    private static final class RegistryResolverImpl implements Resolver {
+        String registryKey;
+
+        @Override
+        public void configure(Parameter f) throws ConfigurationException {
+            Registry annotation = f.getAnnotation(Registry.class);
+            registryKey = findKey(annotation.value(), f.getType(), NameRegistrar.getAsMap());
+            if (StringUtils.isEmpty(registryKey)) {
+                throw new ConfigurationException("Could not find Registry entry for " + f.getName());
+            }
+        }
+
+        @Override
+        public <T> T getValue(TransactionParticipant participant, Context ctx) {
+            return NameRegistrar.getIfExists(registryKey);
+        }
+
+        String findKey(String key, Class<?> type, Map<?, ?> entries) throws ConfigurationException {
+            if (entries.containsKey(key)) {
+                return key;
+            }
+            List<String> typeMatches = new ArrayList<>();
+            List<String> keyMatches = new ArrayList<>();
+            findPotentialMatches(key, type, entries, typeMatches, keyMatches);
+            return getMatch(key, typeMatches, keyMatches);
+        }
+
+        protected String getMatch(String key, List<String> typeMatches, List<String> keyMatches)
+                throws ConfigurationException {
+            if (StringUtils.isNotBlank(key)) {
+                return getMatch(key, keyMatches);
+            } else {
+                return getMatch(key, typeMatches);
+            }
+        }
+
+        protected void findPotentialMatches(String key, Class<?> type, Map<?, ?> entries, List<String> typeMatches,
+                List<String> keyMatches) {
+            for (Entry<?, ?> entry: entries.entrySet()) {
+                String mKey = String.valueOf(entry.getKey());
+                if (mKey.equalsIgnoreCase(key)) {
+                    keyMatches.add(mKey);
+                }
+                if (type.isAssignableFrom(entry.getValue().getClass())) {
+                    typeMatches.add(mKey);
+                }
+            }
+        }
+
+        protected String getMatch(String key, List<String> keyMatches) throws ConfigurationException {
+            switch(keyMatches.size()) {
+            case 0: return null;
+            case 1: return keyMatches.get(0);
+            default : throw new ConfigurationException("Found multiple matches for key " + key);      
+            }
+        }
+    }
+
+    @Override
+    public boolean isMatch(Parameter p) {
+        return p.isAnnotationPresent(org.jpos.annotation.Registry.class);
+    }
+
+    @Override
+    public Resolver resolve(Parameter p) {
+        return new RegistryResolverImpl();
+    }
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/parameters/Resolver.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/parameters/Resolver.java
@@ -1,0 +1,13 @@
+package org.jpos.annotation.resolvers.parameters;
+
+import java.lang.reflect.Parameter;
+
+import org.jpos.core.ConfigurationException;
+import org.jpos.transaction.Context;
+import org.jpos.transaction.TransactionParticipant;
+
+public interface Resolver {
+    default void configure(Parameter f) throws ConfigurationException {
+    }
+    <T> T getValue(TransactionParticipant participant, Context ctx);
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/parameters/ResolverServiceProvider.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/parameters/ResolverServiceProvider.java
@@ -1,0 +1,10 @@
+package org.jpos.annotation.resolvers.parameters;
+
+import java.lang.reflect.Parameter;
+
+import org.jpos.annotation.resolvers.Priority;
+
+public interface ResolverServiceProvider extends Priority {
+    boolean isMatch(Parameter p);
+    Resolver resolve(Parameter p);
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/response/IntPassthruContextReturnHandler.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/response/IntPassthruContextReturnHandler.java
@@ -1,0 +1,18 @@
+package org.jpos.annotation.resolvers.response;
+
+import java.lang.reflect.Method;
+
+import org.jpos.annotation.Return;
+
+public class IntPassthruContextReturnHandler implements ReturnHandlerProvider {
+
+    @Override
+    public boolean isMatch(Method m) {
+        return !m.isAnnotationPresent(Return.class) && int.class.isAssignableFrom(m.getReturnType());
+    }
+
+    @Override
+    public ReturnHandler resolve(Method m) {
+        return (participant, ctx, res) -> (int) res;
+    }    
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/response/MultiValueContextReturnHandler.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/response/MultiValueContextReturnHandler.java
@@ -1,0 +1,35 @@
+package org.jpos.annotation.resolvers.response;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.jpos.annotation.Prepare;
+import org.jpos.annotation.Return;
+
+public class MultiValueContextReturnHandler implements ReturnHandlerProvider {
+    @Override
+    public boolean isMatch(Method m) {        
+        if (Map.class.isAssignableFrom(m.getReturnType()) && m.isAnnotationPresent(Return.class)) {
+            Return r = m.getAnnotation(Return.class);
+            return r.value().length > 1;
+       }
+        
+        return false;
+    }
+
+    @Override
+    public ReturnHandler resolve(Method m) {
+        Return r = m.getAnnotation(Return.class);
+        final String[] keys = r.value();
+        final int jPosRes = m.getAnnotation(Prepare.class).result();
+        return (participant, ctx, res) -> {
+            Map resMap = (Map) res;
+            for(String key: keys) {
+                if (resMap != null && resMap.containsKey(key)) {
+                    ctx.put(key, resMap.get(key));
+                }
+            }
+            return jPosRes;
+        };
+    }
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/response/ReturnHandler.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/response/ReturnHandler.java
@@ -1,0 +1,12 @@
+package org.jpos.annotation.resolvers.response;
+
+import java.lang.reflect.Method;
+
+import org.jpos.transaction.Context;
+import org.jpos.transaction.TransactionParticipant;
+
+public interface ReturnHandler {
+    int doReturn(TransactionParticipant p, Context ctx, Object obj);
+    
+    default void configure(Method m) {}
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/response/ReturnHandlerProvider.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/response/ReturnHandlerProvider.java
@@ -1,0 +1,10 @@
+package org.jpos.annotation.resolvers.response;
+
+import java.lang.reflect.Method;
+
+import org.jpos.annotation.resolvers.Priority;
+
+public interface ReturnHandlerProvider extends Priority {
+    boolean isMatch(Method m);
+    ReturnHandler resolve(Method m);
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/response/SingleValueContextReturnHandler.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/response/SingleValueContextReturnHandler.java
@@ -1,0 +1,31 @@
+package org.jpos.annotation.resolvers.response;
+
+import java.lang.reflect.Method;
+
+import org.jpos.annotation.Prepare;
+import org.jpos.annotation.Return;
+
+public class SingleValueContextReturnHandler implements ReturnHandlerProvider {
+    @Override
+    public boolean isMatch(Method m) {        
+        if (m.isAnnotationPresent(Return.class) && !Void.TYPE.equals(m.getReturnType())) {
+            Return r = m.getAnnotation(Return.class);
+            return r.value().length == 1;
+       }
+        
+        return false;
+    }
+
+    @Override
+    public ReturnHandler resolve(Method m) {
+        Return r = m.getAnnotation(Return.class);
+        final String key = r.value()[0];
+        final int jPosRes = m.getAnnotation(Prepare.class).result();
+        return (participant, ctx, res) -> {
+            if (res != null) {
+                ctx.put(key, res);
+            }
+            return jPosRes;
+        };
+    }
+}

--- a/jpos/src/main/java/org/jpos/annotation/resolvers/response/VoidContextReturnHandler.java
+++ b/jpos/src/main/java/org/jpos/annotation/resolvers/response/VoidContextReturnHandler.java
@@ -1,0 +1,20 @@
+package org.jpos.annotation.resolvers.response;
+
+import java.lang.reflect.Method;
+
+import org.jpos.annotation.Prepare;
+import org.jpos.annotation.Return;
+
+public class VoidContextReturnHandler implements ReturnHandlerProvider {
+
+    @Override
+    public boolean isMatch(Method m) {
+        return Void.TYPE.equals(m.getReturnType()) && !m.isAnnotationPresent(Return.class);
+    }
+
+    @Override
+    public ReturnHandler resolve(Method m) {
+        final int jPosRes = m.getAnnotation(Prepare.class).result();
+        return (participant, ctx, res) -> jPosRes;
+    }    
+}

--- a/jpos/src/main/java/org/jpos/transaction/AnnotatedParticipantWrapper.java
+++ b/jpos/src/main/java/org/jpos/transaction/AnnotatedParticipantWrapper.java
@@ -1,0 +1,127 @@
+package org.jpos.transaction;
+
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jpos.annotation.AnnotatedParticipant;
+import org.jpos.annotation.Prepare;
+import org.jpos.annotation.resolvers.ResolverFactory;
+import org.jpos.annotation.resolvers.exception.ReturnExceptionHandler;
+import org.jpos.annotation.resolvers.parameters.Resolver;
+import org.jpos.annotation.resolvers.response.ReturnHandler;
+import org.jpos.core.ConfigurationException;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.bind.annotation.AllArguments;
+import net.bytebuddy.implementation.bind.annotation.Origin;
+import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+import net.bytebuddy.matcher.ElementMatchers;
+
+public class AnnotatedParticipantWrapper {
+
+    protected TransactionParticipant participant;
+    protected Method prepare;
+    
+    List<Resolver> args = new ArrayList<>();
+    ReturnHandler returnHandler;
+    List<ReturnExceptionHandler> exceptionHandlers;
+    Method checkPoint;
+
+    public static <T extends TransactionParticipant> T wrap(T participant) throws ConfigurationException {
+        try {
+            AnnotatedParticipantWrapper handler = new AnnotatedParticipantWrapper(participant);
+            return (T) new ByteBuddy()
+            .subclass(participant.getClass())
+            .method(ElementMatchers.any())
+            .intercept(MethodDelegation.to(handler))
+            .make()
+            .load(participant.getClass().getClassLoader())
+            .getLoaded()
+            .getDeclaredConstructor()
+            .newInstance();
+        } catch (Throwable e) {
+            throw new ConfigurationException("Cound not create the annotated wrapper", e);
+        }
+    }
+
+    public static boolean isMatch(TransactionParticipant participant) {
+        return participant.getClass().isAnnotationPresent(AnnotatedParticipant.class);
+    }
+
+    public AnnotatedParticipantWrapper(TransactionParticipant participant) throws ConfigurationException {
+        this.participant = participant;
+        configurePrepareMethod();
+        configureReturnHandler();
+        configureParameters();
+        
+    }
+
+    protected void configureReturnHandler() throws ConfigurationException {
+        returnHandler = ResolverFactory.INSTANCE.getReturnHandler(prepare);
+        exceptionHandlers = ResolverFactory.INSTANCE.getExceptionHandlers(prepare);
+    }
+
+    protected void configureParameters() throws ConfigurationException {
+        for(Parameter p: prepare.getParameters()) {
+            args.add(ResolverFactory.INSTANCE.getResolver(p));
+        }
+    }
+
+    protected void configurePrepareMethod() throws ConfigurationException {
+        for(Method m: participant.getClass().getMethods()) {
+            if (m.isAnnotationPresent(Prepare.class)) {
+                if (prepare == null) {
+                    prepare = m;
+                } else {
+                    throw new ConfigurationException("Only one method per class can be defined with the @Prepare. " + participant.getClass().getSimpleName() + " has multiple matches.");
+                }
+            }
+        }
+        if (prepare == null) {
+            throw new ConfigurationException(participant.getClass().getSimpleName() + " needs one method defined with the @Prepare annotation.");            
+        }
+    }
+
+
+    public final int prepare(long id, Serializable o) {
+        Context ctx = (Context) o;
+        try {
+            Object[] resolvedArgs = new Object[args.size()];
+            int i = 0;
+            for(Resolver r: args) {
+                resolvedArgs[i++] = r.getValue(participant, ctx);
+            }
+            Object res = prepare.invoke(participant, resolvedArgs);
+            
+            return returnHandler.doReturn(participant, ctx, res);
+        } catch (IllegalAccessException | IllegalArgumentException e) {
+            return processException(ctx, e);
+        } catch (InvocationTargetException e) {
+            return processException(ctx, e.getTargetException());
+        }
+    }
+
+    private int processException(Context ctx, Throwable e) {
+        ctx.log("Failed to execute " + prepare.toString());
+        ctx.log(e);
+        for(ReturnExceptionHandler handler: exceptionHandlers) {
+            if (handler.isMatch(e)) {
+                return handler.doReturn(participant, ctx, e);
+            }
+        }
+        throw new RuntimeException(e);
+    }
+
+    @RuntimeType
+    public Object intercept(@AllArguments Object[] args,
+                            @Origin Method method) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException { 
+        return method.invoke(participant, args);
+    }
+}
+
+

--- a/jpos/src/main/java/org/jpos/transaction/TransactionManager.java
+++ b/jpos/src/main/java/org/jpos/transaction/TransactionManager.java
@@ -820,6 +820,9 @@ public class TransactionManager
         if (participant instanceof Destroyable) {
             destroyables.add((Destroyable) participant);
         }
+        if (AnnotatedParticipantWrapper.isMatch(participant)) {
+            participant = AnnotatedParticipantWrapper.wrap(participant);
+        }
         return participant;
     }
 

--- a/jpos/src/main/resources/META-INF/services/org.jpos.annotation.resolvers.exception.ReturnExceptionHandlerProvider
+++ b/jpos/src/main/resources/META-INF/services/org.jpos.annotation.resolvers.exception.ReturnExceptionHandlerProvider
@@ -1,0 +1,1 @@
+org.jpos.annotation.resolvers.exception.GenericExceptionHandlerProvider

--- a/jpos/src/main/resources/META-INF/services/org.jpos.annotation.resolvers.parameters.ResolverServiceProvider
+++ b/jpos/src/main/resources/META-INF/services/org.jpos.annotation.resolvers.parameters.ResolverServiceProvider
@@ -1,0 +1,3 @@
+org.jpos.annotation.resolvers.parameters.ContextResolver
+org.jpos.annotation.resolvers.parameters.RegistryResolver
+org.jpos.annotation.resolvers.parameters.ContextPassThruResolver

--- a/jpos/src/main/resources/META-INF/services/org.jpos.annotation.resolvers.response.ReturnHandlerProvider
+++ b/jpos/src/main/resources/META-INF/services/org.jpos.annotation.resolvers.response.ReturnHandlerProvider
@@ -1,0 +1,4 @@
+org.jpos.annotation.resolvers.response.IntPassthruContextReturnHandler
+org.jpos.annotation.resolvers.response.MultiValueContextReturnHandler
+org.jpos.annotation.resolvers.response.SingleValueContextReturnHandler
+org.jpos.annotation.resolvers.response.VoidContextReturnHandler

--- a/jpos/src/test/java/org/jpos/transaction/AnnotatedParticipantWrapperTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/AnnotatedParticipantWrapperTest.java
@@ -1,0 +1,409 @@
+package org.jpos.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.jdom2.Document;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.jpos.annotation.AnnotatedParticipant;
+import org.jpos.annotation.ContextKey;
+import org.jpos.annotation.Prepare;
+import org.jpos.annotation.Registry;
+import org.jpos.annotation.Return;
+import org.jpos.core.Configuration;
+import org.jpos.core.ConfigurationException;
+import org.jpos.core.SimpleConfiguration;
+import org.jpos.q2.Q2;
+import org.jpos.q2.QFactory;
+import org.jpos.rc.IRC;
+import org.jpos.rc.CMF;
+import org.jpos.util.NameRegistrar;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.xml.sax.InputSource;
+
+public class AnnotatedParticipantWrapperTest {
+    
+    private static final String HANDLER = "handler";
+    
+    public static class TxnSupport implements TransactionParticipant {
+        public int  prepare(long id, Serializable context) {
+            return TransactionConstants.ABORTED;
+        }
+        
+        public void setConfiguration(Configuration cfg) {}
+    }
+
+    @AnnotatedParticipant
+    public static class AnnotatedParticipantTest extends TxnSupport {
+        @Prepare(result = TransactionConstants.PREPARED | TransactionConstants.READONLY)
+        @Return("CARD")
+        public Object getCard(Context ctx, @ContextKey("DB") Object db, @Registry Long someKey) throws Exception {
+            Assertions.assertNotNull(ctx);
+            Assertions.assertNotNull(db);
+            Assertions.assertEquals(2, someKey);
+            return new Object();
+        }
+    }
+        
+    public static class RegularParticipantTest extends TxnSupport {}
+    
+    @Test
+    public void testClassAnnotation() throws ConfigurationException {
+        Context ctx = new Context();
+        ctx.put("DB", new Object());
+        Configuration cfg = new SimpleConfiguration();
+        NameRegistrar.register("someKey", 2L);
+        
+        // Test plain participant
+        TxnSupport p = new RegularParticipantTest();
+        p.setConfiguration(cfg);
+        assertRegularParticipant(ctx, p, false);
+        
+        p = new AnnotatedParticipantTest();
+        p.setConfiguration(cfg);
+        // Test direct participant
+        assertRegularParticipant(ctx, p, true);
+        
+        // Test wrapper annotation
+        assertTrue(AnnotatedParticipantWrapper.isMatch(p));
+        TxnSupport pw = AnnotatedParticipantWrapper.wrap(p);
+        assertAnnotatedParticipant(ctx, pw);
+        
+    }
+    
+    @Test
+    public void testClassAnnotationFromTxnMgr() throws ConfigurationException, JDOMException, IOException, MalformedObjectNameException {
+        TransactionManager txnMgr = new TransactionManager();
+        Q2 q2 = mock(Q2.class);
+        QFactory f = spy(new QFactory(new ObjectName("Q2:type=system,service=loader"), q2));
+        when(q2.getFactory()).thenReturn(f);
+        doReturn(new RegularParticipantTest()).when(f).newInstance(RegularParticipantTest.class.getCanonicalName());
+        doReturn(new AnnotatedParticipantTest()).when(f).newInstance(AnnotatedParticipantTest.class.getCanonicalName());
+        txnMgr.setServer(q2);
+        txnMgr.setName("txnMgr");
+        txnMgr.setConfiguration(new SimpleConfiguration());
+        
+        String regParticipantXml = "<participant class=\"" + RegularParticipantTest.class.getCanonicalName() + "\"/>";
+        String annotatedParticipantXml = "<participant class=\"" + AnnotatedParticipantTest.class.getCanonicalName() + "\"/>";
+        
+        Context ctx = new Context();
+        ctx.put("DB", new Object());
+        NameRegistrar.register("someKey", 2L);
+        
+        TxnSupport p = (TxnSupport) getParticipant(txnMgr, regParticipantXml);
+        assertRegularParticipant(ctx, p, false);
+        
+        p = (TxnSupport) getParticipant(txnMgr, annotatedParticipantXml);
+        assertAnnotatedParticipant(ctx, p);
+    }
+        
+    
+    @AnnotatedParticipant
+    public static class InvalidParticipant extends TxnSupport {
+        public InvalidParticipant(Object arg) {}
+    }
+    
+    @AnnotatedParticipant
+    static class InvalidParticipantInvocation extends TxnSupport {
+        public InvalidParticipantInvocation() throws Exception {
+        }
+        
+        @Prepare
+        public void prepare() {}
+    }
+    
+    @Test
+    public void testWrapperInstantiationFailure() {
+        assertThrows(ConfigurationException.class, ()-> AnnotatedParticipantWrapper.wrap(new InvalidParticipant(null) {}));
+        assertThrows(ConfigurationException.class, ()-> AnnotatedParticipantWrapper.wrap(new InvalidParticipant(null)));
+        assertThrows(ConfigurationException.class, ()-> AnnotatedParticipantWrapper.wrap(new InvalidParticipantInvocation()));
+    }
+    
+    public static class PassthruReturn extends TaggingAnnotatedParticipant {
+        @Prepare
+        public int doWork() {
+            return 5;
+        }
+    }
+    
+    public static class MapMultiReturn extends TaggingAnnotatedParticipant {
+        @Prepare(result = 5)
+        @Return({"key1", "key2", "key3"})
+        public Map<String, Object> doWork(@ContextKey(HANDLER) Handler handler) throws Exception {
+            return handler == null ? null : (Map<String, Object>) handler.call();
+        }
+    }
+    
+    public static class MapSingleReturn extends TaggingAnnotatedParticipant {
+        @Prepare(result = 5)
+        @Return({"key1"})
+        public Map<String, Object> doWork(@ContextKey(HANDLER) Handler handler) throws Exception {
+            return handler == null ? null : (Map<String, Object>) handler.call();
+        }
+    }
+    
+    @Test
+    public void testReturnTypes() throws ConfigurationException {
+        assertEquals(5, AnnotatedParticipantWrapper.wrap(new PassthruReturn()).prepare(0, new Context()));
+        Context ctx = new Context();
+        assertEquals(5, AnnotatedParticipantWrapper.wrap(new MapMultiReturn()).prepare(0, ctx));
+        assertEquals(0, ctx.getMap().size());
+        testWithHandler(new MapMultiReturn(), ctx, ()-> new HashMap<String, String>() {{
+            put("a", "b");
+            put("c", "d");
+        }});
+        assertEquals(1, ctx.getMap().size());
+        ctx.getMap().clear();
+        
+        assertEquals(0, ctx.getMap().size());
+        testWithHandler(new MapMultiReturn(), ctx, ()-> new HashMap<String, String>() {{
+            put("key1", "b");
+            put("c", "d");
+        }});
+        assertEquals(2, ctx.getMap().size());
+        ctx.getMap().clear();
+        
+        assertEquals(0, ctx.getMap().size());
+        testWithHandler(new MapSingleReturn(), ctx, ()-> new HashMap<String, String>() {{
+            put("b", "b");
+            put("c", "d");
+        }});
+        assertEquals(2, ctx.getMap().size());
+        ctx.getMap().clear();
+        
+        testWithHandler(new MapSingleReturn(), ctx, null);
+        assertEquals(1, ctx.getMap().size());
+        assertTrue(ctx.getMap().containsKey(HANDLER));
+    }
+    
+    void testWithHandler(TransactionParticipant p, Context ctx, Handler handler) throws ConfigurationException {
+        ctx.put(HANDLER, handler);
+        assertEquals(5, AnnotatedParticipantWrapper.wrap(p).prepare(0, ctx));
+    }
+    
+    @AnnotatedParticipant
+    public static class TaggingAnnotatedParticipant implements TransactionParticipant {
+        @Override
+        public int prepare(long id, Serializable context) {
+            return TransactionConstants.ABORTED;
+        }
+    }
+    
+    public static interface Handler {
+       Object call() throws Exception;
+    }
+    
+    public static class HappyPass extends TaggingAnnotatedParticipant {
+        @Prepare
+        public void doNothing(@ContextKey(HANDLER) Handler handler, @ContextKey("DB") Object db) throws Exception {
+            if (handler != null) handler.call();
+        }
+    }
+    
+    public static class DoublePrepareDefined extends TaggingAnnotatedParticipant {
+        @Prepare
+        public void doNothing() {}
+        @Prepare
+        public void doNothing1() {}
+    }
+    public static class PreparedUnboundArg extends TaggingAnnotatedParticipant {
+        @Prepare
+        public void invalidParams(Object arg) {}
+    }
+    public static class MissingReturn extends TaggingAnnotatedParticipant {
+        @Prepare
+        public Map invalidParams() {
+            return null;
+        }
+    }
+    public static class UnusedReturn extends TaggingAnnotatedParticipant {
+        @Prepare
+        @Return("key")
+        public void invalidParams() {}
+    }
+    
+    public static class TooManyKeysDefined extends TaggingAnnotatedParticipant {
+        @Prepare
+        @Return({"key", "key1"})
+        public Object invalidReturn() {
+            return null;
+        }       
+    }
+    
+    
+    @Test
+    public void testWrapperInvalidAnnotationUse() throws ConfigurationException {
+        assertNotNull(AnnotatedParticipantWrapper.wrap(new HappyPass()));
+        
+        assertThrows(ConfigurationException.class, ()-> {
+            AnnotatedParticipantWrapper.wrap(new TaggingAnnotatedParticipant());
+        });
+        
+        assertThrows(ConfigurationException.class, ()-> {
+            AnnotatedParticipantWrapper.wrap(new DoublePrepareDefined());
+        });
+        
+        assertThrows(ConfigurationException.class, ()-> {
+            AnnotatedParticipantWrapper.wrap(new PreparedUnboundArg());
+        });
+        
+        assertThrows(ConfigurationException.class, ()-> {
+            AnnotatedParticipantWrapper.wrap(new MissingReturn());
+        });
+        
+        assertThrows(ConfigurationException.class, ()-> {
+            AnnotatedParticipantWrapper.wrap(new UnusedReturn());
+        });
+        
+        assertThrows(ConfigurationException.class, ()-> {
+            AnnotatedParticipantWrapper.wrap(new TooManyKeysDefined());
+        });
+    }
+    
+    
+    @Test
+    public void testParticipantExecutionErrorHandling() throws ConfigurationException {
+        TransactionParticipant p = AnnotatedParticipantWrapper.wrap(new HappyPass());
+        testException(p, ()-> {throw new RuntimeException();}, CMF.INTERNAL_ERROR);
+        final Exception circularCause = new Exception() {
+            public synchronized Throwable getCause() {
+                return this;
+            };
+        };
+        testException(p, ()-> {throw circularCause;}, CMF.INTERNAL_ERROR);        
+    }
+    
+    @Test
+    public void testUncaughtExceptionHandling() throws ConfigurationException {
+        TransactionParticipant p = AnnotatedParticipantWrapper.wrap(new HappyPass());
+        Handler h = ()->{throw new Error();};
+        Context ctx = new Context();
+        ctx.put(HANDLER, h);
+        
+        assertThrows(RuntimeException.class, ()->p.prepare(0, ctx));
+        
+    }
+
+    private void testException(TransactionParticipant p, Handler handler, IRC irc) {
+        Context ctx = new Context();
+        ctx.put(HANDLER, handler);
+        assertEquals(TransactionConstants.ABORTED, p.prepare(0, ctx));
+        assertEquals(irc, ctx.get(ContextConstants.IRC));
+    }
+    
+    @Test
+    public void testInvalidArgumentBinding() throws ConfigurationException {
+        Context ctx = new Context();
+        
+        TransactionParticipant p = AnnotatedParticipantWrapper.wrap(new HappyPass());
+
+        assertEquals(TransactionConstants.PREPARED, p.prepare(0, ctx));        
+        
+        ctx.put(HANDLER, new Object());
+        assertEquals(TransactionConstants.ABORTED, p.prepare(0, ctx));        
+        assertEquals(CMF.INTERNAL_ERROR, ctx.get(ContextConstants.IRC));
+    }
+    
+    public static class RegistryNameResolverTest extends TaggingAnnotatedParticipant {
+        @Prepare
+        public void checkRegistry(@Registry("key1") String key) {
+            assertEquals("key1", key);
+        }
+    }
+    
+    public static class RegistryTypeResolverTest extends TaggingAnnotatedParticipant {
+        @Prepare
+        public void checkRegistry(@Registry() String key) {
+            assertEquals("key1", key);
+        }
+    }
+    
+
+    
+    @Test
+    public void testNamedRegistryResolver() throws ConfigurationException {
+        Context ctx = new Context();
+        NameRegistrar.register("key1", "key1");        
+        TransactionParticipant p;
+        
+        p = AnnotatedParticipantWrapper.wrap(new RegistryTypeResolverTest());
+        assertEquals(TransactionConstants.PREPARED, p.prepare(0, ctx));
+        
+        p = AnnotatedParticipantWrapper.wrap(new RegistryNameResolverTest());
+        assertEquals(TransactionConstants.PREPARED, p.prepare(0, ctx));
+        NameRegistrar.unregister("key1");
+        
+        assertThrows(ConfigurationException.class, ()->AnnotatedParticipantWrapper.wrap(new RegistryNameResolverTest()));
+        assertThrows(ConfigurationException.class, ()->AnnotatedParticipantWrapper.wrap(new RegistryTypeResolverTest()));
+
+        NameRegistrar.register("KEY1", "key1");
+        p = AnnotatedParticipantWrapper.wrap(new RegistryTypeResolverTest());
+        assertEquals(TransactionConstants.PREPARED, p.prepare(0, ctx));
+        
+        p = AnnotatedParticipantWrapper.wrap(new RegistryNameResolverTest());
+        assertEquals(TransactionConstants.PREPARED, p.prepare(0, ctx));
+        NameRegistrar.register("KeY1", "key1");
+        assertThrows(ConfigurationException.class, ()->AnnotatedParticipantWrapper.wrap(new RegistryNameResolverTest()));
+        
+        NameRegistrar.unregister("KEY1");
+        NameRegistrar.unregister("KeY1");
+        
+        assertThrows(ConfigurationException.class, ()->AnnotatedParticipantWrapper.wrap(new RegistryNameResolverTest()));
+        assertThrows(ConfigurationException.class, ()->AnnotatedParticipantWrapper.wrap(new RegistryTypeResolverTest()));
+        
+        NameRegistrar.register("someKey", "key1");
+        assertThrows(ConfigurationException.class, ()->AnnotatedParticipantWrapper.wrap(new RegistryNameResolverTest()));
+        
+        p = AnnotatedParticipantWrapper.wrap(new RegistryTypeResolverTest());
+        assertEquals(TransactionConstants.PREPARED, p.prepare(0, ctx));
+        NameRegistrar.register("someKey1", "key1");
+        assertThrows(ConfigurationException.class, ()->AnnotatedParticipantWrapper.wrap(new RegistryTypeResolverTest()));
+
+        NameRegistrar.unregister("someKey");
+        NameRegistrar.unregister("someKey1");
+    }
+
+
+    protected void assertAnnotatedParticipant(Context ctx, TxnSupport p) {
+        assertEquals(TransactionConstants.PREPARED | TransactionConstants.READONLY, p.prepare(0, ctx));
+        assertNotNull(ctx.get(ContextConstants.CARD.name()));
+    }
+
+    protected void assertRegularParticipant(Context ctx, TxnSupport p, boolean ignoreAnnotation) {
+        if (!ignoreAnnotation) {
+            assertFalse(AnnotatedParticipantWrapper.isMatch(p));
+        }
+        assertEquals(TransactionConstants.ABORTED, p.prepare(0, ctx));
+        assertNull(ctx.get(ContextConstants.CARD.name()));
+    }
+
+    private TransactionParticipant getParticipant(TransactionManager txnMgr, String participantXml) throws JDOMException, IOException, ConfigurationException {
+        SAXBuilder builder = new SAXBuilder ();
+        builder.setFeature("http://xml.org/sax/features/namespaces", true);
+        builder.setFeature("http://apache.org/xml/features/xinclude", true);
+        Document doc = builder.build(new InputSource(new StringReader(participantXml)));
+        
+        return txnMgr.createParticipant(doc.getRootElement());
+        
+    }
+
+}


### PR DESCRIPTION
Application developers are very familiar with writing APIs and using annotations to wire things together. In addition, [IoC/Dependency Injection](https://en.wikipedia.org/wiki/Inversion_of_control) is an accepted standard across frameworks. JPos, on the other hand, uses a simple 2-phase commit interface to string together units of work called participants. Participants can be considered like filters strung together to perform a transaction in the web world. 

While writing participants in jPos is simple, the interface is straightforward. However, it has some drawbacks, mainly due to two factors: the lack of [IoC](https://en.wikipedia.org/wiki/Inversion_of_control) and the lack of a contract. This attempts to introduce IoC and a verifiable contract on the TransactionManager using annotations to enable parameters and return types on the prepare method. This should make JPos more developer-friendly by adding auto-binding of parameters.

For example, We convert the standard participant entry point int doPrepare(long id, Context ctx) to any custom method with parameter binding. 
```@prepare(return=PREPARED | READ_ONLY)
  @Result(CARD)
  protected Card findCard(@ContextKey(PAN) String pan, @DBAccess CardDAO cardDao) throws BLException {
```
This increases the code's readability and testability by specifying a contract and doing the injection at the transaction manager level. In this case, findCard only accesses PAN, needs access to the CardDAO object and returns a Card object. When testing, you only need to test card present or missing scenarios because you know this method cannot have any other side effects.

The annotations should be more familiar to any developer comfortable with API development using any current framework.

The power of this comes in with the contract. Suppose I wanted to boondoggle extra functionality into the FindCard participant. I can do so by using the Context, which can have side effects throughout the code without changing any test. However, with the annotated participant, the only thing that can be returned by the FindCard participant is the Card object, so no changes to the contract are allowed without a change to the signature.