### PR TITLE
Add the NoCardValidator class and use it in the SelectDestination participant

### DIFF
--- a/doc/src/asciidoc/ch09/participants/select_destination.adoc
+++ b/doc/src/asciidoc/ch09/participants/select_destination.adoc
@@ -46,12 +46,13 @@ the configuration, then the `default-destination` will be set.
 .SelectDestination Configuration Properties
 [cols="1,2,2", options="header"]
 |========================================================================================
-|Property            | Description                                       | Default Value
-|request             | ISOMsg used to derive destination                 | `REQUEST` 
-|destination         | Destination Context variable                      | `DESTINATION`
-|default-destination | If no routing found, route to this destination    | 
-|ignore-luhn         | Set to `true` to lift LUHN validation             | `false`
-|fail                | Set to `true` to fail if no route found           | `false`
+|Property                | Description                                    | Default Value
+|request                 | ISOMsg used to derive destination              | `REQUEST`
+|destination             | Destination Context variable                   | `DESTINATION`
+|default-destination     | If no routing found, route to this destination |
+|ignore-card-validations | Set to `true` to lift Card validations         | `false`
+|ignore-luhn             | Set to `true` to lift LUHN validation          | `false`
+|fail                    | Set to `true` to fail if no route found        | `false`
 |========================================================================================
 
 `SelectDestination` may place CMF failure messages in the Context, i.e.:

--- a/jpos/src/main/java/org/jpos/core/NoCardValidator.java
+++ b/jpos/src/main/java/org/jpos/core/NoCardValidator.java
@@ -1,0 +1,27 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2024 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.core;
+
+public class NoCardValidator implements CardValidator {
+
+	@Override
+	public void validate(Card card) throws InvalidCardException {
+        return;
+	}
+}

--- a/jpos/src/main/java/org/jpos/core/NoCardValidator.java
+++ b/jpos/src/main/java/org/jpos/core/NoCardValidator.java
@@ -20,8 +20,8 @@ package org.jpos.core;
 
 public class NoCardValidator implements CardValidator {
 
-	@Override
-	public void validate(Card card) throws InvalidCardException {
+    @Override
+    public void validate(Card card) throws InvalidCardException {
         return;
-	}
+    }
 }

--- a/jpos/src/main/java/org/jpos/transaction/participant/SelectDestination.java
+++ b/jpos/src/main/java/org/jpos/transaction/participant/SelectDestination.java
@@ -79,7 +79,8 @@ public class SelectDestination implements TransactionParticipant, Configurable, 
         this.requestName = cfg.get("request", ContextConstants.REQUEST.toString());
         this.destinationName = cfg.get ("destination", ContextConstants.DESTINATION.toString());
         this.defaultDestination = cfg.get("default-destination", null);
-        this.validator =  cfg.getBoolean("ignore-luhn") ?
+        this.validator = cfg.getBoolean("ignore-card-validations") ?
+          new NoCardValidator() : cfg.getBoolean("ignore-luhn") ?
           new IgnoreLuhnCardValidator() : Card.Builder.DEFAULT_CARD_VALIDATOR;
         this.failOnNoRoute = cfg.getBoolean("fail");
     }

--- a/jpos/src/test/java/org/jpos/transaction/participant/SelectDestinationTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/participant/SelectDestinationTest.java
@@ -151,6 +151,19 @@ public class SelectDestinationTest implements TransactionConstants {
         assertEquals("DEFAULT", ctx.getString(DESTINATION.toString()), "Invalid Destination");
     }
 
+    @Test
+    public void testNoCardValidator () {
+        cfg.put ("ignore-card-validations", "true");
+        p.setConfiguration(cfg);
+        Context ctx = new Context();
+        ctx.put (ContextConstants.REQUEST.toString(), createISOMsg("0000000000000001"));
+        int action = p.prepare(1L, ctx);
+        assertEquals (PREPARED | NO_JOIN | READONLY, action, "Action should be PREPARED|NO_JOIN|READONLY");
+        Result rc = ctx.getResult();
+        assertFalse(rc.hasFailures(), "No failures");
+        assertEquals("DEFAULT", ctx.getString(DESTINATION.toString()), "Invalid Destination");
+    }
+
 
     private ISOMsg createISOMsg(String pan) {
         ISOMsg m = new ISOMsg("2100");


### PR DESCRIPTION
The new `NoCardValidator` class was added. It is used in the `SelectDestination` participant to lift any card validations by setting the `ignore-card-validations` configuration property to `true`. It is `false` by default.