### PR TITLE
Avoid exceptions when dumping ctx

### DIFF
--- a/jpos/src/main/java/org/jpos/transaction/Context.java
+++ b/jpos/src/main/java/org/jpos/transaction/Context.java
@@ -279,14 +279,12 @@ public class Context implements Externalizable, Loggeable, Pausable, Cloneable {
     }
 
     protected void dumpMap (PrintStream p, String indent) {
-        if (map != null) {
-            Map<Object,Object> cloned;
-            cloned = Collections.synchronizedMap (new LinkedHashMap<>());
-            synchronized(map) {
-                cloned.putAll(map);
-            }
-            cloned.entrySet().forEach(e -> dumpEntry(p, indent, e));
+        Map<Object,Object> m = getMap();
+        Map<Object,Object> cloned = Collections.synchronizedMap (new LinkedHashMap<>());
+        synchronized(m) {
+            cloned.putAll(m);
         }
+        cloned.entrySet().forEach(e -> dumpEntry(p, indent, e));
     }
 
     protected void dumpEntry (PrintStream p, String indent, Map.Entry<Object,Object> entry) {
@@ -298,7 +296,11 @@ public class Context implements Externalizable, Loggeable, Pausable, Cloneable {
         Object value = entry.getValue();
         if (value instanceof Loggeable) {
             p.println("");
-            ((Loggeable) value).dump(p, indent + " ");
+            try {
+                ((Loggeable) value).dump(p, indent + " ");
+            } catch (Exception ex) {
+                ex.printStackTrace(p);
+            }
             p.print(indent);
         } else if (value instanceof Element) {
             p.println("");
@@ -329,10 +331,15 @@ public class Context implements Externalizable, Loggeable, Pausable, Cloneable {
             ((LogEvent) value).dump(p, indent);
             p.print(indent);
         } else if (value != null) {
-            LogUtil.dump(p, indent, value.toString());
+            try {
+                LogUtil.dump(p, indent, value.toString());
+            } catch (Exception ex) {
+                ex.printStackTrace(p);
+            }
         }
         p.println();
     }
+
     /**
      * return a LogEvent used to store trace information
      * about this transaction.
@@ -402,7 +409,7 @@ public class Context implements Externalizable, Loggeable, Pausable, Cloneable {
     public PausedTransaction getPausedTransaction(long timeout) {
         return get (PAUSED_TRANSACTION.toString(), timeout);
     }
-    
+
     public void setTimeout (long timeout) {
         this.timeout = timeout;
     }


### PR DESCRIPTION
When dumping the transaction manager context entries, if an exception was thrown in the `dump()` of a `Loggeable` or the `toString()` of the last-resort case for printing an entry value, then the context dump would explode with the exception.

This had two problems:
1) leaving an incomplete context dump
2) leaving an **invalid XML** log
For example
```xml
<log realm="org.jpos.transaction.TransactionManager" at="2024-11-21T12:38:49.741993" lifespan="130ms">
  <abort>
    ...
    <context>
    ...some ctx entries...
    ...some ctx entries...
      ACCOUNT: org.hibernate.LazyInitializationException: could not initialize proxy [org.jpos.gl.FinalAccount#1980] - no Session
    at org.hibernate.proxy.AbstractLazyInitializer.initialize(AbstractLazyInitializer.java:176)
    at org.hibernate.proxy.AbstractLazyInitializer.getImplementation(AbstractLazyInitializer.java:322)
    ... (more stack trace) ...
</log>
```

As can be seen, the `toString()` of the  **value** for the `ACCOUNT` entry (some hibernate proxy in the example, but it's irrelevant to the explanation), threw an **`Exception`**.

The rest of the ctx is not dumped, but worse: `</context>` and `</abort>` are not closed.

This PR fixes that.