### PR TITLE
feat: structured JSONL logging with tags, PCI protection, and flat me…

### DIFF
--- a/jpos/src/dist/deploy/00_logger.xml
+++ b/jpos/src/dist/deploy/00_logger.xml
@@ -3,23 +3,9 @@
 <logger name="Q2" class="org.jpos.q2.qbean.LoggerAdaptor" realm="system">
   <property name="redirect" value="stdout, stderr" />
 
-  <log-listener class="org.jpos.util.SimpleLogListener" enabled="${log.simple:true}" />
-
-  <log-listener class="org.jpos.util.SimpleLogListener" enabled="${log.xml:false}">
-    <writer class="org.jpos.util.XmlLogWriter" enabled="true" />
+  <log-listener class="org.jpos.util.SimpleLogListener">
+    <writer class="org.jpos.util.JsonlLogWriter" enabled="true" />
   </log-listener>
-
-  <log-listener class="org.jpos.util.SimpleLogListener" enabled="${log.json:false}">
-    <writer class="org.jpos.util.JsonLogWriter" enabled="true" />
-  </log-listener>
-
-  <log-listener class="org.jpos.util.SimpleLogListener" enabled="${log.markdown:false}">
-    <writer class="org.jpos.util.MarkdownLogWriter" enabled="true" />
-  </log-listener>
-
-<!--  <log-listener class="org.jpos.util.SimpleLogListener" enabled="true">-->
-<!--    <writer class="org.jpos.util.TxtLogWriter" enabled="true" />-->
-<!--  </log-listener>-->
 
   <log-listener class="org.jpos.util.DailyLogListener" enabled="true">
     <property name="window" value="86400" /> <!-- optional, default one day -->

--- a/jpos/src/main/java/org/jpos/iso/BaseChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/BaseChannel.java
@@ -667,6 +667,7 @@ public abstract class BaseChannel extends Observable
             m.setPackager (p);
             m = applyOutgoingFilters (m, evt);
             evt.addMessage (m);
+            applyTags (evt, m);
             m.setDirection(ISOMsg.OUTGOING); // filter may have dropped this info
             m.setPackager (p); // and could have dropped packager as well
             byte[] b = pack(m);
@@ -848,6 +849,7 @@ public abstract class BaseChannel extends Observable
                 unpack (m, b);
             m.setDirection(ISOMsg.INCOMING);
             evt.addMessage (m);
+            applyTags (evt, m);
             m = applyIncomingFilters (m, header, b, evt);
             m.setDirection(ISOMsg.INCOMING);
             cnt[RX]++;
@@ -1261,5 +1263,21 @@ public abstract class BaseChannel extends Observable
         if (isoMsgMetrics != null) {
             isoMsgMetrics.recordMessage(m, MeterInfo.ISOMSG_OUT);
         }
+    }
+    private void applyTags (LogEvent evt, ISOMsg m) {
+        if (m.hasField(3)) {
+            String f3 = m.getString(3);
+            if (f3 != null && f3.length() >= 2)
+                evt.withTag("pcode", f3.substring(0, 2));
+        }
+        if (m.hasField(41))
+            evt.withTag("tid", m.getString(41));
+        if (m.hasField(42))
+            evt.withTag("mid", m.getString(42));
+        try {
+            String mti = m.getMTI();
+            if (mti != null)
+                evt.withTag("mti", mti);
+        } catch (ISOException ignored) { }
     }
 }

--- a/jpos/src/main/java/org/jpos/log/AuditLogEvent.java
+++ b/jpos/src/main/java/org/jpos/log/AuditLogEvent.java
@@ -47,4 +47,4 @@ import org.jpos.log.evt.*;
   @JsonSubTypes.Type(value = Txn.class, name = "txn")
 })
 
-public sealed interface AuditLogEvent permits Connect, Deploy, DeployActivity, Disconnect, License, Listen, LogMessage, SessionEnd, SessionStart, Shutdown, Start, Stop, SysInfo, ThrowableAuditLogEvent, Txn, UnDeploy, Warning { }
+public interface AuditLogEvent { }

--- a/jpos/src/main/java/org/jpos/log/evt/LogEvt.java
+++ b/jpos/src/main/java/org/jpos/log/evt/LogEvt.java
@@ -18,6 +18,7 @@
 
 package org.jpos.log.evt;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -25,12 +26,12 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.jpos.log.AuditLogEvent;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 @JacksonXmlRootElement(localName = "log")
 public record LogEvt(
   @JacksonXmlProperty(isAttribute = true) Instant ts,
-  @JacksonXmlProperty(isAttribute = true) @JsonProperty("trace-id") String traceId,
-  @JacksonXmlProperty(isAttribute = true) String realm,
-  @JacksonXmlProperty(isAttribute = true) String tag,
+  @JacksonXmlProperty(isAttribute = true) String kind,
   @JacksonXmlProperty(isAttribute = true) Long lifespan,
-  @JsonProperty("evt") @JacksonXmlElementWrapper(useWrapping = false) List<AuditLogEvent> events) { }
+  @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String,String> tags,
+  @JsonProperty("payload") @JacksonXmlElementWrapper(useWrapping = false) List<AuditLogEvent> events) { }

--- a/jpos/src/main/java/org/jpos/log/render/json/LogEventJsonLogRenderer.java
+++ b/jpos/src/main/java/org/jpos/log/render/json/LogEventJsonLogRenderer.java
@@ -36,7 +36,9 @@ import org.jpos.util.Loggeable;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public final class LogEventJsonLogRenderer implements LogRenderer<LogEvent> {
     private final ObjectMapper mapper = new ObjectMapper();
@@ -64,10 +66,9 @@ public final class LogEventJsonLogRenderer implements LogRenderer<LogEvent> {
         long elapsed = Duration.between(evt.getCreatedAt(), evt.getDumpedAt()).toMillis();
         LogEvt ev = new LogEvt (
           evt.getDumpedAt(),
-          evt.getTraceId(),
-          evt.getRealm(),
           evt.getTag(),
           elapsed == 0L ? null : elapsed,
+          buildTags(evt),
           events
         );
         try {
@@ -81,6 +82,16 @@ public final class LogEventJsonLogRenderer implements LogRenderer<LogEvent> {
     }
     public Type type() {
         return Type.JSON;
+    }
+
+    private Map<String,String> buildTags(LogEvent evt) {
+        evt.getTraceId(); // ensure trace-id is generated
+        Map<String,String> tags = new LinkedHashMap<>();
+        String realm = evt.getRealm();
+        if (realm != null && !realm.isEmpty())
+            tags.put("realm", realm);
+        tags.putAll(evt.getTags());
+        return tags;
     }
 
     private String dump (Object obj) {

--- a/jpos/src/main/java/org/jpos/log/render/xml/LogEventXmlLogRenderer.java
+++ b/jpos/src/main/java/org/jpos/log/render/xml/LogEventXmlLogRenderer.java
@@ -36,7 +36,9 @@ import org.jpos.util.Loggeable;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public final class LogEventXmlLogRenderer implements LogRenderer<LogEvent> {
     private final XmlMapper mapper = new XmlMapper();
@@ -65,10 +67,9 @@ public final class LogEventXmlLogRenderer implements LogRenderer<LogEvent> {
         long elapsed = Duration.between(evt.getCreatedAt(), evt.getDumpedAt()).toMillis();
         LogEvt ev = new LogEvt (
           evt.getDumpedAt(),
-          evt.getTraceId(),
-          evt.getRealm(),
           evt.getTag(),
           elapsed == 0L ? null : elapsed,
+          buildTags(evt),
           events
         );
         try {
@@ -82,6 +83,16 @@ public final class LogEventXmlLogRenderer implements LogRenderer<LogEvent> {
     }
     public Type type() {
         return Type.XML;
+    }
+
+    private Map<String,String> buildTags(LogEvent evt) {
+        evt.getTraceId(); // ensure trace-id is generated
+        Map<String,String> tags = new LinkedHashMap<>();
+        String realm = evt.getRealm();
+        if (realm != null && !realm.isEmpty())
+            tags.put("realm", realm);
+        tags.putAll(evt.getTags());
+        return tags;
     }
 
     private String kv (String k, String v) {

--- a/jpos/src/main/java/org/jpos/util/JsonLogWriter.java
+++ b/jpos/src/main/java/org/jpos/util/JsonLogWriter.java
@@ -23,6 +23,7 @@ import org.jpos.log.LogRendererRegistry;
 
 import java.io.PrintStream;
 
+@Deprecated(forRemoval = false)
 public class JsonLogWriter implements LogEventWriter {
     private PrintStream ps;
     private final LogRenderer<LogEvent> renderer = LogRendererRegistry.getRenderer(LogEvent.class, LogRenderer.Type.JSON);

--- a/jpos/src/main/java/org/jpos/util/JsonlLogWriter.java
+++ b/jpos/src/main/java/org/jpos/util/JsonlLogWriter.java
@@ -1,0 +1,186 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.jpos.core.Configurable;
+import org.jpos.core.Configuration;
+import org.jpos.core.ConfigurationException;
+import org.jpos.iso.ISOMsg;
+import org.jpos.iso.ISOUtil;
+import org.jpos.log.AuditLogEvent;
+import org.jpos.log.evt.LogEvt;
+import org.jpos.log.evt.LogMessage;
+import org.jpos.log.evt.ThrowableAuditLogEvent;
+import org.jpos.log.render.ThrowableSerializer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.InetAddress;
+import java.time.Duration;
+import java.util.*;
+
+/**
+ * JSONL (one JSON object per line) LogEventWriter with built-in PCI protection.
+ *
+ * <p>When serializing ISOMsg objects in LogEvent payloads, sensitive fields are
+ * masked or wiped inline — no upstream {@link ProtectedLogListener} required.</p>
+ *
+ * <p>Configuration properties (same convention as {@link ProtectedLogListener}):</p>
+ * <ul>
+ *   <li>{@code protect} — space-separated field numbers to mask via {@link ISOUtil#protect(String)} (default: {@code "2"})</li>
+ *   <li>{@code wipe} — space-separated field numbers to replace with [WIPED] (default: {@code "35 45 48 52 55"})</li>
+ * </ul>
+ *
+ * <p>Output is suitable for {@code jq}, Filebeat, and Elasticsearch ingestion.</p>
+ *
+ * @since 3.0.0
+ */
+public class JsonlLogWriter extends BaseLogEventWriter implements Configurable {
+    private static final String WIPED = "[WIPED]";
+    private static final Set<Integer> DEFAULT_SAFE_FIELDS = Set.of(
+        3, 4, 7, 11, 12, 13, 18, 22, 24, 25, 32, 37, 38, 39, 41, 42, 49, 90
+    );
+
+    private ObjectMapper mapper;
+    private String host;
+    private Set<Integer> protectFields = Set.of(2);
+    private Set<Integer> wipeFields = Set.of(35, 45, 48, 52, 55);
+
+    public JsonlLogWriter() {
+        initMapper();
+        try {
+            host = InetAddress.getLocalHost().getHostName();
+        } catch (Exception e) {
+            host = "unknown";
+        }
+    }
+
+    @Override
+    public void setConfiguration(Configuration cfg) throws ConfigurationException {
+        String protect = cfg.get("protect", null);
+        if (protect != null) {
+            protectFields = toIntSet(protect);
+        }
+        String wipe = cfg.get("wipe", null);
+        if (wipe != null) {
+            wipeFields = toIntSet(wipe);
+        }
+        initMapper();
+    }
+
+    @Override
+    public void write(LogEvent ev) {
+        if (p == null || ev == null)
+            return;
+        try {
+            List<AuditLogEvent> events;
+            synchronized (ev.getPayLoad()) {
+                events = ev.getPayLoad()
+                    .stream()
+                    .map(this::toAuditLogEvent)
+                    .toList();
+            }
+            long elapsed = Duration.between(ev.getCreatedAt(), ev.getDumpedAt()).toMillis();
+            LogEvt logEvt = new LogEvt(
+                ev.getDumpedAt(),
+                ev.getTag(),
+                elapsed == 0L ? null : elapsed,
+                buildTags(ev),
+                events
+            );
+            p.println(mapper.writeValueAsString(logEvt));
+            p.flush();
+        } catch (JsonProcessingException e) {
+            p.println("{\"error\":\"" + e.getMessage().replace("\"", "'") + "\"}");
+            p.flush();
+        }
+    }
+
+    private AuditLogEvent toAuditLogEvent(Object obj) {
+        return switch (obj) {
+            case AuditLogEvent ale -> ale;
+            case ISOMsg m -> new LogMessage(protectAndDump(m));
+            case Throwable t -> new ThrowableAuditLogEvent(t);
+            default -> new LogMessage(dump(obj));
+        };
+    }
+
+    private Map<String,String> buildTags(LogEvent ev) {
+        ev.getTraceId(); // ensure trace-id is generated
+        Map<String,String> tags = new LinkedHashMap<>();
+        String realm = ev.getRealm();
+        if (realm != null && !realm.isEmpty())
+            tags.put("realm", realm);
+        if (host != null)
+            tags.put("host", host);
+        tags.putAll(ev.getTags());
+        return tags;
+    }
+
+    private String protectAndDump(ISOMsg original) {
+        ISOMsg m = (ISOMsg) original.clone();
+        for (int field : protectFields) {
+            String v = m.getString(field);
+            if (v != null) {
+                m.set(field, ISOUtil.protect(v));
+            }
+        }
+        for (int field : wipeFields) {
+            if (m.hasField(field)) {
+                m.set(field, WIPED);
+            }
+        }
+        return dump(m);
+    }
+
+    private String dump(Object obj) {
+        if (obj instanceof Loggeable loggeable) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(baos);
+            loggeable.dump(ps, "");
+            return baos.toString().trim();
+        }
+        return obj.toString();
+    }
+
+    private void initMapper() {
+        mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(Throwable.class, new ThrowableSerializer());
+        mapper.registerModule(module);
+    }
+
+    private static Set<Integer> toIntSet(String spaceSeparated) {
+        if (spaceSeparated == null || spaceSeparated.isBlank())
+            return Set.of();
+        Set<Integer> result = new HashSet<>();
+        for (String token : spaceSeparated.trim().split("\\s+")) {
+            result.add(Integer.parseInt(token));
+        }
+        return Collections.unmodifiableSet(result);
+    }
+}

--- a/jpos/src/main/java/org/jpos/util/LogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/LogEvent.java
@@ -49,7 +49,7 @@ public class LogEvent {
     private boolean honorSourceLogger;
     private boolean noArmor;
     private boolean hasException;
-    private String traceId;
+    private Map<String,String> tags;
 
     public LogEvent (String tag) {
         super();
@@ -116,6 +116,7 @@ public class LogEvent {
                 sb.append (elapsed);
                 sb.append ("ms\"");
             }
+            String traceId = tags != null ? tags.get("trace-id") : null;
             if (traceId != null) {
                 sb.append (String.format (" trace-id=\"%s\"", traceId));
             }
@@ -210,12 +211,27 @@ public class LogEvent {
         return source != null ? source.getRealm() : "";
     }
     public LogEvent withTraceId (String traceId) {
-        this.traceId = traceId;
-        return this;
+        return withTag("trace-id", traceId);
     }
     public LogEvent withTraceId (UUID uuid) {
-        this.traceId = uuid.toString().replace("-", "");
+        return withTag("trace-id", uuid.toString().replace("-", ""));
+    }
+    public LogEvent withTag(String key, String value) {
+        if (tags == null)
+            tags = new LinkedHashMap<>();
+        tags.put(key, value);
         return this;
+    }
+    public LogEvent withTags(Map<String,String> map) {
+        if (map != null && !map.isEmpty()) {
+            if (tags == null)
+                tags = new LinkedHashMap<>();
+            tags.putAll(map);
+        }
+        return this;
+    }
+    public Map<String,String> getTags() {
+        return tags != null ? Collections.unmodifiableMap(tags) : Collections.emptyMap();
     }
     public LogEvent withSource (LogSource source) {
         setSource(source);
@@ -231,8 +247,11 @@ public class LogEvent {
     }
     public String getTraceId() {
         synchronized(getPayLoad()) {
-            if (traceId == null)
+            String traceId = tags != null ? tags.get("trace-id") : null;
+            if (traceId == null) {
                 traceId = UUID.randomUUID().toString().replace("-","");
+                withTag("trace-id", traceId);
+            }
             return traceId;
         }
     }

--- a/jpos/src/main/java/org/jpos/util/MarkdownLogWriter.java
+++ b/jpos/src/main/java/org/jpos/util/MarkdownLogWriter.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
+@Deprecated(forRemoval = false)
 public class MarkdownLogWriter implements LogEventWriter {
     private PrintStream ps;
     private final LogRenderer<LogEvent> renderer = LogRendererRegistry.getRenderer(LogEvent.class, LogRenderer.Type.MARKDOWN);

--- a/jpos/src/main/java/org/jpos/util/TxtLogWriter.java
+++ b/jpos/src/main/java/org/jpos/util/TxtLogWriter.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
+@Deprecated(forRemoval = false)
 public class TxtLogWriter implements LogEventWriter {
     private PrintStream ps;
     private final LogRenderer<LogEvent> renderer = LogRendererRegistry.getRenderer(LogEvent.class, LogRenderer.Type.TXT);

--- a/jpos/src/main/java/org/jpos/util/XmlLogWriter.java
+++ b/jpos/src/main/java/org/jpos/util/XmlLogWriter.java
@@ -23,6 +23,7 @@ import org.jpos.log.LogRendererRegistry;
 
 import java.io.PrintStream;
 
+@Deprecated(forRemoval = false)
 public class XmlLogWriter implements LogEventWriter {
     private PrintStream ps;
     private final LogRenderer<LogEvent> renderer = LogRendererRegistry.getRenderer(LogEvent.class, LogRenderer.Type.XML);

--- a/jpos/src/test/java/org/jpos/util/JsonlLogWriterTest.java
+++ b/jpos/src/test/java/org/jpos/util/JsonlLogWriterTest.java
@@ -1,0 +1,181 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jpos.core.SimpleConfiguration;
+import org.jpos.iso.ISOMsg;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Properties;
+
+public class JsonlLogWriterTest {
+    private JsonlLogWriter writer;
+    private ByteArrayOutputStream baos;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        writer = new JsonlLogWriter();
+        baos = new ByteArrayOutputStream();
+        writer.setPrintStream(new PrintStream(baos));
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void writesValidJsonLine() throws Exception {
+        LogEvent ev = new LogEvent("test");
+        ev.addMessage("hello");
+        writer.write(ev);
+
+        String line = baos.toString().trim();
+        assertFalse(line.contains("\n"), "should be a single line");
+        JsonNode node = objectMapper.readTree(line);
+        assertEquals("test", node.get("kind").asText());
+        assertNotNull(node.get("ts"));
+        assertNotNull(node.get("tags").get("host"), "host should be in tags");
+    }
+
+    @Test
+    void includesTagsInOutput() throws Exception {
+        LogEvent ev = new LogEvent("send")
+            .withTag("tid", "TERM001")
+            .withTag("mid", "MERCH001");
+        ev.addMessage("payload");
+        writer.write(ev);
+
+        JsonNode node = objectMapper.readTree(baos.toString().trim());
+        JsonNode tags = node.get("tags");
+        assertNotNull(tags, "tags should be present");
+        assertEquals("TERM001", tags.get("tid").asText());
+        assertEquals("MERCH001", tags.get("mid").asText());
+    }
+
+    @Test
+    void alwaysIncludesTraceIdAndHost() throws Exception {
+        LogEvent ev = new LogEvent("test");
+        ev.addMessage("hello");
+        writer.write(ev);
+
+        JsonNode node = objectMapper.readTree(baos.toString().trim());
+        JsonNode tags = node.get("tags");
+        assertNotNull(tags, "tags should always be present");
+        assertNotNull(tags.get("trace-id"), "trace-id should always be in tags");
+        assertNotNull(tags.get("host"), "host should always be in tags");
+    }
+
+    @Test
+    void protectsPanField() throws Exception {
+        ISOMsg m = new ISOMsg();
+        m.setMTI("0200");
+        m.set(2, "4111111111111111");
+        m.set(11, "123456");
+
+        LogEvent ev = new LogEvent("send");
+        ev.addMessage(m);
+        writer.write(ev);
+
+        String output = baos.toString().trim();
+        assertFalse(output.contains("4111111111111111"), "PAN must not appear in cleartext");
+        assertTrue(output.contains("411111"), "BIN should be preserved");
+        assertTrue(output.contains("1111"), "last 4 should be preserved");
+        assertTrue(output.contains("123456"), "safe field 11 should pass through");
+    }
+
+    @Test
+    void wipesTrackData() throws Exception {
+        ISOMsg m = new ISOMsg();
+        m.setMTI("0200");
+        m.set(35, "4111111111111111=2512");
+        m.set(52, "AABBCCDD");
+
+        LogEvent ev = new LogEvent("send");
+        ev.addMessage(m);
+        writer.write(ev);
+
+        String output = baos.toString().trim();
+        assertFalse(output.contains("4111111111111111=2512"), "track2 must be wiped");
+        assertFalse(output.contains("AABBCCDD"), "PIN block must be wiped");
+        assertTrue(output.contains("[WIPED]"), "wiped fields should show [WIPED]");
+    }
+
+    @Test
+    void customProtectAndWipeConfig() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("protect", "");
+        props.setProperty("wipe", "2");
+        writer.setConfiguration(new SimpleConfiguration(props));
+
+        ISOMsg m = new ISOMsg();
+        m.setMTI("0200");
+        m.set(2, "4111111111111111");
+
+        LogEvent ev = new LogEvent("send");
+        ev.addMessage(m);
+        writer.write(ev);
+
+        String output = baos.toString().trim();
+        assertTrue(output.contains("[WIPED]"), "field 2 should be wiped");
+        assertFalse(output.contains("4111111111111111"), "PAN must not appear");
+    }
+
+    @Test
+    void includesRealmInTags() throws Exception {
+        Log source = new Log();
+        source.setRealm("channel/send");
+        LogEvent ev = new LogEvent(source, "send");
+        ev.addMessage("hello");
+        writer.write(ev);
+
+        JsonNode node = objectMapper.readTree(baos.toString().trim());
+        assertEquals("channel/send", node.get("tags").get("realm").asText());
+    }
+
+    @Test
+    void usesPayloadFieldName() throws Exception {
+        LogEvent ev = new LogEvent("test");
+        ev.addMessage("hello");
+        writer.write(ev);
+
+        JsonNode node = objectMapper.readTree(baos.toString().trim());
+        assertNotNull(node.get("payload"), "events should be serialized as 'payload'");
+        assertNull(node.get("evt"), "old 'evt' field name should not appear");
+    }
+
+    @Test
+    void nullEventIsNoOp() {
+        writer.write(null);
+        assertEquals(0, baos.size());
+    }
+
+    @Test
+    void nullPrintStreamIsNoOp() {
+        writer.setPrintStream(null);
+        LogEvent ev = new LogEvent("test");
+        ev.addMessage("hello");
+        writer.write(ev);
+        // should not throw
+    }
+}

--- a/jpos/src/test/java/org/jpos/util/LogEventTagsTest.java
+++ b/jpos/src/test/java/org/jpos/util/LogEventTagsTest.java
@@ -1,0 +1,86 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class LogEventTagsTest {
+    @Test
+    void tagsEmptyByDefault() {
+        LogEvent ev = new LogEvent("test");
+        assertTrue(ev.getTags().isEmpty());
+    }
+
+    @Test
+    void withTagAddsEntry() {
+        LogEvent ev = new LogEvent("test")
+            .withTag("tid", "T001")
+            .withTag("mid", "M001");
+        assertEquals(Map.of("tid", "T001", "mid", "M001"), ev.getTags());
+    }
+
+    @Test
+    void withTagOverwritesExisting() {
+        LogEvent ev = new LogEvent("test")
+            .withTag("tid", "T001")
+            .withTag("tid", "T002");
+        assertEquals("T002", ev.getTags().get("tid"));
+        assertEquals(1, ev.getTags().size());
+    }
+
+    @Test
+    void withTagsBulkAdd() {
+        LogEvent ev = new LogEvent("test")
+            .withTags(Map.of("tid", "T001", "mid", "M001"));
+        assertEquals(2, ev.getTags().size());
+        assertEquals("T001", ev.getTags().get("tid"));
+    }
+
+    @Test
+    void withTagsNullIsNoOp() {
+        LogEvent ev = new LogEvent("test").withTags(null);
+        assertTrue(ev.getTags().isEmpty());
+    }
+
+    @Test
+    void withTagsEmptyMapIsNoOp() {
+        LogEvent ev = new LogEvent("test").withTags(Map.of());
+        assertTrue(ev.getTags().isEmpty());
+    }
+
+    @Test
+    void getTagsReturnsUnmodifiableView() {
+        LogEvent ev = new LogEvent("test").withTag("k", "v");
+        assertThrows(UnsupportedOperationException.class, () -> ev.getTags().put("x", "y"));
+    }
+
+    @Test
+    void fluentChaining() {
+        LogEvent ev = new LogEvent("test")
+            .withTraceId()
+            .withTag("tid", "T001")
+            .add("payload");
+        assertEquals("T001", ev.getTags().get("tid"));
+        assertNotNull(ev.getTraceId());
+        assertEquals(1, ev.getPayLoad().size());
+    }
+}


### PR DESCRIPTION
…tadata

Add structured logging support for multi-node Elasticsearch/JSONL ingestion:

- Unseal AuditLogEvent to allow jPOS-EE custom event types
- Add tags (Map<String,String>) to LogEvent with fluent API (withTag/withTags/getTags)
- Store traceId as a regular tag ("trace-id") instead of a dedicated field
- Fold realm, trace-id, and host into the flat tags map for uniform ES indexing
- Rename LogEvt output fields: tag→kind, evt→payload
- New JsonlLogWriter (extends BaseLogEventWriter, implements Configurable): one JSON line per event with built-in PCI protection for ISOMsg fields (PAN masking via ISOUtil.protect, track/PIN wipe, configurable protect/wipe properties)
- Populate pcode, tid, mid, mti tags in BaseChannel send/receive
- Deprecate JsonLogWriter, XmlLogWriter, TxtLogWriter, MarkdownLogWriter