### PR TITLE
Fix FSDMsg pack on field with separator to not unpad

### DIFF
--- a/jpos/src/main/java/org/jpos/util/FSDMsg.java
+++ b/jpos/src/main/java/org/jpos/util/FSDMsg.java
@@ -247,6 +247,11 @@ public class FSDMsg implements Loggeable, Cloneable {
         return pack().getBytes(charset);
     }
 
+	    protected String get (String id, String type, int length, String defValue, String separator)
+        throws ISOException
+    {
+	    return get(id,type,length,defValue,separator,true);
+    }
     protected String get (String id, String type, int length, String defValue, String separator, boolean unPad)
         throws ISOException
     {

--- a/jpos/src/main/java/org/jpos/util/FSDMsg.java
+++ b/jpos/src/main/java/org/jpos/util/FSDMsg.java
@@ -27,8 +27,15 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
 
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -240,7 +247,7 @@ public class FSDMsg implements Loggeable, Cloneable {
         return pack().getBytes(charset);
     }
 
-    protected String get (String id, String type, int length, String defValue, String separator)
+    protected String get (String id, String type, int length, String defValue, String separator, boolean unPad)
         throws ISOException
     {
         String value = fields.get (id);
@@ -288,7 +295,7 @@ public class FSDMsg implements Loggeable, Cloneable {
                 break;
         }
 
-        if (lengthLength == 0 && (!isSeparated(separator) || isBinary(type) || EOM_SEPARATOR.equals(separator)))
+        if (lengthLength == 0 && (!isSeparated(separator) || isBinary(type) || EOM_SEPARATOR.equals(separator) ||(isSeparated(separator) && !unPad)))
           return value;
         else {
             if (lengthLength > 0) {
@@ -373,6 +380,10 @@ public class FSDMsg implements Loggeable, Cloneable {
             if (type != null && separator == null) {
             	separator = getSeparatorType (type);
             }
+            boolean unPad = true;
+            if (separator != null && elem.getAttributeValue("pack_unpad") != null) {
+                unPad = Boolean.valueOf(elem.getAttributeValue("pack_unpad"));
+            }
             boolean key  = "true".equals (elem.getAttributeValue ("key"));
             Map properties = key ? loadProperties(elem) : Collections.EMPTY_MAP;
             String defValue = elem.getText();
@@ -380,7 +391,7 @@ public class FSDMsg implements Loggeable, Cloneable {
             if (!properties.isEmpty()) {
             	defValue = defValue.replace("\n", "").replace("\t", "").replace("\r", "");
             }
-            String value = get (id, type, length, defValue, separator);
+            String value = get (id, type, length, defValue, separator, unPad);
             sb.append (value);
 
             if (isSeparated(separator)) {


### PR DESCRIPTION
If the new attribute pack_unpad with value false is added to the field, pack will not unpad (remove trailing spaces from the field).

If the attribute is absent or true backward compatibility is maintained by unpadding the field i.e. stripping the trailing spaces.