### PR TITLE
New Zimbabwe Gold currency ZWG

### DIFF
--- a/jpos/src/main/resources/org/jpos/iso/ISOCurrency.properties
+++ b/jpos/src/main/resources/org/jpos/iso/ISOCurrency.properties
@@ -1,4 +1,4 @@
 BYN=933 2 // Belarusian Ruble BELARUS added in July 1st not available in Java8
 VES=928 2 // VENEZUELA (BOLIVARIAN REPUBLIC OF) ISO 4217 AMENDMENT NUMBER 166
 SLE=925 2 // Effective 1 April 2022 the ISO 4217 code for the Sierra Leone redenominated monetary unit will be SLE. 
-
+ZWG=924 2 // ZIMBABWE (Zimbabwe Gold) ISO 4217 AMENDMENT NUMBER 177 added on June 20th, 2024

--- a/jpos/src/test/java/org/jpos/iso/ISOCurrencyTest.java
+++ b/jpos/src/test/java/org/jpos/iso/ISOCurrencyTest.java
@@ -317,7 +317,8 @@ public class ISOCurrencyTest {
         c.put("504", "MAD"); cD.put("504", 2); // Moroccan Dirham WESTERN SAHARA 
         c.put("886", "YER"); cD.put("886", 2); // Yemeni Rial YEMEN 
         c.put("967", "ZMW"); cD.put("967", 2); // Zambian Kwacha ZAMBIA 
-        c.put("932", "ZWL"); cD.put("932", 2); // Zimbabwe Dollar ZIMBABWE 
+        c.put("932", "ZWL"); cD.put("932", 2); // Zimbabwe Dollar ZIMBABWE
+        c.put("924", "ZWG"); cD.put("924", 2); // Zimbabwe Gold ZIMBABWE
         
         StringBuilder msg = new StringBuilder();
         


### PR DESCRIPTION
ZIMBABWE (Zimbabwe Gold) ISO 4217 AMENDMENT NUMBER 177 added on June 20th, 2024