### PR TITLE
Avoid exceptions when dumping ctx

### DIFF
--- a/jpos/src/main/java/org/jpos/transaction/Context.java
+++ b/jpos/src/main/java/org/jpos/transaction/Context.java
@@ -440,7 +440,11 @@ public class Context implements Externalizable, Loggeable, Cloneable, Pausable {
         Object value = entry.getValue();
         if (value instanceof Loggeable) {
             p.println();
-            ((Loggeable) value).dump(p, indent + " ");
+            try {
+                ((Loggeable) value).dump(p, indent + " ");
+            } catch (Exception ex) {
+                ex.printStackTrace(p);
+            }
             p.print(indent);
         } else if (value instanceof Element) {
             p.println();
@@ -470,10 +474,15 @@ public class Context implements Externalizable, Loggeable, Cloneable, Pausable {
             ((LogEvent) value).dump(p, indent);
             p.print(indent);
         } else if (value != null) {
-            LogUtil.dump(p, indent, value.toString());
+            try {
+                LogUtil.dump(p, indent, value.toString());
+            } catch (Exception ex) {
+                ex.printStackTrace(p);
+            }
         }
         p.println();
     }
+
     /**
      * return a LogEvent used to store trace information
      * about this transaction.


### PR DESCRIPTION
This is equivalente to the `master` fix https://github.com/jpos/jPOS/pull/624
but for the `next` branch