### PR TITLE
Define padding method for each CryptogramDataBuilder

### DIFF
--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CPACryptogram.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CPACryptogram.java
@@ -4,14 +4,10 @@ import org.jpos.security.ARPCMethod;
 import org.jpos.security.MKDMethod;
 import org.jpos.security.SKDMethod;
 
-import org.jpos.emv.cryptogram.CryptogramDataBuilder.PaddingMethod;
-
 /**
  * Common Payment Application (CPA) Cryptogram Specification
  */
 public class CPACryptogram implements CryptogramSpec {
-
-    final PaddingMethod paddingMethod = CryptogramDataBuilder.ISO9797Method2;
 
     @Override
     public MKDMethod getMKDMethod() {

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CVN10DataBuilder.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CVN10DataBuilder.java
@@ -36,7 +36,6 @@ public class CVN10DataBuilder implements CryptogramDataBuilder {
         return approved ? "0000" : "9900";
     }
 
-
     @Override
     public String buildARQCRequest(TLVList data, IssuerApplicationData iad) {
         StringBuilder sb = new StringBuilder();
@@ -46,7 +45,7 @@ public class CVN10DataBuilder implements CryptogramDataBuilder {
     }
 
     @Override
-    public String buildARQCRequest_padded(TLVList data, IssuerApplicationData iad, PaddingMethod paddingMethod){
-        return paddingMethod.apply(buildARQCRequest(data, iad));
+    public PaddingMethod getPaddingMethod() {
+        return PaddingMethod.ISO9797Method1;
     }
 }

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CVN18DataBuilder.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CVN18DataBuilder.java
@@ -49,7 +49,7 @@ public class CVN18DataBuilder implements CryptogramDataBuilder {
     }
 
     @Override
-    public String buildARQCRequest_padded(TLVList data, IssuerApplicationData iad, PaddingMethod paddingMethod) {
-        return paddingMethod.apply(buildARQCRequest(data, iad));
+    public PaddingMethod getPaddingMethod() {
+        return PaddingMethod.ISO9797Method1;
     }
 }

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CVNCPADataBuilder.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CVNCPADataBuilder.java
@@ -20,7 +20,7 @@ public class CVNCPADataBuilder implements CryptogramDataBuilder {
     }
 
     @Override
-    public String buildARQCRequest_padded(TLVList data, IssuerApplicationData iad, PaddingMethod paddingMethod) {
-        return paddingMethod.apply(buildARQCRequest(data, iad));
+    public PaddingMethod getPaddingMethod() {
+        return PaddingMethod.ISO9797Method2;
     }
 }

--- a/jpos/src/main/java/org/jpos/emv/cryptogram/CVNMCDataBuilder.java
+++ b/jpos/src/main/java/org/jpos/emv/cryptogram/CVNMCDataBuilder.java
@@ -49,13 +49,12 @@ public class CVNMCDataBuilder implements CryptogramDataBuilder {
     }
 
     @Override
-    public String buildARQCRequest_padded(TLVList data, IssuerApplicationData iad, PaddingMethod paddingMethod) {
-        return paddingMethod.apply(buildARQCRequest(data, iad));
-    }
-
-    @Override
     public String getDefaultARPCRequest(boolean approved) {
         return approved ? "0012" : "9900";
     }
 
+    @Override
+    public PaddingMethod getPaddingMethod() {
+        return PaddingMethod.ISO9797Method2;
+    }
 }

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/CPACryptogramTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/CPACryptogramTest.java
@@ -12,10 +12,10 @@ public class CPACryptogramTest {
     @Test
     void test(){
         CPACryptogram spec = new CPACryptogram();
-        assertEquals(spec.paddingMethod, CryptogramDataBuilder.ISO9797Method2);
         assertEquals(spec.getMKDMethod(), MKDMethod.OPTION_A);
         assertEquals(spec.getSKDMethod(), SKDMethod.EMV_CSKD);
         assertEquals(spec.getARPCMethod(), ARPCMethod.METHOD_2);
         assertTrue(spec.getDataBuilder() instanceof CVNCPADataBuilder);
+        assertEquals(CryptogramDataBuilder.PaddingMethod.ISO9797Method2, spec.getDataBuilder().getPaddingMethod());
     }
 }

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/CVN10DataBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/CVN10DataBuilderTest.java
@@ -58,7 +58,7 @@ class CVN10DataBuilderTest {
 
         assertEquals(
                 "00000000010000000000000008400000000000084018123101ABCDEF101800000203000000000000",
-                builder.buildARQCRequest_padded(data, iad, builder.ISO9797Method1)
+                builder.buildARQCRequest_padded(data, iad)
         );
 
 

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/CVN18DataBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/CVN18DataBuilderTest.java
@@ -58,7 +58,7 @@ class CVN18DataBuilderTest {
 
         assertEquals(
                 "00000000010000000000000008400000000000084018123101ABCDEF101800000106011203000000",
-                builder.buildARQCRequest_padded(data, iad, builder.ISO9797Method1)
+                builder.buildARQCRequest_padded(data, iad)
         );
 
 

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/CVNCPADataBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/CVNCPADataBuilderTest.java
@@ -37,7 +37,7 @@ public class CVNCPADataBuilderTest {
 
         assertEquals(
                 "0000000100000000000010000840000000108008409807040011111111580034560FA500A03800000000000000000000000F01000000000000000000000000000080000000000000",
-                builder.buildARQCRequest_padded(data, iad, builder.ISO9797Method2)
+                builder.buildARQCRequest_padded(data, iad)
         );
     }
 }

--- a/jpos/src/test/java/org/jpos/emv/cryptogram/CryptogramDataBuilderTest.java
+++ b/jpos/src/test/java/org/jpos/emv/cryptogram/CryptogramDataBuilderTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Random;
 
-import static org.jpos.emv.cryptogram.CryptogramDataBuilder.*;
+import static org.jpos.emv.cryptogram.CryptogramDataBuilder.PaddingMethod.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
PR #577 introduced the ability to create padded ARQC data.
However, it still requires the caller to specify what padding method to use, while ideally this should be handled by the CryptogramDataBuilder internally.

This PR proposes the following changes:
- `buildARQCRequest_padded` signature change: Remove the padding method parameter and instead define the padding method for each CryptogramDataBuilder as a polymorphic method `getPaddingMethod`. The parameter removal causes no loss of flexibility as users may now override `getPaddingMethod` in a CryptogramDataBuilder subclass.
- `buildARQCRequest_padded` is moved up to the CryptogramDataBuilder interface as a default method to keep code DRY.
- `PaddingMethod` changed to enum, to enable `toString()`.

These are not breaking changes as they impact only 2.1.10-SNAPSHOT and 3.0.0-SNAPSHOT, but not proper releases yet.