### PR TITLE
Move `padISO9797Method2` from `JCESecurityModule` to `ISOUtil`.

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOUtil.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOUtil.java
@@ -210,6 +210,21 @@ public class ISOUtil {
             d.append('0');
         return d.toString();
     }
+
+    /**
+     * Pads {@code data} as per ISO/IEC 9797-1, method 2.
+     * @param data Data to be padded.
+     * @return Returns {@code data} padded as per ISO/IEC 9797-1, method 2.
+     */
+    public static byte[] padISO9797Method2(byte[] data) {
+        byte[] t = new byte[data.length - data.length % 8 + 8];
+        System.arraycopy(data, 0, t, 0, data.length);
+        for (int i = data.length; i < t.length; i++)
+            t[i] = (byte) (i == data.length ? 0x80 : 0x00);
+        data = t;
+        return data;
+    }
+
     /**
      * converts to BCD
      * @param s - the number

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -551,24 +551,9 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
 
     private byte[] calculateIVCVC3(Key mkcvc3, byte[] data)
             throws JCEHandlerException {
-        byte[] paddedData = paddingISO9797Method2(data);
+        byte[] paddedData = ISOUtil.padISO9797Method2(data);
         byte[] mac = calculateMACISO9797Alg3(mkcvc3, paddedData);
         return Arrays.copyOfRange(mac,6,8);
-    }
-
-    /**
-     * ISO/IEC 9797-1 padding method 2
-     * @param d da to be padded
-     * @return padded data
-     */
-    private byte[] paddingISO9797Method2(byte[] d) {
-        //Padding - first byte 0x80 rest 0x00
-        byte[] t = new byte[d.length - d.length%8 + 8];
-        System.arraycopy(d, 0, t, 0, d.length);
-        for (int i=d.length;i<t.length;i++)
-          t[i] = (byte)(i==d.length?0x80:0x00);
-        d = t;
-        return d;
     }
 
     /**
@@ -825,11 +810,11 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
           case VSDC:
               //Add VSDC pin block padding
               clearPINBlock = ISOUtil.concat(new byte[]{0x08}, clearPINBlock);
-              clearPINBlock = paddingISO9797Method2(clearPINBlock);
+              clearPINBlock = ISOUtil.padISO9797Method2(clearPINBlock);
               break;
           case CCD:
               //Add CCD pin block padding
-              clearPINBlock = paddingISO9797Method2(clearPINBlock);
+              clearPINBlock = ISOUtil.padISO9797Method2(clearPINBlock);
               break;
           default:
         }
@@ -1073,7 +1058,7 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
                 b = ISOUtil.concat(arqc, arc);
                 if (propAuthData != null)
                     b = ISOUtil.concat(b, propAuthData);
-                b = paddingISO9797Method2(b);
+                b = ISOUtil.padISO9797Method2(b);
                 b = calculateMACISO9797Alg3(skarpc, b);
                 return Arrays.copyOf(b, 4);
             default:
@@ -1093,12 +1078,12 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
         switch(skdm){
           case VSDC:
             smi = deriveSK_VISA(mksmi, atc);
-            data = paddingISO9797Method2(data);
+            data = ISOUtil.padISO9797Method2(data);
             break;
           case MCHIP:
           case EMV_CSKD:
             smi = deriveCommonSK_SM(mksmi,arqc);
-            data = paddingISO9797Method2(data);
+            data = ISOUtil.padISO9797Method2(data);
             break;
           default:
             throw new SMException("Session Key Derivation "+skdm+" not supported");

--- a/jpos/src/test/java/org/jpos/iso/ISOUtilTest.java
+++ b/jpos/src/test/java/org/jpos/iso/ISOUtilTest.java
@@ -433,6 +433,16 @@ public class ISOUtilTest {
     }
 
     @Test
+    public void testpadISO9797Method2() {
+        byte[] data = ISOUtil.hex2byte("010203");
+        byte[] result = ISOUtil.padISO9797Method2(data);
+        assertEquals("0102038000000000", ISOUtil.hexString(result));
+        data = ISOUtil.hex2byte("01020304010203");
+        result = ISOUtil.padISO9797Method2(data);
+        assertEquals("0102030401020380", ISOUtil.hexString(result));
+    }
+
+    @Test
     public void testByte2BitSet() throws Throwable {
         byte[] b = new byte[9];
         BitSet result = ISOUtil.byte2BitSet(b, 0, true);

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -240,7 +240,7 @@ public class JCESecurityModuleTest {
       }
 
       byte[] getDataPad80() {
-          return paddingISO9797Method2(getDataNoPad());
+          return ISOUtil.padISO9797Method2(getDataNoPad());
       }
 
       byte[] getATC() {
@@ -250,22 +250,6 @@ public class JCESecurityModuleTest {
       byte[] getUPN() {
           return dm.get("UPN");
       }
-
-    }
-
-    /**
-     * ISO/IEC 9797-1 padding method 2
-     * @param d da to be padded
-     * @return padded data
-     */
-    static byte[] paddingISO9797Method2(byte[] d) {
-        //Padding - first byte 0x80 rest 0x00
-        byte[] t = new byte[d.length - d.length%8 + 8];
-        System.arraycopy(d, 0, t, 0, d.length);
-        for (int i=d.length;i<t.length;i++)
-          t[i] = (byte)(i==d.length?0x80:0x00);
-        d = t;
-        return d;
     }
 
     @Test


### PR DESCRIPTION
This PR moves the `paddingISO9797Method2` method from `JCESecurityModule` to `ISOUtil`, renaming it to `padISO9797Method2`. This change exposes the method through a public API, allowing for reuse both inside and outside the jPOS library.