### PR TITLE
Correct use of serverOutLock in some channels

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/channel/ASCIIChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/ASCIIChannel.java
@@ -113,9 +113,12 @@ public class ASCIIChannel extends BaseChannel {
                 if ((l=Integer.parseInt(new String(b))) == 0 &&
                     isExpectKeepAlive()) {
 
-                    synchronized (serverOutLock) {
+                    serverOutLock.lock();
+                    try {
                         serverOut.write(b);
                         serverOut.flush();
+                    } finally {
+                        serverOutLock.unlock();
                     }
                 }
             } catch (NumberFormatException e) {

--- a/jpos/src/main/java/org/jpos/iso/channel/CSChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/CSChannel.java
@@ -71,7 +71,7 @@ public class CSChannel extends BaseChannel {
      * @exception IOException
      * @see ISOPackager
      */
-    public CSChannel (ISOPackager p, ServerSocket serverSocket) 
+    public CSChannel (ISOPackager p, ServerSocket serverSocket)
         throws IOException
     {
         super(p, serverSocket);
@@ -96,9 +96,11 @@ public class CSChannel extends BaseChannel {
         while (l == 0) {
             serverIn.readFully(b,0,4);
             l = ((int)b[0] &0xFF) << 8 | (int)b[1] &0xFF;
-            if (replyKeepAlive && l == 0) {
+            if (l == 0 &&
+                (replyKeepAlive || isExpectKeepAlive()))
+            {
+                serverOutLock.lock();
                 try {
-                    serverOutLock.lock();
                     serverOut.write(b);
                     serverOut.flush();
                 } finally {
@@ -108,9 +110,9 @@ public class CSChannel extends BaseChannel {
         }
         return l;
     }
-    protected int getHeaderLength() { 
+    protected int getHeaderLength() {
         // CS Channel does not support header
-        return 0; 
+        return 0;
     }
     protected void sendMessageHeader(ISOMsg m, int len) {
         // CS Channel does not support header


### PR DESCRIPTION
In jPOS 3, `BaseChannel.serverOutLock` is now a `ReentrantLock`.
There was some older code trying to use it as a synchronized monitor object.

This PR fixes the usage for `ASCIIChannel` and a some minor fixes for `CSChannel` and  `AmexChannel` (includes a lot of indentation changes form tabs to space, sorry... but you can ignore whitespace changes)

