### PR TITLE
Fix channel name split issue in JPOS 3

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOServer.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOServer.java
@@ -653,7 +653,7 @@ public class ISOServer extends Observable
             WeakReference ref = (WeakReference) entry.getValue();
             ISOChannel c = (ISOChannel) ref.get ();
             if (c != null && !LAST.equals (entry.getKey()) && c.isConnected()) {
-                if (i > 0) {
+                if (i > 0 && !sb.isEmpty()) {
                     sb.append (' ');
                 }
                 sb.append (entry.getKey());

--- a/jpos/src/main/java/org/jpos/q2/iso/QServer.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QServer.java
@@ -348,11 +348,12 @@ public class QServer
             }
             else if ("ALL".equals(sendMethod)) {
                 String channelNames = getISOChannelNames();
+                String[] channelName;
                 if (channelNames != null) {
-                    StringTokenizer tok = new StringTokenizer(channelNames, " ");
-                    while (tok.hasMoreTokens()) {
+                    channelName = channelNames.split(" (?=\\d+ \\S+:\\S+)");
+                    for (String s : channelName) {
                         try {
-                            ISOChannel c = server.getISOChannel(tok.nextToken());
+                            ISOChannel c = server.getISOChannel(s);
                             if (c == null) {
                                 throw new ISOException("Server has no active connections");
                             }
@@ -368,15 +369,9 @@ public class QServer
             }
             else if ("RR".equals(sendMethod)) {
                 String channelNames = getISOChannelNames();
-                int i =0;
                 String[] channelName;
                 if (channelNames != null) {
-                    StringTokenizer tok = new StringTokenizer(channelNames, " ");
-                    channelName = new String[tok.countTokens()];
-                    while (tok.hasMoreTokens()) {
-                        channelName[i] = tok.nextToken();
-                        i++;
-                    }
+                    channelName = channelNames.split(" (?=\\d+ \\S+:\\S+)");
                     try {
                         ISOChannel c = server.getISOChannel(channelName[msgn.incrementAndGet() % channelName.length]);
                         if (c == null) {


### PR DESCRIPTION
In JPOS 2, the channel name format is `{IP:port}`, but in JPOS 3, it changes to `{LocalPort} {IP:Port}` (with a space between them). However, QServer splits the channel name based only on **spaces**, which causes unexpected behavior.
```
StringTokenizer tok = new StringTokenizer(channelNames, " ");
channelName = new String[tok.countTokens()];
```

Example:
Given the value of getISOChannelNames() returned by JPOS 3 is 
`10011 127.0.0.1:12345 10012 127.0.0.1:12346  10013 127.0.0.1:12346`
Going thru the StringTokenizer, it will become this 
channelName[0] = 10011
channelName[1] = 127.0.0.1:12345
channelName[2] = 10012
channelName[3] = 127.0.0.1:12346
Attached a photo during debugging 
![image](https://github.com/user-attachments/assets/4392c813-9ca4-404c-87cf-9599183034aa)

![image](https://github.com/user-attachments/assets/5aec1b6b-1ae2-4c2b-b33e-b72bb25f63fc)


Fix the issue by providing a new regex.
Attach a photo of regrex checker 
![image](https://github.com/user-attachments/assets/14438845-f185-4e7a-9435-c64ef98db6a8)

Add `!sb.isEmpty()` to the condition. Without it, `getChannelNames()` will start with an empty space.
![image](https://github.com/user-attachments/assets/5aec1b6b-1ae2-4c2b-b33e-b72bb25f63fc)