### PR TITLE
fix(test): fix timing flakes in ChronometerTest and ThroughputControlTestCase

### DIFF
--- a/jpos/src/test/java/org/jpos/util/ChronometerTest.java
+++ b/jpos/src/test/java/org/jpos/util/ChronometerTest.java
@@ -18,12 +18,34 @@
 
 package org.jpos.util;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ChronometerTest {
-    private long TOLERANCE = 200L;
+    // Generous tolerance to absorb JVM cold-start and OS scheduler jitter,
+    // especially when running the full test suite under load.
+    // A 1-second ceiling on a 25 ms sleep still reliably catches bugs where
+    // elapsed() returns 0, wraps, measures in wrong units, etc.
+    private long TOLERANCE = 1000L;
+
+    /**
+     * Prime the JVM timer infrastructure before any timing-sensitive tests run.
+     * Without this, the very first Thread.sleep() can measure several hundred
+     * milliseconds due to JVM class-loading and timer-thread initialisation,
+     * causing spurious failures in the assertions below.
+     */
+    @BeforeAll
+    static void warmUp() throws InterruptedException {
+        for (int i = 0; i < 5; i++) {
+            Chronometer w = new Chronometer();
+            Thread.sleep(20);
+            w.elapsed();
+            w.lap();
+        }
+    }
+
     @Test
     public void testElapsed() throws InterruptedException {
         Chronometer c = new Chronometer();

--- a/jpos/src/test/java/org/jpos/util/ThroughputControlTestCase.java
+++ b/jpos/src/test/java/org/jpos/util/ThroughputControlTestCase.java
@@ -67,8 +67,8 @@ public class ThroughputControlTestCase {
           "50 transactions should take at least 4 seconds but took " + elapsed
         );
         assertTrue(
-          elapsed < 4500L,
-          "50 transactions shouldn't take more than approximately 4.5 seconds but took " + elapsed
+          elapsed < 6000L,
+          "50 transactions shouldn't take more than approximately 6 seconds but took " + elapsed
         );
 
 


### PR DESCRIPTION
### ChronometerTest
- Add `@BeforeAll warmUp()` — 5 × `sleep(20)` + `elapsed()`/`lap()` iterations to prime JVM timer threads before assertions run
- Increase `TOLERANCE` 200 ms → 1000 ms to absorb OS scheduler jitter when running under a loaded full-suite build; still reliably catches real bugs (elapsed returning 0, wrong units, negative values, etc.)

**Root cause**: `Thread.sleep(25)` measured 300–440 ms on a cold JVM due to timer-thread initialisation. Warmup alone is insufficient under full test-suite load (parallel worker contention), hence the wider ceiling.

### ThroughputControlTestCase.testFifty
- Widen upper bound 4500 ms → 6000 ms

The minimum (4000 ms for 10 tps × 50 tx) is deterministic; the 500 ms ceiling was too tight on a loaded machine (failed at 4586 ms).