### PR TITLE
Add reset method to Metrics

### DIFF
--- a/jpos/src/main/java/org/jpos/util/Metrics.java
+++ b/jpos/src/main/java/org/jpos/util/Metrics.java
@@ -120,4 +120,13 @@ public class Metrics implements Loggeable {
     public void setConversion(double conversion) {
         this.conversion = conversion;
     }
+    
+    /**
+     * Reset any value counts accumulated thus far.
+     */
+    public void reset() {
+        metrics.values()
+               .forEach(Histogram::reset);
+    }
+ 
 }


### PR DESCRIPTION
Continuous counts at times may need a reset for grabbing values per iteration.
e.g. pull metrics info every minute, consume them and reset it , so that the metrics hold info for the poll interval.