### PR TITLE
Export `org.jpos.iso.channel.*` via JPMS

### DIFF
--- a/jpos/src/main/java/module-info.java
+++ b/jpos/src/main/java/module-info.java
@@ -23,6 +23,7 @@ module org.jpos.jpos {
     requires org.bouncycastle.provider;
     //    requires net.i2p.crypto.eddsa;
 
+    exports org.jpos.iso.channel;
     exports org.jpos.iso.packager;
     exports org.jpos.iso.validator;
     exports org.jpos.iso;


### PR DESCRIPTION
JPMS-export built-in channels that are not exported in the 3.0 release. I can't seem to find the reason of the exclusions of channels, but if I missed anything please close the PR.