### PR TITLE
Add ISO 8583:2023 dataset support and cmfv3 packager

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/Dataset.java
+++ b/jpos/src/main/java/org/jpos/iso/Dataset.java
@@ -1,0 +1,63 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import java.util.List;
+
+/**
+ * Represents one dataset instance inside an ISO 8583:2023 composite field.
+ */
+public interface Dataset {
+    /**
+     * Returns the dataset identifier as carried on the wire.
+     *
+     * @return dataset identifier in the range {@code 0x01} to {@code 0xFE}
+     */
+    int getIdentifier();
+
+    /**
+     * Returns the logical dataset encoding format.
+     *
+     * @return dataset format
+     */
+    DatasetFormat getFormat();
+
+    /**
+     * Returns all decoded elements in insertion order.
+     *
+     * @return immutable list of dataset elements
+     */
+    List<DatasetElement> getElements();
+
+    /**
+     * Returns all elements that match the supplied element identifier.
+     *
+     * @param id element identifier, either a TLV tag or DBM bit number
+     * @return immutable list of matching elements
+     */
+    List<DatasetElement> getElements(int id);
+
+    /**
+     * Returns the first element that matches the supplied identifier.
+     *
+     * @param id element identifier, either a TLV tag or DBM bit number
+     * @return matching element or {@code null} when absent
+     */
+    DatasetElement getElement(int id);
+}

--- a/jpos/src/main/java/org/jpos/iso/DatasetElement.java
+++ b/jpos/src/main/java/org/jpos/iso/DatasetElement.java
@@ -1,0 +1,104 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import java.util.Arrays;
+
+/**
+ * Holds one decoded element inside a dataset.
+ */
+public class DatasetElement {
+    private final int id;
+    private final ISOComponent component;
+    private final boolean constructed;
+
+    /**
+     * Creates a primitive dataset element.
+     *
+     * @param id element identifier, either a TLV tag or DBM bit number
+     * @param component backing ISO component
+     */
+    public DatasetElement(int id, ISOComponent component) {
+        this(id, component, false);
+    }
+
+    /**
+     * Creates a dataset element.
+     *
+     * @param id element identifier, either a TLV tag or DBM bit number
+     * @param component backing ISO component
+     * @param constructed whether the source TLV tag was constructed
+     */
+    public DatasetElement(int id, ISOComponent component, boolean constructed) {
+        if (component == null) {
+            throw new IllegalArgumentException("component cannot be null");
+        }
+        this.id = id;
+        this.component = component;
+        this.constructed = constructed;
+    }
+
+    /**
+     * Returns the element identifier.
+     *
+     * @return element identifier
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Returns the backing ISO component.
+     *
+     * @return ISO component
+     */
+    public ISOComponent getComponent() {
+        return component;
+    }
+
+    /**
+     * Indicates whether the element originated from a constructed TLV tag.
+     *
+     * @return {@code true} for constructed TLV elements
+     */
+    public boolean isConstructed() {
+        return constructed;
+    }
+
+    /**
+     * Returns the component value.
+     *
+     * @return element value
+     * @throws ISOException on component access errors
+     */
+    public Object getValue() throws ISOException {
+        return component.getValue();
+    }
+
+    /**
+     * Returns a defensive copy of the element bytes.
+     *
+     * @return encoded element value bytes, or {@code null}
+     * @throws ISOException on component access errors
+     */
+    public byte[] getBytes() throws ISOException {
+        byte[] bytes = component.getBytes();
+        return bytes != null ? Arrays.copyOf(bytes, bytes.length) : null;
+    }
+}

--- a/jpos/src/main/java/org/jpos/iso/DatasetFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/DatasetFieldPackager.java
@@ -1,0 +1,146 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Wraps a regular binary field packager so its payload can be exposed as an
+ * {@link ISODatasetField}.
+ */
+public class DatasetFieldPackager extends ISOFieldPackager {
+    protected ISODatasetPackager datasetPackager;
+    protected ISOFieldPackager fieldPackager;
+
+    /**
+     * Creates a dataset-aware field packager.
+     *
+     * @param fieldPackager outer field packager used for length and transport encoding
+     * @param datasetPackager inner dataset payload packager
+     */
+    public DatasetFieldPackager(ISOFieldPackager fieldPackager, ISODatasetPackager datasetPackager) {
+        super(fieldPackager.getLength(), fieldPackager.getDescription());
+        this.datasetPackager = datasetPackager;
+        this.fieldPackager = fieldPackager;
+    }
+
+    /**
+     * Packs a dataset field by first encoding the inner dataset payload and
+     * then delegating the outer field framing to the wrapped field packager.
+     *
+     * @param c field component to pack
+     * @return packed field bytes
+     * @throws ISOException on packing errors
+     */
+    @Override
+    public byte[] pack(ISOComponent c) throws ISOException {
+        if (c instanceof ISODatasetField) {
+            ISODatasetField datasetField = (ISODatasetField) c;
+            int fieldNumber = datasetField.getFieldNumber() >= 0 ? datasetField.getFieldNumber() : 0;
+            ISOBinaryField field = new ISOBinaryField(fieldNumber, datasetPackager.pack(datasetField));
+            if (datasetPackager.getFieldNumber() > -1) {
+                field.setFieldNumber(datasetPackager.getFieldNumber());
+            }
+            return fieldPackager.pack(field);
+        }
+        return fieldPackager.pack(c);
+    }
+
+    /**
+     * Unpacks a dataset field from a byte array.
+     *
+     * @param c destination component
+     * @param b source buffer
+     * @param offset starting offset
+     * @return number of bytes consumed from the outer field
+     * @throws ISOException on unpacking errors
+     */
+    @Override
+    public int unpack(ISOComponent c, byte[] b, int offset) throws ISOException {
+        ISOBinaryField field = new ISOBinaryField(0);
+        if (datasetPackager.getFieldNumber() > -1) {
+            field.setFieldNumber(datasetPackager.getFieldNumber());
+        }
+        int consumed = fieldPackager.unpack(field, b, offset);
+        if (field.getValue() != null && c instanceof ISODatasetField) {
+            datasetPackager.unpack(c, (byte[]) field.getValue());
+        }
+        return consumed;
+    }
+
+    /**
+     * Unpacks a dataset field from a stream.
+     *
+     * @param c destination component
+     * @param in source stream
+     * @throws IOException on stream errors
+     * @throws ISOException on unpacking errors
+     */
+    @Override
+    public void unpack(ISOComponent c, InputStream in) throws IOException, ISOException {
+        ISOBinaryField field = new ISOBinaryField(0);
+        if (datasetPackager.getFieldNumber() > -1) {
+            field.setFieldNumber(datasetPackager.getFieldNumber());
+        }
+        fieldPackager.unpack(field, in);
+        if (field.getValue() != null && c instanceof ISODatasetField) {
+            datasetPackager.unpack(c, (byte[]) field.getValue());
+        }
+    }
+
+    /**
+     * Creates an {@link ISODatasetField} for the supplied field number.
+     *
+     * @param fieldNumber outer field number
+     * @return dataset field component
+     */
+    @Override
+    public ISOComponent createComponent(int fieldNumber) {
+        return new ISODatasetField(fieldNumber);
+    }
+
+    /**
+     * Returns the maximum packed length of the outer field.
+     *
+     * @return maximum packed length
+     */
+    @Override
+    public int getMaxPackedLength() {
+        return fieldPackager.getLength();
+    }
+
+    /**
+     * Returns the inner dataset payload packager.
+     *
+     * @return dataset packager
+     */
+    public ISODatasetPackager getISODatasetPackager() {
+        return datasetPackager;
+    }
+
+    /**
+     * Returns the wrapped outer field packager.
+     *
+     * @return outer field packager
+     */
+    public ISOFieldPackager getISOFieldPackager() {
+        return fieldPackager;
+    }
+}

--- a/jpos/src/main/java/org/jpos/iso/DatasetFormat.java
+++ b/jpos/src/main/java/org/jpos/iso/DatasetFormat.java
@@ -1,0 +1,24 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+public enum DatasetFormat {
+    TLV,
+    DBM
+}

--- a/jpos/src/main/java/org/jpos/iso/ISODataset.java
+++ b/jpos/src/main/java/org/jpos/iso/ISODataset.java
@@ -1,0 +1,243 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Mutable dataset implementation used by {@link ISODatasetField}.
+ */
+public class ISODataset implements Dataset {
+    private final int identifier;
+    private final DatasetFormat format;
+    private final List<DatasetElement> elements = new ArrayList<>();
+
+    /**
+     * Creates an empty dataset.
+     *
+     * @param identifier dataset identifier
+     * @param format dataset format
+     */
+    public ISODataset(int identifier, DatasetFormat format) {
+        if (identifier < 0x01 || identifier > 0xFE) {
+            throw new IllegalArgumentException("dataset identifier out of range");
+        }
+        this.identifier = identifier;
+        this.format = format;
+    }
+
+    @Override
+    public int getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public DatasetFormat getFormat() {
+        return format;
+    }
+
+    /**
+     * Appends an element without replacing existing entries with the same id.
+     *
+     * @param element element to append
+     */
+    public void addElement(DatasetElement element) {
+        elements.add(element);
+    }
+
+    /**
+     * Replaces any existing elements with the same id and then appends the supplied element.
+     *
+     * @param element element to store
+     */
+    public void putElement(DatasetElement element) {
+        elements.removeIf(existing -> existing.getId() == element.getId());
+        addElement(element);
+    }
+
+    /**
+     * Appends a primitive element.
+     *
+     * @param id element identifier
+     * @param component backing component
+     */
+    public void addElement(int id, ISOComponent component) {
+        addElement(new DatasetElement(id, component));
+    }
+
+    /**
+     * Replaces any existing element with the same id.
+     *
+     * @param id element identifier
+     * @param component backing component
+     */
+    public void putElement(int id, ISOComponent component) {
+        putElement(new DatasetElement(id, component));
+    }
+
+    /**
+     * Appends an element and records its constructed TLV flag.
+     *
+     * @param id element identifier
+     * @param component backing component
+     * @param constructed whether the tag is constructed
+     */
+    public void addElement(int id, ISOComponent component, boolean constructed) {
+        addElement(new DatasetElement(id, component, constructed));
+    }
+
+    /**
+     * Replaces any existing element with the same id and records its constructed TLV flag.
+     *
+     * @param id element identifier
+     * @param component backing component
+     * @param constructed whether the tag is constructed
+     */
+    public void putElement(int id, ISOComponent component, boolean constructed) {
+        putElement(new DatasetElement(id, component, constructed));
+    }
+
+    /**
+     * Removes all elements that match the supplied identifier.
+     *
+     * @param id element identifier to remove
+     */
+    public void removeElement(int id) {
+        elements.removeIf(existing -> existing.getId() == id);
+    }
+
+    /**
+     * Indicates whether the dataset contains any elements.
+     *
+     * @return {@code true} when empty
+     */
+    public boolean isEmpty() {
+        return elements.isEmpty();
+    }
+
+    /**
+     * Stores a character element and returns this dataset for fluent chaining.
+     *
+     * @param id element identifier
+     * @param value element value
+     * @return this dataset
+     */
+    public ISODataset with(int id, String value) {
+        ISOField field = new ISOField(id, value);
+        putElement(id, field);
+        return this;
+    }
+
+    /**
+     * Stores a binary element and returns this dataset for fluent chaining.
+     *
+     * @param id element identifier
+     * @param value element value
+     * @return this dataset
+     */
+    public ISODataset with(int id, byte[] value) {
+        ISOBinaryField field = new ISOBinaryField(id, value);
+        putElement(id, field);
+        return this;
+    }
+
+    /**
+     * Stores an ISO component and returns this dataset for fluent chaining.
+     *
+     * @param id element identifier
+     * @param component backing component
+     * @return this dataset
+     */
+    public ISODataset with(int id, ISOComponent component) {
+        component.setFieldNumber(id);
+        putElement(id, component);
+        return this;
+    }
+
+    /**
+     * Stores an ISO component and its constructed TLV flag, returning this dataset for fluent chaining.
+     *
+     * @param id element identifier
+     * @param component backing component
+     * @param constructed whether the tag is constructed
+     * @return this dataset
+     */
+    public ISODataset with(int id, ISOComponent component, boolean constructed) {
+        component.setFieldNumber(id);
+        putElement(id, component, constructed);
+        return this;
+    }
+
+    @Override
+    public List<DatasetElement> getElements() {
+        return Collections.unmodifiableList(elements);
+    }
+
+    @Override
+    public List<DatasetElement> getElements(int id) {
+        List<DatasetElement> matches = new ArrayList<>();
+        for (DatasetElement element : elements) {
+            if (element.getId() == id) {
+                matches.add(element);
+            }
+        }
+        return Collections.unmodifiableList(matches);
+    }
+
+    @Override
+    public DatasetElement getElement(int id) {
+        for (DatasetElement element : elements) {
+            if (element.getId() == id) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    public ISOComponent getComponent(int id) {
+        DatasetElement element = getElement(id);
+        return element != null ? element.getComponent() : null;
+    }
+
+    /**
+     * Returns the logical value of the first matching element.
+     *
+     * @param id element identifier
+     * @return element value or {@code null}
+     * @throws ISOException on component access errors
+     */
+    public Object getValue(int id) throws ISOException {
+        DatasetElement element = getElement(id);
+        return element != null ? element.getValue() : null;
+    }
+
+    /**
+     * Returns the bytes of the first matching element.
+     *
+     * @param id element identifier
+     * @return element bytes or {@code null}
+     * @throws ISOException on component access errors
+     */
+    public byte[] getBytes(int id) throws ISOException {
+        DatasetElement element = getElement(id);
+        return element != null ? element.getBytes() : null;
+    }
+}

--- a/jpos/src/main/java/org/jpos/iso/ISODatasetField.java
+++ b/jpos/src/main/java/org/jpos/iso/ISODatasetField.java
@@ -1,0 +1,314 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import org.jpos.iso.packager.XMLPackager;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Composite ISO field that holds one or more datasets.
+ */
+public class ISODatasetField extends ISOComponent {
+    private int fieldNumber;
+    private final List<Dataset> datasets = new ArrayList<>();
+
+    /**
+     * Creates an unbound dataset field.
+     */
+    public ISODatasetField() {
+        this(-1);
+    }
+
+    /**
+     * Creates a dataset field bound to an outer field number.
+     *
+     * @param fieldNumber outer field number
+     */
+    public ISODatasetField(int fieldNumber) {
+        this.fieldNumber = fieldNumber;
+    }
+
+    /**
+     * Appends a dataset to this field.
+     *
+     * @param dataset dataset to add
+     */
+    public void addDataset(Dataset dataset) {
+        datasets.add(dataset);
+    }
+
+    /**
+     * Removes a dataset instance from this field.
+     *
+     * @param dataset dataset to remove
+     */
+    public void removeDataset(Dataset dataset) {
+        datasets.remove(dataset);
+    }
+
+    /**
+     * Indicates whether this field still contains datasets.
+     *
+     * @return {@code true} when at least one dataset is present
+     */
+    public boolean hasDatasets() {
+        return !datasets.isEmpty();
+    }
+
+    /**
+     * Returns all datasets in insertion order.
+     *
+     * @return immutable list of datasets
+     */
+    public List<Dataset> getDatasets() {
+        return Collections.unmodifiableList(datasets);
+    }
+
+    /**
+     * Returns all datasets that match the supplied identifier.
+     *
+     * @param identifier dataset identifier
+     * @return immutable list of matching datasets
+     */
+    public List<Dataset> getDatasets(int identifier) {
+        List<Dataset> matches = new ArrayList<>();
+        for (Dataset dataset : datasets) {
+            if (dataset.getIdentifier() == identifier) {
+                matches.add(dataset);
+            }
+        }
+        return Collections.unmodifiableList(matches);
+    }
+
+    /**
+     * Returns the first dataset that matches the supplied identifier.
+     *
+     * @param identifier dataset identifier
+     * @return matching dataset or {@code null}
+     */
+    public Dataset getDataset(int identifier) {
+        for (Dataset dataset : datasets) {
+            if (dataset.getIdentifier() == identifier) {
+                return dataset;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the component stored under the given dataset and element identifiers.
+     *
+     * @param datasetId dataset identifier
+     * @param elementId element identifier
+     * @return matching component or {@code null}
+     */
+    public ISOComponent get(int datasetId, int elementId) {
+        Dataset dataset = getDataset(datasetId);
+        if (dataset instanceof ISODataset) {
+            return ((ISODataset) dataset).getComponent(elementId);
+        }
+        DatasetElement element = dataset != null ? dataset.getElement(elementId) : null;
+        return element != null ? element.getComponent() : null;
+    }
+
+    /**
+     * Returns the logical value stored under the given dataset and element identifiers.
+     *
+     * @param datasetId dataset identifier
+     * @param elementId element identifier
+     * @return element value or {@code null}
+     * @throws ISOException on component access errors
+     */
+    public Object getValue(int datasetId, int elementId) throws ISOException {
+        ISOComponent component = get(datasetId, elementId);
+        return component != null ? component.getValue() : null;
+    }
+
+    /**
+     * Returns the bytes stored under the given dataset and element identifiers.
+     *
+     * @param datasetId dataset identifier
+     * @param elementId element identifier
+     * @return element bytes or {@code null}
+     * @throws ISOException on component access errors
+     */
+    public byte[] getBytes(int datasetId, int elementId) throws ISOException {
+        ISOComponent component = get(datasetId, elementId);
+        return component != null ? component.getBytes() : null;
+    }
+
+    /**
+     * Returns this composite field.
+     *
+     * @return this field
+     */
+    @Override
+    public ISOComponent getComposite() {
+        return this;
+    }
+
+    /**
+     * Returns the outer ISO field number.
+     *
+     * @return outer field number
+     */
+    @Override
+    public Object getKey() {
+        return fieldNumber;
+    }
+
+    /**
+     * Returns the datasets carried by this field.
+     *
+     * @return dataset list
+     */
+    @Override
+    public Object getValue() {
+        return getDatasets();
+    }
+
+    /**
+     * Dataset fields do not expose their bytes directly and must be packed via a
+     * {@link DatasetFieldPackager}.
+     *
+     * @return never returns normally
+     * @throws ISOException always
+     */
+    @Override
+    public byte[] getBytes() throws ISOException {
+        throw new ISOException("Dataset fields must be packed via DatasetFieldPackager");
+    }
+
+    /**
+     * Sets the outer ISO field number.
+     *
+     * @param fieldNumber outer field number
+     */
+    @Override
+    public void setFieldNumber(int fieldNumber) {
+        this.fieldNumber = fieldNumber;
+    }
+
+    /**
+     * Returns the outer ISO field number.
+     *
+     * @return outer field number
+     */
+    @Override
+    public int getFieldNumber() {
+        return fieldNumber;
+    }
+
+    /**
+     * Replaces the datasets held by this field.
+     *
+     * @param obj either a {@link Dataset} or a {@link java.util.List} of datasets
+     * @throws ISOException when the supplied value type is unsupported
+     */
+    @Override
+    public void setValue(Object obj) throws ISOException {
+        datasets.clear();
+        if (obj instanceof Dataset) {
+            datasets.add((Dataset) obj);
+        } else if (obj instanceof List<?>) {
+            for (Object item : (List<?>) obj) {
+                if (!(item instanceof Dataset)) {
+                    throw new ISOException("Invalid dataset list entry " + item);
+                }
+                datasets.add((Dataset) item);
+            }
+        } else if (obj != null) {
+            throw new ISOException("Unsupported dataset field value " + obj.getClass().getName());
+        }
+    }
+
+    /**
+     * Dataset fields must be packed through their field packager.
+     *
+     * @return never returns normally
+     * @throws ISOException always
+     */
+    @Override
+    public byte[] pack() throws ISOException {
+        throw new ISOException("Not available on Dataset field");
+    }
+
+    /**
+     * Dataset fields must be unpacked through their field packager.
+     *
+     * @param b source buffer
+     * @return never returns normally
+     * @throws ISOException always
+     */
+    @Override
+    public int unpack(byte[] b) throws ISOException {
+        throw new ISOException("Not available on Dataset field");
+    }
+
+    /**
+     * Dataset fields must be unpacked through their field packager.
+     *
+     * @param in source stream
+     * @throws ISOException always
+     */
+    @Override
+    public void unpack(InputStream in) throws ISOException {
+        throw new ISOException("Not available on Dataset field");
+    }
+
+    /**
+     * Dumps the field as dataset-aware XML.
+     *
+     * @param p destination stream
+     * @param indent indentation prefix
+     */
+    @Override
+    public void dump(PrintStream p, String indent) {
+        p.println(indent + "<" + XMLPackager.ISOFIELD_TAG + " " + XMLPackager.ID_ATTR + "=\"" + fieldNumber + "\" type=\"dataset\">");
+        String innerIndent = indent + "  ";
+        for (Dataset dataset : datasets) {
+            p.println(innerIndent + "<dataset id=\"" + String.format("%02X", dataset.getIdentifier()) + "\" format=\"" + dataset.getFormat() + "\">");
+            String datasetIndent = innerIndent + "  ";
+            for (DatasetElement element : dataset.getElements()) {
+                try {
+                    String elementId = dataset.getFormat() == DatasetFormat.TLV
+                      ? String.format("0x%X", element.getId())
+                      : Integer.toString(element.getId());
+                    p.println(datasetIndent
+                      + "<element id=\""
+                      + elementId
+                      + "\""
+                      + (element.isConstructed() ? " constructed=\"true\"" : "")
+                      + " value=\""
+                      + ISOUtil.hexString(element.getBytes())
+                      + "\"/>");
+                } catch (ISOException e) {
+                    p.println(datasetIndent + "<element id=\"" + element.getId() + "\" error=\"" + ISOUtil.normalize(e.getMessage()) + "\"/>");
+                }
+            }
+            p.println(innerIndent + "</dataset>");
+        }
+        p.println(indent + "</" + XMLPackager.ISOFIELD_TAG + ">");
+    }
+}

--- a/jpos/src/main/java/org/jpos/iso/ISODatasetPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISODatasetPackager.java
@@ -1,0 +1,25 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+/**
+ * Marker interface for packagers that encode and decode dataset payloads.
+ */
+public interface ISODatasetPackager extends ISOPackager, ISOSubFieldPackager {
+}

--- a/jpos/src/main/java/org/jpos/iso/ISODatasetPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISODatasetPackager.java
@@ -22,4 +22,13 @@ package org.jpos.iso;
  * Marker interface for packagers that encode and decode dataset payloads.
  */
 public interface ISODatasetPackager extends ISOPackager, ISOSubFieldPackager {
+    /**
+     * Indicates whether datasets handled by this packager use the standard
+     * dataset identifier and length envelope.
+     *
+     * @return {@code true} when the standard dataset envelope is present
+     */
+    default boolean hasDatasetEnvelope() {
+        return true;
+    }
 }

--- a/jpos/src/main/java/org/jpos/iso/ISOMsg.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOMsg.java
@@ -1366,7 +1366,7 @@ public class ISOMsg extends ISOComponent
         int datasetId;
         int elementId;
 
-        if (datasetPackager.getClass().getName().endsWith(".ICCDataPackager")) {
+        if (!datasetPackager.hasDatasetEnvelope()) {
             if (st.countTokens() != 1)
                 return false;
             datasetId = fieldNo;
@@ -1416,7 +1416,7 @@ public class ISOMsg extends ISOComponent
         int datasetId;
         int elementId;
 
-        if (datasetPackager.getClass().getName().endsWith(".ICCDataPackager")) {
+        if (!datasetPackager.hasDatasetEnvelope()) {
             if (st.countTokens() != 1)
                 return false;
             datasetId = fieldNo;
@@ -1474,12 +1474,12 @@ public class ISOMsg extends ISOComponent
     private ISODatasetField cloneDatasetField(ISODatasetField field) throws ISOException {
         ISODatasetField clone = new ISODatasetField(field.getFieldNumber());
         for (Dataset dataset : field.getDatasets()) {
-            clone.addDataset(cloneDataset((ISODataset) dataset));
+            clone.addDataset(cloneDataset(dataset));
         }
         return clone;
     }
 
-    private ISODataset cloneDataset(ISODataset dataset) throws ISOException {
+    private ISODataset cloneDataset(Dataset dataset) throws ISOException {
         ISODataset clone = new ISODataset(dataset.getIdentifier(), dataset.getFormat());
         for (DatasetElement element : dataset.getElements()) {
             clone.addElement(element.getId(), cloneDatasetComponent(element.getComponent()), element.isConstructed());

--- a/jpos/src/main/java/org/jpos/iso/ISOMsg.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOMsg.java
@@ -251,12 +251,30 @@ public class ISOMsg extends ISOComponent
     }
 
     /**
+     * Sets a top-level character field and returns this message for fluent chaining.
+     *
+     * @param fldno field number
+     * @param value field value
+     * @return this message
+     */
+    public ISOMsg with(int fldno, String value) {
+        set(fldno, value);
+        return this;
+    }
+
+    /**
      * Creates an ISOField associated with fldno within this ISOMsg.
      *
      * @param fpath dot-separated field path (i.e. 63.2)
      * @param value field value
      */
     public void set(String fpath, String value) {
+        try {
+            if (setDatasetPath(fpath, value))
+                return;
+        } catch (ISOException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
         StringTokenizer st = new StringTokenizer (fpath, ".");
         ISOMsg m = this;
         for (;;) {
@@ -286,12 +304,26 @@ public class ISOMsg extends ISOComponent
     }
 
     /**
+     * Sets a character field by path and returns this message for fluent chaining.
+     *
+     * @param fpath dot-separated field path
+     * @param value field value
+     * @return this message
+     */
+    public ISOMsg with(String fpath, String value) {
+        set(fpath, value);
+        return this;
+    }
+
+    /**
      * Creates an ISOField associated with fldno within this ISOMsg
      * @param fpath dot-separated field path (i.e. 63.2)
      * @param c component
      * @throws ISOException on error
      */
     public void set(String fpath, ISOComponent c) throws ISOException {
+        if (setDatasetPath(fpath, c))
+            return;
         StringTokenizer st = new StringTokenizer (fpath, ".");
         ISOMsg m = this;
         for (;;) {
@@ -319,6 +351,19 @@ public class ISOMsg extends ISOComponent
             }
         }
     }
+
+    /**
+     * Sets a component by path and returns this message for fluent chaining.
+     *
+     * @param fpath dot-separated field path
+     * @param c component to store
+     * @return this message
+     * @throws ISOException on path or component errors
+     */
+    public ISOMsg with(String fpath, ISOComponent c) throws ISOException {
+        set(fpath, c);
+        return this;
+    }
     /**
      * Creates an ISOField associated with fldno within this ISOMsg.
      *
@@ -326,6 +371,12 @@ public class ISOMsg extends ISOComponent
      * @param value binary field value
      */
     public void set(String fpath, byte[] value) {
+        try {
+            if (setDatasetPath(fpath, value))
+                return;
+        } catch (ISOException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
         StringTokenizer st = new StringTokenizer (fpath, ".");
         ISOMsg m = this;
         for (;;) {
@@ -343,6 +394,30 @@ public class ISOMsg extends ISOComponent
                 break;
             }
         }
+    }
+
+    /**
+     * Sets a top-level binary field and returns this message for fluent chaining.
+     *
+     * @param fldno field number
+     * @param value field value
+     * @return this message
+     */
+    public ISOMsg with(int fldno, byte[] value) {
+        set(fldno, value);
+        return this;
+    }
+
+    /**
+     * Sets a binary field by path and returns this message for fluent chaining.
+     *
+     * @param fpath dot-separated field path
+     * @param value field value
+     * @return this message
+     */
+    public ISOMsg with(String fpath, byte[] value) {
+        set(fpath, value);
+        return this;
     }
 
     /**
@@ -388,6 +463,12 @@ public class ISOMsg extends ISOComponent
      * @param fpath dot-separated field path (i.e. 63.2)
      */
     public void unset(String fpath) {
+        try {
+            if (unsetDatasetPath(fpath))
+                return;
+        } catch (ISOException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
         StringTokenizer st = new StringTokenizer (fpath, ".");
         ISOMsg m = this;
         ISOMsg lastm = m;
@@ -425,6 +506,29 @@ public class ISOMsg extends ISOComponent
         for (String fpath : fpaths) {
             unset(fpath);
         }
+    }
+
+    /**
+     * Unsets one or more top-level fields and returns this message for fluent chaining.
+     *
+     * @param flds field numbers to remove
+     * @return this message
+     */
+    public ISOMsg without(int ... flds) {
+        unset(flds);
+        return this;
+    }
+
+    /**
+     * Unsets one or more field paths, including nested composites and dataset elements,
+     * and returns this message for fluent chaining.
+     *
+     * @param fpaths field paths to remove
+     * @return this message
+     */
+    public ISOMsg without(String ... fpaths) {
+        unset(fpaths);
+        return this;
     }
     /**
      * In order to interchange <b>Composites</b> and <b>Leafs</b> we use
@@ -775,12 +879,14 @@ public class ISOMsg extends ISOComponent
                 m.trailer = trailer.clone();
             for (Integer k : fields.keySet()) {
                 ISOComponent c = (ISOComponent) m.fields.get(k);
-                if (c instanceof ISOMsg)
-                    m.fields.put(k, ((ISOMsg) c).clone());
+                if (c instanceof ISOMsg || c instanceof ISODatasetField)
+                    m.fields.put(k, cloneComponent(c));
             }
             return m;
         } catch (CloneNotSupportedException e) {
             throw new InternalError();
+        } catch (ISOException e) {
+            throw new IllegalStateException(e);
         }
     }
 
@@ -798,8 +904,8 @@ public class ISOMsg extends ISOComponent
                 if (hasField(field)) {
                     try {
                         ISOComponent c = getComponent(field);
-                        if (c instanceof ISOMsg) {
-                            m.set((ISOMsg)((ISOMsg)c).clone());
+                        if (c instanceof ISOMsg || c instanceof ISODatasetField) {
+                            m.set(cloneComponent(c));
                         } else {
                             m.set(c);
                         }
@@ -826,8 +932,8 @@ public class ISOMsg extends ISOComponent
             for (String fpath : fpaths) {
                 try {
                     ISOComponent component = getComponent(fpath);
-                    if (component instanceof ISOMsg) {
-                        m.set(fpath, (ISOMsg)((ISOMsg)component).clone());
+                    if (component instanceof ISOMsg || component instanceof ISODatasetField) {
+                        m.set(fpath, cloneComponent(component));
                     } else if (component != null) {
                         m.set(fpath, component);
                     }
@@ -1241,5 +1347,153 @@ public class ISOMsg extends ISOComponent
     private int parseInt (String s) {
         return s.startsWith("0x") ? Integer.parseInt(s.substring(2), 16) : Integer.parseInt(s);
     }
-}
 
+    private boolean setDatasetPath(String fpath, Object value) throws ISOException {
+        StringTokenizer st = new StringTokenizer(fpath, ".");
+        if (st.countTokens() < 2)
+            return false;
+
+        int fieldNo = parseInt(st.nextToken());
+        ISOFieldPackager fp = null;
+        if (packager instanceof ISOBasePackager) {
+            fp = ((ISOBasePackager) packager).getFieldPackager(fieldNo);
+        }
+        if (!(fp instanceof DatasetFieldPackager))
+            return false;
+
+        DatasetFieldPackager dfp = (DatasetFieldPackager) fp;
+        ISODatasetPackager datasetPackager = dfp.getISODatasetPackager();
+        int datasetId;
+        int elementId;
+
+        if (datasetPackager.getClass().getName().endsWith(".ICCDataPackager")) {
+            if (st.countTokens() != 1)
+                return false;
+            datasetId = fieldNo;
+            elementId = parseInt(st.nextToken());
+        } else {
+            if (st.countTokens() != 2)
+                return false;
+            datasetId = parseInt(st.nextToken());
+            elementId = parseInt(st.nextToken());
+        }
+
+        ISODatasetField field;
+        ISOComponent component = getComponent(fieldNo);
+        if (component == null) {
+            field = new ISODatasetField(fieldNo);
+            set(field);
+        } else if (component instanceof ISODatasetField) {
+            field = (ISODatasetField) component;
+        } else {
+            throw new ISOException("Field " + fieldNo + " is not a dataset field");
+        }
+
+        ISODataset dataset = (ISODataset) field.getDataset(datasetId);
+        if (dataset == null) {
+            dataset = new ISODataset(datasetId, datasetId <= 0x70 ? DatasetFormat.TLV : DatasetFormat.DBM);
+            field.addDataset(dataset);
+        }
+        dataset.putElement(elementId, toDatasetComponent(elementId, value));
+        return true;
+    }
+
+    private boolean unsetDatasetPath(String fpath) throws ISOException {
+        StringTokenizer st = new StringTokenizer(fpath, ".");
+        if (st.countTokens() < 2)
+            return false;
+
+        int fieldNo = parseInt(st.nextToken());
+        ISOFieldPackager fp = null;
+        if (packager instanceof ISOBasePackager) {
+            fp = ((ISOBasePackager) packager).getFieldPackager(fieldNo);
+        }
+        if (!(fp instanceof DatasetFieldPackager))
+            return false;
+
+        DatasetFieldPackager dfp = (DatasetFieldPackager) fp;
+        ISODatasetPackager datasetPackager = dfp.getISODatasetPackager();
+        int datasetId;
+        int elementId;
+
+        if (datasetPackager.getClass().getName().endsWith(".ICCDataPackager")) {
+            if (st.countTokens() != 1)
+                return false;
+            datasetId = fieldNo;
+            elementId = parseInt(st.nextToken());
+        } else {
+            if (st.countTokens() != 2)
+                return false;
+            datasetId = parseInt(st.nextToken());
+            elementId = parseInt(st.nextToken());
+        }
+
+        ISOComponent component = getComponent(fieldNo);
+        if (component == null)
+            return true;
+        if (!(component instanceof ISODatasetField))
+            throw new ISOException("Field " + fieldNo + " is not a dataset field");
+
+        ISODatasetField field = (ISODatasetField) component;
+        ISODataset dataset = (ISODataset) field.getDataset(datasetId);
+        if (dataset == null)
+            return true;
+
+        dataset.removeElement(elementId);
+        if (dataset.isEmpty()) {
+            field.removeDataset(dataset);
+            if (!field.hasDatasets())
+                unset(fieldNo);
+        }
+        return true;
+    }
+
+    private ISOComponent toDatasetComponent(int elementId, Object value) throws ISOException {
+        if (value instanceof ISOComponent) {
+            ISOComponent component = (ISOComponent) value;
+            component.setFieldNumber(elementId);
+            return component;
+        }
+        if (value instanceof byte[]) {
+            return new ISOBinaryField(elementId, (byte[]) value);
+        }
+        if (value instanceof String) {
+            return new ISOField(elementId, (String) value);
+        }
+        throw new ISOException("Unsupported dataset value type " + (value != null ? value.getClass().getName() : "null"));
+    }
+
+    private ISOComponent cloneComponent(ISOComponent c) throws ISOException {
+        if (c instanceof ISOMsg)
+            return (ISOComponent) ((ISOMsg) c).clone();
+        if (c instanceof ISODatasetField)
+            return cloneDatasetField((ISODatasetField) c);
+        return c;
+    }
+
+    private ISODatasetField cloneDatasetField(ISODatasetField field) throws ISOException {
+        ISODatasetField clone = new ISODatasetField(field.getFieldNumber());
+        for (Dataset dataset : field.getDatasets()) {
+            clone.addDataset(cloneDataset((ISODataset) dataset));
+        }
+        return clone;
+    }
+
+    private ISODataset cloneDataset(ISODataset dataset) throws ISOException {
+        ISODataset clone = new ISODataset(dataset.getIdentifier(), dataset.getFormat());
+        for (DatasetElement element : dataset.getElements()) {
+            clone.addElement(element.getId(), cloneDatasetComponent(element.getComponent()), element.isConstructed());
+        }
+        return clone;
+    }
+
+    private ISOComponent cloneDatasetComponent(ISOComponent component) throws ISOException {
+        if (component instanceof ISOMsg)
+            return (ISOComponent) ((ISOMsg) component).clone();
+        if (component instanceof ISOBinaryField)
+            return new ISOBinaryField(component.getFieldNumber(), component.getBytes() != null ? component.getBytes().clone() : null);
+        if (component instanceof ISOField)
+            return new ISOField(component.getFieldNumber(), (String) component.getValue());
+        return component;
+    }
+}

--- a/jpos/src/main/java/org/jpos/iso/packager/DatasetPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/DatasetPackager.java
@@ -283,10 +283,6 @@ public class DatasetPackager extends GenericPackager implements ISODatasetPackag
      */
     protected ISODataset unpackDBM(int identifier, byte[] content) throws ISOException {
         DBMBitmap dbm = unpackDBMBitmap(content);
-        if (dbm.tlvContinuation) {
-            // TODO Support DBM trailing TLV continuation as defined by ISO 8583:2023 §4.4.4.4.
-            throw new ISOException(String.format("Dataset %02X uses DBM TLV continuation, which is not supported yet", identifier));
-        }
         ISODataset dataset = new ISODataset(identifier, DatasetFormat.DBM);
         int consumed = dbm.consumed;
         for (int elementId : dbm.elements) {
@@ -296,6 +292,13 @@ public class DatasetPackager extends GenericPackager implements ISODatasetPackag
             ISOComponent component = fld[elementId].createComponent(elementId);
             consumed += fld[elementId].unpack(component, content, consumed);
             dataset.addElement(elementId, component);
+        }
+        if (dbm.tlvContinuation) {
+            if (consumed >= content.length) {
+                throw new ISOException(String.format("Dataset %02X sets DBM TLV continuation but has no trailing TLV content", identifier));
+            }
+            unpackTLVContinuation(identifier, dataset, Arrays.copyOfRange(content, consumed, content.length));
+            consumed = content.length;
         }
         if (consumed != content.length) {
             throw new ISOException(String.format("Dataset %02X content mismatch: consumed=%d len=%d", identifier, consumed, content.length));
@@ -315,16 +318,21 @@ public class DatasetPackager extends GenericPackager implements ISODatasetPackag
         if (elements.isEmpty()) {
             return new byte[0];
         }
-        validateDBMElements(dataset);
-        byte[] bitmap = packDBMBitmap(elements);
+        List<DatasetElement> dbmElements = dbmAddressableElements(dataset);
+        List<DatasetElement> tlvElements = trailingTLVElements(dataset);
+        validateDBMElements(dataset, dbmElements);
+        byte[] bitmap = packDBMBitmap(dbmElements, !tlvElements.isEmpty());
         try (ByteArrayOutputStream out = new ByteArrayOutputStream(128)) {
             out.write(bitmap);
-            for (int elementId : sortedElementIds(elements)) {
+            for (int elementId : sortedElementIds(dbmElements)) {
                 DatasetElement element = dataset.getElement(elementId);
                 if (elementId >= fld.length || fld[elementId] == null) {
                     throw new ISOException(String.format("No packager defined for dataset %02X element %d", dataset.getIdentifier(), elementId));
                 }
                 out.write(fld[elementId].pack(element.getComponent()));
+            }
+            if (!tlvElements.isEmpty()) {
+                out.write(packTLVElements(tlvElements));
             }
             return out.toByteArray();
         } catch (IOException e) {
@@ -332,9 +340,9 @@ public class DatasetPackager extends GenericPackager implements ISODatasetPackag
         }
     }
 
-    private void validateDBMElements(Dataset dataset) throws ISOException {
+    private void validateDBMElements(Dataset dataset, List<DatasetElement> dbmElements) throws ISOException {
         Set<Integer> seen = new TreeSet<>();
-        for (DatasetElement element : dataset.getElements()) {
+        for (DatasetElement element : dbmElements) {
             if (!seen.add(element.getId())) {
                 throw new ISOException(String.format("DBM dataset %02X contains duplicate element %d", dataset.getIdentifier(), element.getId()));
             }
@@ -388,7 +396,7 @@ public class DatasetPackager extends GenericPackager implements ISODatasetPackag
         return new DBMBitmap(elements, tlvContinuation, offset);
     }
 
-    private byte[] packDBMBitmap(List<DatasetElement> elements) {
+    private byte[] packDBMBitmap(List<DatasetElement> elements, boolean tlvContinuation) {
         int highestElement = elements.stream().mapToInt(DatasetElement::getId).max().orElse(0);
         int extraWords = 0;
         while (capacity(extraWords) < highestElement) {
@@ -404,7 +412,60 @@ public class DatasetPackager extends GenericPackager implements ISODatasetPackag
         for (DatasetElement element : elements) {
             setElementBit(bitmap, element.getId(), extraWords);
         }
+        if (tlvContinuation) {
+            bitmap[bitmap.length - 1] |= 0x01;
+        }
         return bitmap;
+    }
+
+    private List<DatasetElement> dbmAddressableElements(Dataset dataset) {
+        List<DatasetElement> elements = new ArrayList<>();
+        for (DatasetElement element : dataset.getElements()) {
+            if (isDBMAddressable(element.getId())) {
+                elements.add(element);
+            }
+        }
+        return elements;
+    }
+
+    private List<DatasetElement> trailingTLVElements(Dataset dataset) {
+        List<DatasetElement> elements = new ArrayList<>();
+        for (DatasetElement element : dataset.getElements()) {
+            if (!isDBMAddressable(element.getId())) {
+                elements.add(element);
+            }
+        }
+        return elements;
+    }
+
+    private boolean isDBMAddressable(int elementId) {
+        return elementId > 0 && elementId < fld.length && fld[elementId] != null;
+    }
+
+    private void unpackTLVContinuation(int identifier, ISODataset dataset, byte[] content) throws ISOException {
+        TLVList tlv = new TLVList();
+        try {
+            tlv.unpack(content);
+        } catch (RuntimeException e) {
+            throw new ISOException(String.format("Invalid DBM TLV continuation in dataset %02X", identifier), e);
+        }
+        for (TLVMsg tag : tlv.getTags()) {
+            dataset.addElement(tag.getTag(), new ISOBinaryField(tag.getTag(), tag.getValue()), isConstructedTag(tag.getTag()));
+        }
+    }
+
+    private byte[] packTLVElements(List<DatasetElement> elements) throws ISOException {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream(64)) {
+            for (DatasetElement element : elements) {
+                TLVMsg tlv = new TLVMsg(element.getId(), element.getBytes());
+                out.write(tlv.getTLV());
+            }
+            return out.toByteArray();
+        } catch (IllegalArgumentException e) {
+            throw new ISOException("Unable to pack DBM TLV continuation", e);
+        } catch (IOException e) {
+            throw new ISOException(e);
+        }
     }
 
     private int capacity(int extraWords) {

--- a/jpos/src/main/java/org/jpos/iso/packager/DatasetPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/DatasetPackager.java
@@ -284,6 +284,7 @@ public class DatasetPackager extends GenericPackager implements ISODatasetPackag
     protected ISODataset unpackDBM(int identifier, byte[] content) throws ISOException {
         DBMBitmap dbm = unpackDBMBitmap(content);
         if (dbm.tlvContinuation) {
+            // TODO Support DBM trailing TLV continuation as defined by ISO 8583:2023 §4.4.4.4.
             throw new ISOException(String.format("Dataset %02X uses DBM TLV continuation, which is not supported yet", identifier));
         }
         ISODataset dataset = new ISODataset(identifier, DatasetFormat.DBM);

--- a/jpos/src/main/java/org/jpos/iso/packager/DatasetPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/DatasetPackager.java
@@ -1,0 +1,472 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso.packager;
+
+import org.jpos.iso.Dataset;
+import org.jpos.iso.DatasetElement;
+import org.jpos.iso.DatasetFormat;
+import org.jpos.iso.ISOBinaryField;
+import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISODataset;
+import org.jpos.iso.ISODatasetField;
+import org.jpos.iso.ISODatasetPackager;
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOUtil;
+import org.jpos.tlv.TLVList;
+import org.jpos.tlv.TLVMsg;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
+import org.xml.sax.Attributes;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Packager for ISO 8583:2023 composite fields that contain one or more datasets.
+ */
+public class DatasetPackager extends GenericPackager implements ISODatasetPackager {
+    private static final int TLV_DATASET_MAX_IDENTIFIER = 0x70;
+    private static final int DATASET_ENVELOPE_SIZE = 3;
+    private static final int DBM_INITIAL_BITS = 16;
+    private static final int DBM_CONTINUATION_BITS = 8;
+
+    private int fieldId;
+
+    /**
+     * Creates an empty dataset packager.
+     *
+     * @throws ISOException on packager initialization errors
+     */
+    public DatasetPackager() throws ISOException {
+        super();
+    }
+
+    /**
+     * Returns the outer ISO field number this dataset packager is bound to.
+     *
+     * @return outer field number, or {@code 0} when not initialized from XML
+     */
+    @Override
+    public int getFieldNumber() {
+        return fieldId;
+    }
+
+    /**
+     * Captures the outer field id declared in the XML packager definition.
+     *
+     * @param atts XML attributes for the current field packager
+     */
+    @Override
+    public void setGenericPackagerParams(Attributes atts) {
+        super.setGenericPackagerParams(atts);
+        fieldId = Integer.parseInt(atts.getValue("id"));
+    }
+
+    /**
+     * Packs a dataset field payload, including each dataset envelope.
+     *
+     * @param m dataset field component
+     * @return packed payload bytes
+     * @throws ISOException on packing errors
+     */
+    @Override
+    public byte[] pack(ISOComponent m) throws ISOException {
+        if (!(m instanceof ISODatasetField)) {
+            throw new ISOException("Can't call dataset packager on " + (m != null ? m.getClass().getName() : "null"));
+        }
+        LogEvent evt = new LogEvent(this, "pack");
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream(128)) {
+            ISODatasetField field = (ISODatasetField) m;
+            for (Dataset dataset : field.getDatasets()) {
+                byte[] content = packDatasetContent(dataset);
+                if (content.length == 0) {
+                    throw new ISOException(String.format("Dataset %02X cannot be empty", dataset.getIdentifier()));
+                }
+                if (content.length > 0xFFFF) {
+                    throw new ISOException(String.format("Dataset %02X too long: %d", dataset.getIdentifier(), content.length));
+                }
+                out.write(dataset.getIdentifier() & 0xFF);
+                out.write((content.length >> 8) & 0xFF);
+                out.write(content.length & 0xFF);
+                out.write(content);
+            }
+            byte[] packed = out.toByteArray();
+            if (logger != null) {
+                evt.addMessage(ISOUtil.hexString(packed));
+            }
+            return packed;
+        } catch (ISOException e) {
+            evt.addMessage(e);
+            throw e;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw new ISOException(e);
+        } finally {
+            Logger.log(evt);
+        }
+    }
+
+    /**
+     * Unpacks one or more datasets from a field payload.
+     *
+     * @param m destination dataset field
+     * @param b payload bytes
+     * @return number of bytes consumed
+     * @throws ISOException on unpacking errors
+     */
+    @Override
+    public int unpack(ISOComponent m, byte[] b) throws ISOException {
+        if (!(m instanceof ISODatasetField)) {
+            throw new ISOException("Can't call dataset packager on " + (m != null ? m.getClass().getName() : "null"));
+        }
+        LogEvent evt = new LogEvent(this, "unpack");
+        try {
+            ISODatasetField field = (ISODatasetField) m;
+            int consumed = 0;
+            while (consumed < b.length) {
+                if (b.length - consumed < DATASET_ENVELOPE_SIZE) {
+                    throw new ISOException("Truncated dataset envelope");
+                }
+                int identifier = b[consumed] & 0xFF;
+                int length = ((b[consumed + 1] & 0xFF) << 8) | (b[consumed + 2] & 0xFF);
+                consumed += DATASET_ENVELOPE_SIZE;
+                if (length <= 0) {
+                    throw new ISOException(String.format("Dataset %02X has invalid length %d", identifier, length));
+                }
+                if (consumed + length > b.length) {
+                    throw new ISOException(String.format("Dataset %02X overruns composite field", identifier));
+                }
+                byte[] content = Arrays.copyOfRange(b, consumed, consumed + length);
+                field.addDataset(unpackDataset(identifier, resolveDatasetFormat(identifier), content));
+                consumed += length;
+            }
+            if (logger != null) {
+                evt.addMessage(ISOUtil.hexString(b));
+            }
+            return consumed;
+        } catch (ISOException e) {
+            evt.addMessage(e);
+            throw e;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw new ISOException(e);
+        } finally {
+            Logger.log(evt);
+        }
+    }
+
+    /**
+     * Unpacks one or more datasets from a stream-backed payload.
+     *
+     * @param m destination dataset field
+     * @param in source stream
+     * @throws IOException on stream errors
+     * @throws ISOException on unpacking errors
+     */
+    @Override
+    public void unpack(ISOComponent m, InputStream in) throws IOException, ISOException {
+        unpack(m, in.readAllBytes());
+    }
+
+    /**
+     * Resolves the format implied by a dataset identifier.
+     *
+     * @param identifier dataset identifier
+     * @return inferred dataset format
+     */
+    protected DatasetFormat resolveDatasetFormat(int identifier) {
+        return identifier <= TLV_DATASET_MAX_IDENTIFIER ? DatasetFormat.TLV : DatasetFormat.DBM;
+    }
+
+    /**
+     * Packs the inner dataset payload without the outer dataset envelope.
+     *
+     * @param dataset dataset to encode
+     * @return encoded dataset payload
+     * @throws ISOException on packing errors
+     */
+    protected byte[] packDatasetContent(Dataset dataset) throws ISOException {
+        if (dataset.getFormat() == DatasetFormat.TLV) {
+            return packTLV(dataset);
+        }
+        return packDBM(dataset);
+    }
+
+    /**
+     * Decodes a dataset payload without the outer dataset envelope.
+     *
+     * @param identifier dataset identifier
+     * @param format dataset format
+     * @param content dataset payload bytes
+     * @return decoded dataset
+     * @throws ISOException on decoding errors
+     */
+    protected Dataset unpackDataset(int identifier, DatasetFormat format, byte[] content) throws ISOException {
+        return format == DatasetFormat.TLV
+          ? unpackTLV(identifier, content)
+          : unpackDBM(identifier, content);
+    }
+
+    /**
+     * Decodes a TLV dataset payload.
+     *
+     * @param identifier dataset identifier
+     * @param content TLV payload bytes
+     * @return decoded dataset
+     * @throws ISOException on decoding errors
+     */
+    protected ISODataset unpackTLV(int identifier, byte[] content) throws ISOException {
+        TLVList tlv = new TLVList();
+        try {
+            tlv.unpack(content);
+        } catch (RuntimeException e) {
+            throw new ISOException(String.format("Invalid TLV dataset %02X", identifier), e);
+        }
+        ISODataset dataset = new ISODataset(identifier, DatasetFormat.TLV);
+        for (TLVMsg tag : tlv.getTags()) {
+            ISOBinaryField field = new ISOBinaryField(tag.getTag(), tag.getValue());
+            dataset.addElement(tag.getTag(), field, isConstructedTag(tag.getTag()));
+        }
+        return dataset;
+    }
+
+    /**
+     * Encodes a TLV dataset payload.
+     *
+     * @param dataset dataset to encode
+     * @return TLV payload bytes
+     * @throws ISOException on encoding errors
+     */
+    protected byte[] packTLV(Dataset dataset) throws ISOException {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream(128)) {
+            for (DatasetElement element : dataset.getElements()) {
+                TLVMsg tlv = new TLVMsg(element.getId(), element.getBytes());
+                out.write(tlv.getTLV());
+            }
+            return out.toByteArray();
+        } catch (IllegalArgumentException e) {
+            throw new ISOException(String.format("Unable to pack TLV dataset %02X", dataset.getIdentifier()), e);
+        } catch (IOException e) {
+            throw new ISOException(e);
+        }
+    }
+
+    /**
+     * Decodes a DBM dataset payload.
+     *
+     * @param identifier dataset identifier
+     * @param content DBM payload bytes
+     * @return decoded dataset
+     * @throws ISOException on decoding errors
+     */
+    protected ISODataset unpackDBM(int identifier, byte[] content) throws ISOException {
+        DBMBitmap dbm = unpackDBMBitmap(content);
+        if (dbm.tlvContinuation) {
+            throw new ISOException(String.format("Dataset %02X uses DBM TLV continuation, which is not supported yet", identifier));
+        }
+        ISODataset dataset = new ISODataset(identifier, DatasetFormat.DBM);
+        int consumed = dbm.consumed;
+        for (int elementId : dbm.elements) {
+            if (elementId >= fld.length || fld[elementId] == null) {
+                throw new ISOException(String.format("No packager defined for dataset %02X element %d", identifier, elementId));
+            }
+            ISOComponent component = fld[elementId].createComponent(elementId);
+            consumed += fld[elementId].unpack(component, content, consumed);
+            dataset.addElement(elementId, component);
+        }
+        if (consumed != content.length) {
+            throw new ISOException(String.format("Dataset %02X content mismatch: consumed=%d len=%d", identifier, consumed, content.length));
+        }
+        return dataset;
+    }
+
+    /**
+     * Encodes a DBM dataset payload.
+     *
+     * @param dataset dataset to encode
+     * @return DBM payload bytes
+     * @throws ISOException on encoding errors
+     */
+    protected byte[] packDBM(Dataset dataset) throws ISOException {
+        List<DatasetElement> elements = dataset.getElements();
+        if (elements.isEmpty()) {
+            return new byte[0];
+        }
+        validateDBMElements(dataset);
+        byte[] bitmap = packDBMBitmap(elements);
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream(128)) {
+            out.write(bitmap);
+            for (int elementId : sortedElementIds(elements)) {
+                DatasetElement element = dataset.getElement(elementId);
+                if (elementId >= fld.length || fld[elementId] == null) {
+                    throw new ISOException(String.format("No packager defined for dataset %02X element %d", dataset.getIdentifier(), elementId));
+                }
+                out.write(fld[elementId].pack(element.getComponent()));
+            }
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new ISOException(e);
+        }
+    }
+
+    private void validateDBMElements(Dataset dataset) throws ISOException {
+        Set<Integer> seen = new TreeSet<>();
+        for (DatasetElement element : dataset.getElements()) {
+            if (!seen.add(element.getId())) {
+                throw new ISOException(String.format("DBM dataset %02X contains duplicate element %d", dataset.getIdentifier(), element.getId()));
+            }
+        }
+    }
+
+    private int[] sortedElementIds(List<DatasetElement> elements) {
+        return elements.stream().mapToInt(DatasetElement::getId).sorted().toArray();
+    }
+
+    private DBMBitmap unpackDBMBitmap(byte[] content) throws ISOException {
+        if (content.length < 2) {
+            throw new ISOException("DBM content too short");
+        }
+        List<byte[]> words = new ArrayList<>();
+        int offset = 0;
+        byte[] first = Arrays.copyOfRange(content, offset, offset + 2);
+        words.add(first);
+        offset += 2;
+
+        boolean continuation = isBitSet(first[0], 1);
+        while (continuation) {
+            if (offset >= content.length) {
+                throw new ISOException("Truncated DBM continuation");
+            }
+            byte[] next = new byte[] { content[offset] };
+            words.add(next);
+            offset++;
+            continuation = isBitSet(next[0], 1);
+        }
+
+        List<Integer> elements = new ArrayList<>();
+        int elementId = 1;
+        for (int i = 0; i < words.size(); i++) {
+            byte[] word = words.get(i);
+            boolean last = i == words.size() - 1;
+            int size = i == 0 ? DBM_INITIAL_BITS : DBM_CONTINUATION_BITS;
+            int lastUsableBit = last ? size - 1 : size;
+            int startBit = 2;
+            for (int bit = startBit; bit <= lastUsableBit; bit++) {
+                int byteIndex = (bit - 1) / 8;
+                int bitInByte = ((bit - 1) % 8) + 1;
+                if (isBitSet(word[byteIndex], bitInByte)) {
+                    elements.add(elementId);
+                }
+                elementId++;
+            }
+        }
+
+        boolean tlvContinuation = isBitSet(words.get(words.size() - 1)[words.get(words.size() - 1).length - 1], 8);
+        return new DBMBitmap(elements, tlvContinuation, offset);
+    }
+
+    private byte[] packDBMBitmap(List<DatasetElement> elements) {
+        int highestElement = elements.stream().mapToInt(DatasetElement::getId).max().orElse(0);
+        int extraWords = 0;
+        while (capacity(extraWords) < highestElement) {
+            extraWords++;
+        }
+        byte[] bitmap = new byte[2 + extraWords];
+        if (extraWords > 0) {
+            setBit(bitmap, 1);
+            for (int i = 2; i < bitmap.length - 1; i++) {
+                bitmap[i] |= (byte) 0x80;
+            }
+        }
+        for (DatasetElement element : elements) {
+            setElementBit(bitmap, element.getId(), extraWords);
+        }
+        return bitmap;
+    }
+
+    private int capacity(int extraWords) {
+        int capacity = extraWords == 0 ? 14 : 15;
+        if (extraWords > 0) {
+            capacity += (extraWords - 1) * 7;
+            capacity += 6;
+        }
+        return capacity;
+    }
+
+    private void setElementBit(byte[] bitmap, int elementId, int extraWords) {
+        if (extraWords == 0) {
+            if (elementId < 1 || elementId > 14) {
+                throw new IllegalArgumentException("DBM element out of range for single-word bitmap: " + elementId);
+            }
+            setBit(bitmap, elementId + 1);
+            return;
+        }
+        if (elementId <= 15) {
+            setBit(bitmap, elementId + 1);
+            return;
+        }
+        int remaining = elementId - 15;
+        for (int word = 1; word <= extraWords; word++) {
+            int wordCapacity = word < extraWords ? 7 : 6;
+            if (remaining <= wordCapacity) {
+                bitmap[word + 1] |= (byte) (0x80 >> remaining);
+                return;
+            }
+            remaining -= wordCapacity;
+        }
+        throw new IllegalArgumentException("DBM element out of range: " + elementId);
+    }
+
+    private void setBit(byte[] bitmap, int bitNumber) {
+        int byteIndex = (bitNumber - 1) / 8;
+        int shift = 7 - ((bitNumber - 1) % 8);
+        bitmap[byteIndex] |= (byte) (1 << shift);
+    }
+
+    private boolean isBitSet(byte value, int bitNumber) {
+        return ((value >> (8 - bitNumber)) & 0x01) == 0x01;
+    }
+
+    private boolean isConstructedTag(int tag) {
+        String hexTag = Integer.toHexString(tag);
+        if ((hexTag.length() & 0x01) == 1) {
+            hexTag = '0' + hexTag;
+        }
+        byte[] tagBytes = ISOUtil.hex2byte(hexTag);
+        return (tagBytes[0] & 0x20) == 0x20;
+    }
+
+    private static class DBMBitmap {
+        private final List<Integer> elements;
+        private final boolean tlvContinuation;
+        private final int consumed;
+
+        private DBMBitmap(List<Integer> elements, boolean tlvContinuation, int consumed) {
+            this.elements = elements;
+            this.tlvContinuation = tlvContinuation;
+            this.consumed = consumed;
+        }
+    }
+}

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
@@ -22,6 +22,8 @@ import org.jpos.core.Configurable;
 import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
 import org.jpos.iso.*;
+import org.jpos.iso.DatasetFieldPackager;
+import org.jpos.iso.ISODatasetPackager;
 import org.jpos.util.LogSource;
 import org.jpos.util.Logger;
 import org.xml.sax.Attributes;
@@ -523,9 +525,12 @@ public class GenericPackager
 
                 msgPackager.setLogger (getLogger(), getRealm() + "-fld-" + fno);
 
-                // Create the ISOMsgField packager with the retrieved msg and field Packagers
-                ISOMsgFieldPackager mfp =
-                    new ISOMsgFieldPackager(fieldPackager, msgPackager);
+                ISOFieldPackager mfp;
+                if (msgPackager instanceof ISODatasetPackager) {
+                    mfp = new DatasetFieldPackager(fieldPackager, (ISODatasetPackager) msgPackager);
+                } else {
+                    mfp = new ISOMsgFieldPackager(fieldPackager, msgPackager);
+                }
 
                 // Add the newly created ISOMsgField packager to the
                 // lower level field stack

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericValidatingPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericValidatingPackager.java
@@ -20,9 +20,11 @@ package org.jpos.iso.packager;
 
 import org.jpos.core.ConfigurationException;
 import org.jpos.core.SimpleConfiguration;
+import org.jpos.iso.DatasetFieldPackager;
 import org.jpos.iso.ISOBasePackager;
 import org.jpos.iso.ISOBaseValidator;
 import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISODatasetPackager;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOFieldPackager;
 import org.jpos.iso.ISOFieldValidator;
@@ -378,9 +380,12 @@ onto the stack.
                 msgPackager.setLogger (getLogger(), "Generic Packager");
                 ISOFieldPackager fieldPackager = (ISOFieldPackager) fieldStack.pop();
                 Integer fno = (Integer) fieldStack.pop();
-                // Create the ISOMsgField packager with the retrieved msg and field Packagers
-                ISOMsgFieldPackager mfp =
-                        new ISOMsgFieldPackager(fieldPackager, msgPackager);
+                ISOFieldPackager mfp;
+                if (msgPackager instanceof ISODatasetPackager) {
+                    mfp = new DatasetFieldPackager(fieldPackager, (ISODatasetPackager) msgPackager);
+                } else {
+                    mfp = new ISOMsgFieldPackager(fieldPackager, msgPackager);
+                }
 
                 // Add the newly created ISOMsgField packager to the
                 // lower level field stack

--- a/jpos/src/main/java/org/jpos/iso/packager/ICCDataPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/ICCDataPackager.java
@@ -1,0 +1,101 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso.packager;
+
+import org.jpos.iso.Dataset;
+import org.jpos.iso.DatasetFormat;
+import org.jpos.iso.ISODatasetField;
+import org.jpos.iso.ISOComponent;
+import org.jpos.iso.ISODataset;
+import org.jpos.iso.ISOException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Special-case packager for DE 055 ICC data, which carries raw BER-TLV without
+ * the standard dataset identifier and length envelope.
+ */
+public class ICCDataPackager extends DatasetPackager {
+    /**
+     * Creates an ICC data packager.
+     *
+     * @throws ISOException on packager initialization errors
+     */
+    public ICCDataPackager() throws ISOException {
+        super();
+    }
+
+    /**
+     * Packs raw ICC BER-TLV bytes without the standard dataset envelope.
+     *
+     * @param m ICC dataset field
+     * @return packed BER-TLV bytes
+     * @throws ISOException on packing errors
+     */
+    @Override
+    public byte[] pack(ISOComponent m) throws ISOException {
+        if (!(m instanceof ISODatasetField)) {
+            throw new ISOException("Can't call ICC data packager on " + (m != null ? m.getClass().getName() : "null"));
+        }
+        ISODatasetField field = (ISODatasetField) m;
+        Dataset dataset = field.getDataset(getFieldNumber());
+        if (dataset == null) {
+            if (field.getDatasets().isEmpty()) {
+                return new byte[0];
+            }
+            dataset = field.getDatasets().get(0);
+        }
+        if (dataset.getFormat() != DatasetFormat.TLV) {
+            throw new ISOException("ICC data is BER-TLV only");
+        }
+        return packDatasetContent(dataset);
+    }
+
+    /**
+     * Unpacks raw ICC BER-TLV bytes into a synthetic dataset keyed by the outer field number.
+     *
+     * @param m destination dataset field
+     * @param b BER-TLV bytes
+     * @return number of bytes consumed
+     * @throws ISOException on unpacking errors
+     */
+    @Override
+    public int unpack(ISOComponent m, byte[] b) throws ISOException {
+        if (!(m instanceof ISODatasetField)) {
+            throw new ISOException("Can't call ICC data packager on " + (m != null ? m.getClass().getName() : "null"));
+        }
+        ISODataset dataset = unpackTLV(getFieldNumber(), b);
+        ((ISODatasetField) m).addDataset(dataset);
+        return b.length;
+    }
+
+    /**
+     * Unpacks raw ICC BER-TLV bytes from a stream.
+     *
+     * @param m destination dataset field
+     * @param in source stream
+     * @throws IOException on stream errors
+     * @throws ISOException on unpacking errors
+     */
+    @Override
+    public void unpack(ISOComponent m, InputStream in) throws IOException, ISOException {
+        unpack(m, in.readAllBytes());
+    }
+}

--- a/jpos/src/main/java/org/jpos/iso/packager/ICCDataPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/ICCDataPackager.java
@@ -43,6 +43,17 @@ public class ICCDataPackager extends DatasetPackager {
     }
 
     /**
+     * ICC data is encoded as raw BER-TLV, without the standard dataset
+     * identifier and length envelope.
+     *
+     * @return always {@code false}
+     */
+    @Override
+    public boolean hasDatasetEnvelope() {
+        return false;
+    }
+
+    /**
      * Packs raw ICC BER-TLV bytes without the standard dataset envelope.
      *
      * @param m ICC dataset field

--- a/jpos/src/main/java/org/jpos/iso/packager/XMLPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/XMLPackager.java
@@ -62,10 +62,14 @@ public class XMLPackager extends DefaultHandler
     public static final String TYPE_BINARY   = "binary";
     public static final String TYPE_BITMAP   = "bitmap";
     public static final String TYPE_AMOUNT   = "amount";
+    public static final String TYPE_DATASET  = "dataset";
     public static final String CURRENCY_ATTR = "currency";
     public static final String HEADER_TAG    = "header";
     public static final String ENCODING_ATTR = "encoding";
     public static final String ASCII_ENCODING= "ascii";
+    public static final String DATASET_TAG   = "dataset";
+    public static final String ELEMENT_TAG   = "element";
+    public static final String FORMAT_ATTR   = "format";
 
     // fields that will be forced to be interpreted as binary data
     private int[] binaryFields= null;
@@ -167,17 +171,9 @@ public class XMLPackager extends DefaultHandler
         (String ns, String name, String qName, Attributes atts)
         throws SAXException
     {
-        int fieldNumber = -1;
         try {
-            String id       = atts.getValue(ID_ATTR);
-            if (id != null) {
-                try {
-                    fieldNumber = Integer.parseInt (id);
-                } catch (NumberFormatException ex) {
-                    throw new SAXException ("Invalid id " + id);
-                }
-            }
             if (name.equals (ISOMSG_TAG)) {
+                int fieldNumber = parseDecimalId(atts.getValue(ID_ATTR));
                 if (fieldNumber >= 0) {
                     if (stk.empty())
                         throw new SAXException ("inner without outer");
@@ -189,7 +185,9 @@ public class XMLPackager extends DefaultHandler
                     stk.push (new ISOMsg(0));
                 }
             } else if (name.equals (ISOFIELD_TAG)) {
+                int fieldNumber = parseDecimalId(atts.getValue(ID_ATTR));
                 ISOMsg m     = (ISOMsg) stk.peek();
+                String id    = atts.getValue(ID_ATTR);
                 String value = atts.getValue(VALUE_ATTR);
                 String type  = atts.getValue(TYPE_ATTR);
                 if (id == null)
@@ -197,7 +195,10 @@ public class XMLPackager extends DefaultHandler
                 value = value == null ? "" : value;
 
                 ISOComponent ic;
-                if (TYPE_BINARY.equals (type)) {
+                if (TYPE_DATASET.equals(type)) {
+                    ic = new ISODatasetField(fieldNumber);
+                }
+                else if (TYPE_BINARY.equals (type)) {
                     ic = new ISOBinaryField (
                         fieldNumber,
                             ISOUtil.hex2byte (
@@ -217,14 +218,34 @@ public class XMLPackager extends DefaultHandler
                 }
                 m.set (ic);
                 stk.push (ic);
+            } else if (DATASET_TAG.equals(name)) {
+                if (!(stk.peek() instanceof ISODatasetField))
+                    throw new SAXException("dataset without dataset field");
+                String id = atts.getValue(ID_ATTR);
+                String format = atts.getValue(FORMAT_ATTR);
+                if (id == null || format == null)
+                    throw new SAXException("invalid dataset");
+                ISODataset dataset = new ISODataset(parseHexId(id), DatasetFormat.valueOf(format));
+                ((ISODatasetField) stk.peek()).addDataset(dataset);
+                stk.push(dataset);
+            } else if (ELEMENT_TAG.equals(name)) {
+                if (!(stk.peek() instanceof ISODataset))
+                    throw new SAXException("element without dataset");
+                ISODataset dataset = (ISODataset) stk.peek();
+                String id = atts.getValue(ID_ATTR);
+                String value = atts.getValue(VALUE_ATTR);
+                if (id == null)
+                    throw new SAXException("invalid dataset element");
+                int elementId = dataset.getFormat() == DatasetFormat.TLV ? parseHexId(id) : parseDecimalOrHexId(id);
+                byte[] bytes = value == null ? new byte[0] : ISOUtil.hex2byte(value.getBytes(), 0, value.length() / 2);
+                dataset.addElement(elementId, new ISOBinaryField(elementId, bytes), dataset.getFormat() == DatasetFormat.TLV && isConstructedTag(elementId));
             } else if (HEADER_TAG.equals (name)) {
                 BaseHeader bh = new BaseHeader();
                 bh.setAsciiEncoding (ASCII_ENCODING.equalsIgnoreCase(atts.getValue(ENCODING_ATTR)));
                 stk.push (bh);
             }
         } catch (ISOException e) {
-            throw new SAXException
-                ("ISOException unpacking "+fieldNumber);
+            throw new SAXException ("ISOException unpacking XML dataset", e);
         }
     }
 
@@ -261,6 +282,8 @@ public class XMLPackager extends DefaultHandler
             ISOMsg m = (ISOMsg) stk.pop();
             if (stk.empty())
                 stk.push (m); // push outer message
+        } else if (DATASET_TAG.equals(name)) {
+            stk.pop();
         } else if (ISOFIELD_TAG.equals (name)) {
             stk.pop();
         } else if (HEADER_TAG.equals (name)) {
@@ -324,5 +347,39 @@ public class XMLPackager extends DefaultHandler
     public void setXMLParserFeature(String fname, boolean val) throws SAXException  {
         reader.setFeature(fname, val);
     }
-}
 
+    private int parseDecimalId(String id) throws SAXException {
+        if (id == null)
+            return -1;
+        try {
+            return Integer.parseInt(id);
+        } catch (NumberFormatException ex) {
+            throw new SAXException("Invalid id " + id, ex);
+        }
+    }
+
+    private int parseDecimalOrHexId(String id) throws SAXException {
+        try {
+            return id.startsWith("0x") || id.startsWith("0X") ? Integer.parseInt(id.substring(2), 16) : Integer.parseInt(id);
+        } catch (NumberFormatException ex) {
+            throw new SAXException("Invalid id " + id, ex);
+        }
+    }
+
+    private int parseHexId(String id) throws SAXException {
+        try {
+            String normalized = id.startsWith("0x") || id.startsWith("0X") ? id.substring(2) : id;
+            return Integer.parseInt(normalized, 16);
+        } catch (NumberFormatException ex) {
+            throw new SAXException("Invalid hex id " + id, ex);
+        }
+    }
+
+    private boolean isConstructedTag(int tag) {
+        String hexTag = Integer.toHexString(tag);
+        if ((hexTag.length() & 0x01) == 1)
+            hexTag = "0" + hexTag;
+        byte[] tagBytes = ISOUtil.hex2byte(hexTag);
+        return (tagBytes[0] & 0x20) == 0x20;
+    }
+}

--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -1,0 +1,1175 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE isopackager PUBLIC
+        "-//jPOS/jPOS Generic Packager DTD 1.0//EN"
+        "http://jpos.org/dtd/generic-packager-1.0.dtd">
+
+<!-- jPOS Common Message Format - see http://jpos.org/doc/jPOS-CMF.pdf -->
+
+<isopackager>
+  <isofield
+      id="0"
+      length="4"
+      name="Message Type Indicator"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="1"
+      length="16"
+      name="Bitmap"
+      class="org.jpos.iso.IFB_BITMAP"/>
+  <isofield
+      id="2"
+      length="19"
+      name="Primary Account number"
+      pad="false"
+      class="org.jpos.iso.IFB_LLNUM"/>
+  <isofield
+      id="3"
+      length="6"
+      name="Processing Code"
+      pad="false"
+      class="org.jpos.iso.IF_CHAR"/>
+  <isofield
+      id="4"
+      length="16"
+      name="Amount, Transaction"
+      pad="false"
+      class="org.jpos.iso.IFB_AMOUNT2003"/>
+  <isofield
+      id="5"
+      length="16"
+      name="Amount, Reconciliation"
+      pad="false"
+      class="org.jpos.iso.IFB_AMOUNT2003"/>
+  <isofield
+      id="6"
+      length="16"
+      name="Amount, Cardholder billing"
+      pad="false"
+      class="org.jpos.iso.IFB_AMOUNT2003"/>
+  <isofield
+      id="7"
+      length="10"
+      name="Date and time, transmission"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="8"
+      length="12"
+      name="Amount, Cardholder billing fee"
+      pad="false"
+      class="org.jpos.iso.IFB_AMOUNT2003"/>
+  <isofield
+      id="9"
+      length="8"
+      name="Conversion rate, Reconciliation"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="10"
+      length="8"
+      name="Conversion rate, Cardholder billing"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="11"
+      length="12"
+      name="Systems trace audit number"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="12"
+      length="14"
+      name="Date and time, Local transaction"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="13"
+      length="6"
+      name="Date, Effective"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="14"
+      length="4"
+      name="Date, Expiration"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="15"
+      length="8"
+      name="Date, Settlement"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="16"
+      length="4"
+      name="Date, Conversion"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="17"
+      length="4"
+      name="Date, Capture"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="18"
+      length="140"
+      name="Message error indicator"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="19"
+      length="3"
+      name="Country code, Acquiring institution"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="20"
+      length="3"
+      name="Country code, Primary account number"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofieldpackager
+      id="21"
+      length="19"
+      name="Transaction life cycle identification data"
+      class="org.jpos.iso.IFB_BINARY"
+      pad="false"
+      emitBitmap="false"
+      firstField="0"
+      packager="org.jpos.iso.packager.GenericSubFieldPackager">
+      <isofield
+          id="0"
+          length="1"
+          name="support indicator"
+          class="org.jpos.iso.IF_CHAR"/>
+      <isofield
+          id="1"
+          length="15"
+          name="trace indicator"
+          class="org.jpos.iso.IF_CHAR"/>
+      <isofield
+          id="2"
+          length="2"
+          name="sequence number"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="3"
+          length="4"
+          name="authentication token"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+  </isofieldpackager>
+  <isofield
+      id="22"
+      length="16"
+      name="Point of service data code"
+      class="org.jpos.iso.IFB_BINARY"/>
+  <isofield
+      id="23"
+      length="3"
+      name="Card sequence number"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="24"
+      length="3"
+      name="Function code"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="25"
+      length="4"
+      name="Message reason code"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="26"
+      length="4"
+      name="Merchant category code"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofieldpackager
+      id="27"
+      length="27"
+      name="POS capability"
+      pad="false"
+      class="org.jpos.iso.IFB_BINARY"
+      emitBitmap="false"
+      firstField="0"
+      packager="org.jpos.iso.packager.GenericSubFieldPackager">
+    <isofield
+      id="0"
+      length="8"
+      name="Card Reading and Verification Capabilities"
+      pad="false"
+      class="org.jpos.iso.IFB_BINARY"/>
+    <isofield
+      id="1"
+      length="1"
+      name="Approval code length"
+      class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+      id="2"
+      length="3"
+      name="Cardholder receipt data length"
+      class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+      id="3"
+      length="3"
+      name="Card acceptor receipt data length"
+      class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+      id="4"
+      length="3"
+      name="Cardholder display data length"
+      class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+      id="5"
+      length="3"
+      name="Card acceptor display data length"
+      class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+      id="6"
+      length="3"
+      name="ICC script data length"
+      class="org.jpos.iso.IFA_NUMERIC"/>
+    <isofield
+      id="7"
+      length="1"
+      name="Track3 rewrite capability"
+      class="org.jpos.iso.IF_CHAR"/>
+    <isofield
+      id="8"
+      length="1"
+      name="Card capture capability"
+      class="org.jpos.iso.IF_CHAR"/>
+    <isofield
+      id="9"
+      length="1"
+      name="PIN Input length"
+      class="org.jpos.iso.IFB_BINARY"/>
+  </isofieldpackager>
+  <isofield
+      id="28"
+      length="8"
+      name="Date, Reconciliation"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="29"
+      length="3"
+      name="Reconciliation indicator"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofieldpackager
+      id="30"
+      length="16"
+      name="Amounts original"
+      class="org.jpos.iso.IFB_BINARY"
+      emitBitmap="false"
+      firstField="0"
+      packager="org.jpos.iso.packager.GenericSubFieldPackager">
+      <isofield
+          id="0"
+          length="16"
+          name="Replacement amount"
+          pad="false"
+          class="org.jpos.iso.IFB_AMOUNT2003"/>
+      <isofield
+          id="1"
+          length="16"
+          name="Replacement reconciliation amount"
+          pad="false"
+          class="org.jpos.iso.IFB_AMOUNT2003"/>
+  </isofieldpackager>
+  <isofield
+      id="31"
+      length="23"
+      name="Acquirer reference number"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="32"
+      length="11"
+      name="Acquirer institution identfication code"
+      pad="false"
+      class="org.jpos.iso.IFB_LLNUM"/>
+  <isofield
+      id="33"
+      length="11"
+      name="Forwarding institution identification code"
+      pad="false"
+      class="org.jpos.iso.IFB_LLNUM"/>
+  <isofieldpackager
+      id="34"
+      length="9999"
+      name="Electronic commerce data"
+      class="org.jpos.iso.IFB_LLLLBINARY"
+      packager="org.jpos.iso.packager.DatasetPackager">
+  </isofieldpackager>
+  <isofield
+      id="35"
+      length="37"
+      name="Track 2 data"
+      class="org.jpos.iso.IFB_LLCHAR"/>
+  <isofield
+      id="36"
+      length="104"
+      name="Track 3 data"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="37"
+      length="12"
+      name="Retrieval reference number"
+      class="org.jpos.iso.IF_CHAR"/>
+  <isofield
+      id="38"
+      length="6"
+      name="Approval code"
+      class="org.jpos.iso.IF_CHAR"/>
+  <isofield
+      id="39"
+      length="4"
+      name="Action code"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+
+  <isofield
+      id="40"
+      length="3"
+      name="Service code"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="41"
+      length="16"
+      name="Card acceptor terminal identification"
+      class="org.jpos.iso.IF_CHAR"/>
+  <isofield
+      id="42"
+      length="35"
+      name="Card acceptor identification code"
+      class="org.jpos.iso.IFB_LLCHAR"/>
+  <isofieldpackager
+      id="43"
+      length="9999"
+      name="Card acceptor name/location"
+      class="org.jpos.iso.IFB_LLLLBINARY"
+      emitBitmap="true" bitmapField="0"
+      packager="org.jpos.iso.packager.DatasetPackager">
+      <isofield
+          id="0"
+          length="16"
+          name="Bit Map"
+          class="org.jpos.iso.IFB_BITMAP"/>
+      <isofield
+          id="2"
+          length="50"
+          name="Card acceptor name"
+          class="org.jpos.iso.IFB_LLCHAR"/>
+      <isofield
+          id="3"
+          length="99"
+          name="Card acceptor street address"
+          class="org.jpos.iso.IFB_LLCHAR"/>
+      <isofield
+          id="4"
+          length="50"
+          name="Card acceptor city"
+          class="org.jpos.iso.IFB_LLCHAR"/>
+      <isofield
+          id="5"
+          length="3"
+          name="Card acceptor state, province, or region"
+          class="org.jpos.iso.IF_CHAR"/>
+      <isofield
+          id="6"
+          length="10"
+          name="Card acceptor postal code"
+          class="org.jpos.iso.IF_CHAR"/>
+      <isofield
+          id="7"
+          length="3"
+          name="Card acceptor country code"
+          class="org.jpos.iso.IF_CHAR"/>
+      <isofield
+          id="8"
+          length="16"
+          name="Card acceptor phone number"
+          class="org.jpos.iso.IF_CHAR"/>
+      <isofield
+          id="9"
+          length="16"
+          name="Card acceptor customer service phone number"
+          class="org.jpos.iso.IF_CHAR"/>
+      <isofield
+          id="10"
+          length="30"
+          name="Card acceptor additional contact information"
+          class="org.jpos.iso.IFB_LLCHAR"/>
+      <isofield
+          id="11"
+          length="255"
+          name="Card acceptor internet URL"
+          class="org.jpos.iso.IFB_LLLCHAR"/>
+      <isofield
+          id="12"
+          length="99"
+          name="Card acceptor e-mail address"
+          class="org.jpos.iso.IFB_LLCHAR"/>
+  </isofieldpackager>
+  <isofield
+      id="44"
+      length="9999"
+      name="Additional response data"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="45"
+      length="76"
+      name="Track 1 data"
+      class="org.jpos.iso.IFB_LLCHAR"/>
+  <isofield
+      id="46"
+      length="216"
+      name="Amounts fees"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="47"
+      length="999"
+      name="Additional data national"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="48"
+      length="999"
+      name="Additional data private"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofieldpackager
+      id="49"
+      length="9999"
+      name="Verification data"
+      class="org.jpos.iso.IFB_LLLLBINARY"
+      emitBitmap="true" bitmapField="0"
+      packager="org.jpos.iso.packager.DatasetPackager">
+      <isofield
+          id="0"
+          length="16"
+          name="Bit Map"
+          class="org.jpos.iso.IFB_BITMAP"/>
+      <isofield
+        id="1"
+        length="1"
+        name="Additional identification type"
+        class="org.jpos.iso.IFB_NUMERIC" />
+      <isofield
+        id="2"
+        length="4"
+        name="Card verification data"
+        class="org.jpos.iso.IFB_NUMERIC" />
+      <isofield
+        id="3"
+        length="16"
+        name="Cardholder billing address compressed"
+        class="org.jpos.iso.IF_CHAR" />
+      <isofield
+        id="4"
+        length="10"
+        name="Cardholder billing postal code"
+        class="org.jpos.iso.IF_CHAR" />
+      <isofield
+        id="5"
+        length="40"
+        name="Cardholder billing street address"
+        class="org.jpos.iso.IF_CHAR" />
+      <isofield
+        id="6"
+        length="1"
+        name="Address verification result code"
+        class="org.jpos.iso.IF_CHAR" />
+  </isofieldpackager>
+  <isofield
+      id="50"
+      length="9999"
+      name="Reserved for ISO"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="51"
+      length="9999"
+      name="Reserved for ISO"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="52"
+      length="8"
+      name="PIN data"
+      class="org.jpos.iso.IFB_BINARY"/>
+  <isofield
+      id="53"
+      length="48"
+      name="Security related control information"
+      class="org.jpos.iso.IFB_LLBINARY"/>
+  <isofield
+      id="54"
+      length="126"
+      name="Amounts, additional"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofieldpackager
+      id="55"
+      length="9999"
+      name="IC system related data"
+      class="org.jpos.iso.IFB_LLLLBINARY"
+      packager="org.jpos.iso.packager.ICCDataPackager">
+  </isofieldpackager>
+  <isofield
+      id="56"
+      length="41"
+      name="Original data elements"
+      pad="false"
+      class="org.jpos.iso.IFB_LLNUM"/>
+  <isofield
+      id="57"
+      length="3"
+      name="Authorization life cycle code"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="58"
+      length="11"
+      name="Authorizing agent institution identification code"
+      pad="false"
+      class="org.jpos.iso.IFB_LLNUM"/>
+  <isofield
+      id="59"
+      length="999"
+      name="Transport data"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="60"
+      length="999"
+      name="Reserved for national use"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="61"
+      length="999"
+      name="Reserved for national use"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="62"
+      length="999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="63"
+      length="999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="64"
+      length="4"
+      name="Message authentication code field"
+      class="org.jpos.iso.IFB_BINARY"/>
+  <isofield
+      id="65"
+      length="8"
+      name="Reserved for ISO use"
+      class="org.jpos.iso.IFB_BINARY"/>
+  <isofield
+      id="66"
+      length="216"
+      name="Amounts, original fees"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="67"
+      length="2"
+      name="Extended payment data"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield
+      id="68"
+      length="9"
+      name="Batch/file transfer message control"
+      pad="false"
+      class="org.jpos.iso.IF_CHAR"/>
+  <isofield
+      id="69"
+      length="40"
+      name="Batch/file transfer control data"
+      pad="false"
+      class="org.jpos.iso.IF_CHAR"/>
+  <isofield
+      id="70"
+      length="18"
+      name="File transfer description data"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofieldpackager
+      id="71"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"
+      packager="org.jpos.iso.packager.DatasetPackager">
+  </isofieldpackager>
+  <isofield
+      id="72"
+      length="999"
+      name="Data record"
+      class="org.jpos.iso.IFB_LLLBINARY"/>
+  <isofield
+      id="73"
+      length="8"
+      name="Date action"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofieldpackager
+      id="74"
+      length="78"
+      name="Reconciliation data primary"
+      class="org.jpos.iso.IFB_BINARY"
+      emitBitmap="false" firstField="0"
+      packager="org.jpos.iso.packager.GenericSubFieldPackager">
+      <isofield
+          id="0"
+          length="16"
+          name="Credits amount"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="1"
+          length="10"
+          name="Credits number"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="2"
+          length="16"
+          name="Credits chargeback amount"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="3"
+          length="10"
+          name="Credits chargeback number"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="4"
+          length="16"
+          name="Credits reversal amount"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="5"
+          length="10"
+          name="Credits reversal number"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="6"
+          length="16"
+          name="Debits amount"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="7"
+          length="10"
+          name="Debits number"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="8"
+          length="16"
+          name="Debits chargeback amount"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="9"
+          length="10"
+          name="Debits chargeback number"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="10"
+          length="16"
+          name="Debits reversal amount"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+      <isofield
+          id="11"
+          length="10"
+          name="Debits reversal number"
+          class="org.jpos.iso.IFB_NUMERIC"/>
+  </isofieldpackager>
+  <isofield
+      id="75"
+      length="90"
+      name="Reconciliation data secondary"
+      pad="false"
+      class="org.jpos.iso.IFB_NUMERIC"/>
+  <isofield id="76"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="77"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="78"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="79"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="80"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="81"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="82"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="83"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="84"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="85"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="86"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="87"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="88"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="89"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="90"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="96"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield id="92"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="93"
+      length="11"
+      name="Transaction destination institution identification code"
+      pad="false"
+      class="org.jpos.iso.IFB_LLNUM"/>
+  <isofield
+      id="94"
+      length="11"
+      name="Transaction originator institution identification code"
+      pad="false"
+      class="org.jpos.iso.IFB_LLNUM"/>
+  <isofield
+      id="95"
+      length="99"
+      name="Card issuer reference data"
+      class="org.jpos.iso.IFB_LLCHAR"/>
+  <isofield
+      id="96"
+      length="999"
+      name="Key management data"
+      class="org.jpos.iso.IFB_LLLBINARY"/>
+  <isofield
+      id="97"
+      length="21"
+      name="Amount, Net reconciliation"
+      pad="false"
+      class="org.jpos.iso.IFB_AMOUNT2003"/>
+  <isofield
+      id="98"
+      length="25"
+      name="Payee"
+      class="org.jpos.iso.IF_CHAR"/>
+  <isofield
+      id="99"
+      length="11"
+      name="Settlement institution identification code"
+      class="org.jpos.iso.IFB_LLCHAR"/>
+  <isofield
+      id="100"
+      length="11"
+      name="Receiving institution identification code"
+      pad="false"
+      class="org.jpos.iso.IFB_LLNUM"/>
+  <isofield
+      id="101"
+      length="99"
+      name="File name"
+      class="org.jpos.iso.IFB_LLCHAR"/>
+  <isofield
+      id="102"
+      length="28"
+      name="Account identification 1"
+      class="org.jpos.iso.IFB_LLCHAR"/>
+  <isofield
+      id="103"
+      length="28"
+      name="Account identification 2"
+      class="org.jpos.iso.IFB_LLCHAR"/>
+  <isofieldpackager
+      id="104"
+      length="9999"
+      name="Transaction specific data"
+      class="org.jpos.iso.IFB_LLLLBINARY"
+      packager="org.jpos.iso.packager.DatasetPackager">
+  </isofieldpackager>
+  <isofield
+      id="105"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="106"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="107"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="108"
+      length="9999"
+      name="Reserved for ISO use"
+      pad="false"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+
+  <isofield
+      id="109"
+      length="144"
+      name="Reconciliation fee amounts credit"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="110"
+      length="144"
+      name="Reconciliation fee amounts debit"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="111"
+      length="9999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="112"
+      length="9999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofieldpackager
+      id="113"
+      length="9999"
+      name="TPP private use"
+      class="org.jpos.iso.IFB_LLLLBINARY"
+      packager="org.jpos.iso.packager.GenericSubFieldPackager">
+      <isofield
+          id="0"
+          length="0"
+          name="Placeholder"
+          class="org.jpos.iso.IF_NOP" />
+      <isofield
+          id="1"
+          length="16"
+          name="Bit Map"
+          class="org.jpos.iso.IFB_BITMAP" />
+      <isofield
+          id="2"
+          length="20"
+          name="jPOS CMF Version"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="3"
+          length="40"
+          name="Firstname"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="4"
+          length="40"
+          name="Middle name"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="5"
+          length="40"
+          name="Lastname"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="6"
+          length="40"
+          name="Secondary lastname"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="7"
+          length="99"
+          name="email"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="8"
+          length="1"
+          name="Status flags"
+          class="org.jpos.iso.IFB_BINARY" />
+      <isofield
+          id="9"
+          length="10"
+          name="Honorific"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="10"
+          length="1"
+          name="Gender"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
+          id="11"
+          length="40"
+          name="Address 1"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="12"
+          length="40"
+          name="Address 2"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="13"
+          length="40"
+          name="City"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="14"
+          length="2"
+          name="State"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
+          id="15"
+          length="10"
+          name="Zip code"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="16"
+          length="2"
+          name="Country code"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
+          id="17"
+          length="20"
+          name="Phone"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="18"
+          length="99"
+          name="Notes"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="19"
+          length="32"
+          name="Dates"
+          class="org.jpos.iso.IFB_LLNUM" />
+      <isofield
+          id="20"
+          length="64"
+          name="Customer Alternate Identifier"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="21"
+          length="16"
+          name="Card Product ID"
+          class="org.jpos.iso.IFB_LLNUM" />
+      <isofield
+          id="22"
+          length="221"
+          name="UUIDs"
+          class="org.jpos.iso.IFB_LLLCHAR" />
+      <isofield
+          id="23"
+          length="11"
+          name="SSN"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
+          id="24"
+          length="4"
+          name="Installments Information"
+          class="org.jpos.iso.IFB_NUMERIC" />
+      <isofield
+          id="25"
+          length="64"
+          name="Network Name"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="26"
+          length="16"
+          name="Device ID/IMEI"
+          class="org.jpos.iso.IFB_LLNUM" />
+      <isofield
+          id="27"
+          length="64"
+          name="Geolocation"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="28"
+          length="64"
+          name="Cardholder Identification Data"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="29"
+          length="64"
+          name="Invoice"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="30"
+          length="2"
+          name="Total records for presentment"
+          class="org.jpos.iso.IFB_NUMERIC" />
+      <isofield
+          id="31"
+          length="2"
+          name="Presentment Sequence Number"
+          class="org.jpos.iso.IFB_NUMERIC" />
+      <isofield
+          id="32"
+          length="99"
+          name="Interchange fee"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="39"
+          length="4"
+          name="Remote ISO result code"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="52"
+          length="8"
+          name="New PIN Block"
+          class="org.jpos.iso.IFB_BINARY"/>
+      <isofield
+          id="53"
+          length="48"
+          name="KSN for new PIN Block"
+          class="org.jpos.iso.IFB_LLBINARY"/>
+      <isofield
+          id="63"
+          length="9999"
+          name="Additional Data - reserved for private use"
+          class="org.jpos.iso.IFB_LLLLCHAR" />
+      <isofield
+          id="69"
+          length="40"
+          name="Card Token"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
+          id="70"
+          length="19"
+          name="Transaction ID"
+          class="org.jpos.iso.IFB_NUMERIC" />
+      <isofield
+          id="71"
+          length="19"
+          name="Transaction GroupID"
+          class="org.jpos.iso.IFB_NUMERIC" />
+  </isofieldpackager>
+  <isofield
+      id="114"
+      length="9999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="115"
+      length="9999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="116"
+      length="9999"
+      name="Reserved for national use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="117"
+      length="9999"
+      name="Reserved for national use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="118"
+      length="9999"
+      name="Reserved for national use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="119"
+      length="9999"
+      name="Reserved for national use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="120"
+      length="9999"
+      name="Reserved for national use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="121"
+      length="9999"
+      name="Reserved for national use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="122"
+      length="9999"
+      name="Reserved for national use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="123"
+      length="999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLCHAR"/>
+  <isofield
+      id="124"
+      length="9999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="125"
+      length="9999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="126"
+      length="9999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="127"
+      length="9999"
+      name="Reserved for private use"
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
+  <isofield
+      id="128"
+      length="4"
+      name="Message authentication code field"
+      class="org.jpos.iso.IFB_BINARY"/>
+</isopackager>

--- a/jpos/src/test/java/org/jpos/iso/DatasetPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/DatasetPackagerTest.java
@@ -68,6 +68,43 @@ public class DatasetPackagerTest {
     }
 
     @Test
+    public void testDBMUnpacksTrailingTLVContinuation() throws Exception {
+        DatasetPackager packager = createBinaryDatasetPackager(2);
+        ISODatasetField field = new ISODatasetField(49);
+        byte[] packed = ISOUtil.hex2byte("7100084001119F02020102");
+
+        int consumed = packager.unpack(field, packed);
+
+        assertEquals(packed.length, consumed);
+        ISODataset dataset = (ISODataset) field.getDataset(0x71);
+        assertNotNull(dataset);
+        assertEquals(DatasetFormat.DBM, dataset.getFormat());
+        assertArrayEquals(new byte[] { 0x11 }, dataset.getBytes(1));
+        assertArrayEquals(ISOUtil.hex2byte("0102"), dataset.getBytes(0x9F02));
+        assertArrayEquals(packed, packager.pack(field));
+    }
+
+    @Test
+    public void testDBMPacksTrailingTLVContinuationRoundTrip() throws Exception {
+        DatasetPackager packager = createBinaryDatasetPackager(2);
+        ISODatasetField field = new ISODatasetField(49);
+        ISODataset dataset = new ISODataset(0x71, DatasetFormat.DBM);
+        dataset.addElement(1, new ISOBinaryField(1, new byte[] { 0x11 }));
+        dataset.addElement(0x9F02, new ISOBinaryField(0x9F02, ISOUtil.hex2byte("0102")));
+        field.addDataset(dataset);
+
+        byte[] packed = packager.pack(field);
+
+        assertEquals("7100084001119F02020102", ISOUtil.hexString(packed));
+
+        ISODatasetField unpackedField = new ISODatasetField(49);
+        packager.unpack(unpackedField, packed);
+        ISODataset unpacked = (ISODataset) unpackedField.getDataset(0x71);
+        assertArrayEquals(new byte[] { 0x11 }, unpacked.getBytes(1));
+        assertArrayEquals(ISOUtil.hex2byte("0102"), unpacked.getBytes(0x9F02));
+    }
+
+    @Test
     public void testTLVParsingSupportsOneTwoAndThreeByteTags() throws Exception {
         DatasetPackager packager = new DatasetPackager();
         packager.setFieldPackager(new ISOFieldPackager[1]);

--- a/jpos/src/test/java/org/jpos/iso/DatasetPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/DatasetPackagerTest.java
@@ -1,0 +1,371 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import org.jpos.iso.packager.DatasetPackager;
+import org.jpos.iso.packager.GenericPackager;
+import org.jpos.tlv.TLVList;
+import org.jpos.tlv.TLVMsg;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DatasetPackagerTest {
+    @Test
+    public void testDBMSingleBitmapParsing() throws Exception {
+        DatasetPackager packager = createBinaryDatasetPackager(2);
+        ISODatasetField field = new ISODatasetField(49);
+        byte[] packed = ISOUtil.hex2byte("71000460001122");
+
+        int consumed = packager.unpack(field, packed);
+
+        assertEquals(packed.length, consumed);
+        assertEquals(1, field.getDatasets().size());
+        Dataset dataset = field.getDataset(0x71);
+        assertNotNull(dataset);
+        assertEquals(DatasetFormat.DBM, dataset.getFormat());
+        assertArrayEquals(new byte[] { 0x11 }, ((ISODataset) dataset).getBytes(1));
+        assertArrayEquals(new byte[] { 0x22 }, ((ISODataset) dataset).getBytes(2));
+        assertArrayEquals(packed, packager.pack(field));
+    }
+
+    @Test
+    public void testDBMChainedBitmapRoundTrip() throws Exception {
+        DatasetPackager packager = createBinaryDatasetPackager(16);
+        ISODatasetField field = new ISODatasetField(49);
+        ISODataset dataset = new ISODataset(0x71, DatasetFormat.DBM);
+        dataset.addElement(1, new ISOBinaryField(1, new byte[] { 0x11 }));
+        dataset.addElement(16, new ISOBinaryField(16, new byte[] { 0x22 }));
+        field.addDataset(dataset);
+
+        byte[] packed = packager.pack(field);
+
+        assertEquals("710005C000401122", ISOUtil.hexString(packed));
+
+        ISODatasetField unpackedField = new ISODatasetField(49);
+        packager.unpack(unpackedField, packed);
+        ISODataset unpacked = (ISODataset) unpackedField.getDataset(0x71);
+        assertArrayEquals(new byte[] { 0x11 }, unpacked.getBytes(1));
+        assertArrayEquals(new byte[] { 0x22 }, unpacked.getBytes(16));
+    }
+
+    @Test
+    public void testTLVParsingSupportsOneTwoAndThreeByteTags() throws Exception {
+        DatasetPackager packager = new DatasetPackager();
+        packager.setFieldPackager(new ISOFieldPackager[1]);
+        ISODatasetField field = new ISODatasetField(34);
+        byte[] packed = ISOUtil.hex2byte("0100145A0212349F02060102030405069F810103070809");
+
+        packager.unpack(field, packed);
+
+        ISODataset dataset = (ISODataset) field.getDataset(0x01);
+        assertNotNull(dataset);
+        assertArrayEquals(ISOUtil.hex2byte("1234"), dataset.getBytes(0x5A));
+        assertArrayEquals(ISOUtil.hex2byte("010203040506"), dataset.getBytes(0x9F02));
+        assertArrayEquals(ISOUtil.hex2byte("070809"), dataset.getBytes(0x9F8101));
+        assertArrayEquals(packed, packager.pack(field));
+    }
+
+    @Test
+    public void testCompositeFieldSupportsMixedAndRepeatedDatasets() throws Exception {
+        DatasetPackager packager = createBinaryDatasetPackager(2);
+        ISODatasetField field = new ISODatasetField(49);
+
+        ISODataset tlvDataset = new ISODataset(0x01, DatasetFormat.TLV);
+        tlvDataset.addElement(0x5A, new ISOBinaryField(0x5A, ISOUtil.hex2byte("1234")));
+        field.addDataset(tlvDataset);
+
+        ISODataset dbmDataset1 = new ISODataset(0x71, DatasetFormat.DBM);
+        dbmDataset1.addElement(1, new ISOBinaryField(1, new byte[] { 0x11 }));
+        field.addDataset(dbmDataset1);
+
+        ISODataset dbmDataset2 = new ISODataset(0x71, DatasetFormat.DBM);
+        dbmDataset2.addElement(2, new ISOBinaryField(2, new byte[] { 0x22 }));
+        field.addDataset(dbmDataset2);
+
+        byte[] packed = packager.pack(field);
+
+        ISODatasetField unpackedField = new ISODatasetField(49);
+        packager.unpack(unpackedField, packed);
+        assertEquals(3, unpackedField.getDatasets().size());
+        assertEquals(2, unpackedField.getDatasets(0x71).size());
+        assertArrayEquals(ISOUtil.hex2byte("1234"), ((ISODataset) unpackedField.getDataset(0x01)).getBytes(0x5A));
+        assertArrayEquals(new byte[] { 0x11 }, ((ISODataset) unpackedField.getDatasets(0x71).get(0)).getBytes(1));
+        assertArrayEquals(new byte[] { 0x22 }, ((ISODataset) unpackedField.getDatasets(0x71).get(1)).getBytes(2));
+    }
+
+    @Test
+    public void testCMFElectronicCommerceDataRoundTrip() throws Exception {
+        GenericPackager packager = createCMFV3Packager();
+
+        ISOMsg msg = new ISOMsg("0100");
+        msg.setPackager(packager);
+        ISODatasetField field34 = new ISODatasetField(34);
+        ISODataset dataset = new ISODataset(0x01, DatasetFormat.TLV)
+          .with(0x5A, ISOUtil.hex2byte("1234"))
+          .with(0x9F02, ISOUtil.hex2byte("000000000100"));
+        field34.addDataset(dataset);
+        msg.set(field34);
+
+        byte[] packed = msg.pack();
+
+        ISOMsg unpacked = new ISOMsg();
+        unpacked.setPackager(packager);
+        unpacked.unpack(packed);
+
+        assertInstanceOf(ISODatasetField.class, unpacked.getComponent(34));
+        ISODataset parsed = (ISODataset) ((ISODatasetField) unpacked.getComponent(34)).getDataset(0x01);
+        assertArrayEquals(ISOUtil.hex2byte("1234"), parsed.getBytes(0x5A));
+        assertArrayEquals(ISOUtil.hex2byte("000000000100"), parsed.getBytes(0x9F02));
+    }
+
+    @Test
+    public void testCMFVerificationDataAndICCDataRoundTrip() throws Exception {
+        GenericPackager packager = createCMFV3Packager();
+
+        ISOMsg msg = new ISOMsg("0100");
+        msg.setPackager(packager);
+
+        ISODatasetField field49 = new ISODatasetField(49);
+        ISODataset verification = new ISODataset(0x71, DatasetFormat.DBM)
+          .with(1, "1")
+          .with(2, "1234");
+        field49.addDataset(verification);
+        msg.set(field49);
+
+        ISODatasetField field55 = new ISODatasetField(55);
+        ISODataset icc = new ISODataset(55, DatasetFormat.TLV)
+          .with(0x9F26, ISOUtil.hex2byte("1122334455667788"))
+          .with(0x9F10, ISOUtil.hex2byte("06011203A0B800"));
+        field55.addDataset(icc);
+        msg.set(field55);
+
+        byte[] packed = msg.pack();
+
+        ISOMsg unpacked = new ISOMsg();
+        unpacked.setPackager(packager);
+        unpacked.unpack(packed);
+
+        assertInstanceOf(ISODatasetField.class, unpacked.getComponent(49));
+        ISODataset parsed49 = (ISODataset) ((ISODatasetField) unpacked.getComponent(49)).getDataset(0x71);
+        assertEquals("1", parsed49.getValue(1));
+        assertEquals("1234", parsed49.getValue(2));
+
+        assertInstanceOf(ISODatasetField.class, unpacked.getComponent(55));
+        ISODataset parsed55 = (ISODataset) ((ISODatasetField) unpacked.getComponent(55)).getDataset(55);
+        assertArrayEquals(ISOUtil.hex2byte("1122334455667788"), parsed55.getBytes(0x9F26));
+        assertArrayEquals(ISOUtil.hex2byte("06011203A0B800"), parsed55.getBytes(0x9F10));
+    }
+
+    @Test
+    public void testCMFJarPackagerAllDatasetFieldsWithFluentMessageBuilder() throws Exception {
+        GenericPackager packager = createCMFV3Packager();
+
+        ISOMsg msg = new ISOMsg("0100");
+        msg.setPackager(packager);
+
+        msg.with("34.0x01.0x5A", ISOUtil.hex2byte("1234"))
+          .with("43.0x01.0x9F1A", ISOUtil.hex2byte("0840"))
+          .with("43.0x71.2", "Example Merchant")
+          .with("43.0x71.7", "USA")
+          .with("49.0x01.0x5F2A", ISOUtil.hex2byte("0840"))
+          .with("49.0x71.1", "1")
+          .with("49.0x71.2", "1234")
+          .with("55.0x9F26", ISOUtil.hex2byte("1122334455667788"))
+          .with("55.0x9F10", ISOUtil.hex2byte("06011203A0B800"))
+          .with("71.0x01.0x9F36", ISOUtil.hex2byte("0022"))
+          .with("104.0x01.0xDF01", ISOUtil.hex2byte("CAFEBABE"));
+
+        byte[] packed = msg.pack();
+
+        ISOMsg unpacked = new ISOMsg();
+        unpacked.setPackager(packager);
+        unpacked.unpack(packed);
+
+        assertInstanceOf(ISODatasetField.class, unpacked.getComponent(34));
+        assertInstanceOf(ISODatasetField.class, unpacked.getComponent(43));
+        assertInstanceOf(ISODatasetField.class, unpacked.getComponent(49));
+        assertInstanceOf(ISODatasetField.class, unpacked.getComponent(55));
+        assertInstanceOf(ISODatasetField.class, unpacked.getComponent(71));
+        assertInstanceOf(ISODatasetField.class, unpacked.getComponent(104));
+
+        assertArrayEquals(ISOUtil.hex2byte("1234"), ((ISODataset) ((ISODatasetField) unpacked.getComponent(34)).getDataset(0x01)).getBytes(0x5A));
+        assertArrayEquals(ISOUtil.hex2byte("0840"), ((ISODataset) ((ISODatasetField) unpacked.getComponent(43)).getDataset(0x01)).getBytes(0x9F1A));
+        assertEquals("Example Merchant", ((ISODataset) ((ISODatasetField) unpacked.getComponent(43)).getDataset(0x71)).getValue(2));
+        assertEquals("USA", ((ISODataset) ((ISODatasetField) unpacked.getComponent(43)).getDataset(0x71)).getValue(7));
+        assertArrayEquals(ISOUtil.hex2byte("0840"), ((ISODataset) ((ISODatasetField) unpacked.getComponent(49)).getDataset(0x01)).getBytes(0x5F2A));
+        assertEquals("1", ((ISODataset) ((ISODatasetField) unpacked.getComponent(49)).getDataset(0x71)).getValue(1));
+        assertEquals("1234", ((ISODataset) ((ISODatasetField) unpacked.getComponent(49)).getDataset(0x71)).getValue(2));
+        assertArrayEquals(ISOUtil.hex2byte("1122334455667788"), ((ISODataset) ((ISODatasetField) unpacked.getComponent(55)).getDataset(55)).getBytes(0x9F26));
+        assertArrayEquals(ISOUtil.hex2byte("06011203A0B800"), ((ISODataset) ((ISODatasetField) unpacked.getComponent(55)).getDataset(55)).getBytes(0x9F10));
+        assertArrayEquals(ISOUtil.hex2byte("0022"), ((ISODataset) ((ISODatasetField) unpacked.getComponent(71)).getDataset(0x01)).getBytes(0x9F36));
+        assertArrayEquals(ISOUtil.hex2byte("CAFEBABE"), ((ISODataset) ((ISODatasetField) unpacked.getComponent(104)).getDataset(0x01)).getBytes(0xDF01));
+
+        msg.dump (System.out, "");
+    }
+
+    @Test
+    public void testCMFAndCMFV3Field55CompatibilityWithTLVList() throws Exception {
+        GenericPackager legacyPackager = createLegacyCMFPackager();
+        GenericPackager datasetPackager = createCMFV3Packager();
+
+        TLVList expected55 = new TLVList()
+          .append(0x9F26, "1122334455667788")
+          .append(0x9F10, "06011203A0B800")
+          .append(0x9F36, "0022")
+          .append(0x95, "0000000000");
+        byte[] expected55Bytes = expected55.pack();
+
+        ISOMsg legacyMsg = new ISOMsg("0100");
+        legacyMsg.setPackager(legacyPackager);
+        legacyMsg.set(3, "000000");
+        legacyMsg.set(11, "123456");
+        legacyMsg.set(41, "TERMID01");
+        legacyMsg.set(new ISOBinaryField(55, expected55Bytes));
+
+        byte[] legacyPacked = legacyMsg.pack();
+
+        ISOMsg unpackedLegacy = new ISOMsg();
+        unpackedLegacy.setPackager(legacyPackager);
+        unpackedLegacy.unpack(legacyPacked);
+
+        ISOMsg datasetMsg = new ISOMsg("0100");
+        datasetMsg.setPackager(datasetPackager);
+        datasetMsg.with(3, "000000")
+          .with(11, "123456")
+          .with(41, "TERMID01")
+          .with("55.0x9F26", ISOUtil.hex2byte("1122334455667788"))
+          .with("55.0x9F10", ISOUtil.hex2byte("06011203A0B800"))
+          .with("55.0x9F36", ISOUtil.hex2byte("0022"))
+          .with("55.0x95", ISOUtil.hex2byte("0000000000"));
+
+        byte[] datasetPacked = datasetMsg.pack();
+
+        ISOMsg unpackedDataset = new ISOMsg();
+        unpackedDataset.setPackager(datasetPackager);
+        unpackedDataset.unpack(datasetPacked);
+
+        assertArrayEquals(legacyPacked, datasetPacked);
+        assertEquals(unpackedLegacy.getMTI(), unpackedDataset.getMTI());
+        assertEquals(unpackedLegacy.getString(3), unpackedDataset.getString(3));
+        assertEquals(unpackedLegacy.getString(11), unpackedDataset.getString(11));
+        assertEquals(unpackedLegacy.getString(41), unpackedDataset.getString(41));
+        assertArrayEquals(legacyPacked, unpackedDataset.pack());
+
+        byte[] legacy55Bytes = unpackedLegacy.getBytes(55);
+        assertArrayEquals(expected55Bytes, legacy55Bytes);
+
+        TLVList legacy55 = new TLVList();
+        legacy55.unpack(legacy55Bytes);
+        assertTLVListsEqual(expected55, legacy55);
+
+        assertInstanceOf(ISODatasetField.class, unpackedDataset.getComponent(55));
+        ISODataset field55 = (ISODataset) ((ISODatasetField) unpackedDataset.getComponent(55)).getDataset(55);
+        assertArrayEquals(ISOUtil.hex2byte("1122334455667788"), field55.getBytes(0x9F26));
+        assertArrayEquals(ISOUtil.hex2byte("06011203A0B800"), field55.getBytes(0x9F10));
+        assertArrayEquals(ISOUtil.hex2byte("0022"), field55.getBytes(0x9F36));
+        assertArrayEquals(ISOUtil.hex2byte("0000000000"), field55.getBytes(0x95));
+        assertDatasetMatchesTLVList(legacy55, field55);
+        assertDatasetMatchesTLVList(expected55, field55);
+    }
+
+    @Test
+    public void testCloneDeepClonesDatasetsAndSupportsFluentWithout() throws Exception {
+        ISOMsg original = new ISOMsg("0100");
+        original.setPackager(createCMFV3Packager());
+        original.with(3, "000000")
+          .with(11, "123456")
+          .with("63.2", "ORIGINAL")
+          .with("55.0x9F26", ISOUtil.hex2byte("1122334455667788"))
+          .with("55.0x9F10", ISOUtil.hex2byte("06011203A0B800"));
+
+        ISOMsg clone = (ISOMsg) original.clone();
+        clone.with(11, "654321")
+          .without(3)
+          .without("63.2")
+          .with("63.3", "CLONE")
+          .without("55.0x9F10")
+          .with("55.0x95", ISOUtil.hex2byte("0000000000"));
+
+        assertNotSame(original.getComponent(55), clone.getComponent(55));
+        assertNotSame(((ISODatasetField) original.getComponent(55)).getDataset(55), ((ISODatasetField) clone.getComponent(55)).getDataset(55));
+
+        assertEquals("000000", original.getString(3));
+        assertEquals("123456", original.getString(11));
+        assertEquals("ORIGINAL", original.getString("63.2"));
+        assertArrayEquals(ISOUtil.hex2byte("1122334455667788"), ((ISODatasetField) original.getComponent(55)).getBytes(55, 0x9F26));
+        assertArrayEquals(ISOUtil.hex2byte("06011203A0B800"), ((ISODatasetField) original.getComponent(55)).getBytes(55, 0x9F10));
+        assertNull(((ISODatasetField) original.getComponent(55)).getBytes(55, 0x95));
+
+        assertNull(clone.getString(3));
+        assertEquals("654321", clone.getString(11));
+        assertNull(clone.getString("63.2"));
+        assertEquals("CLONE", clone.getString("63.3"));
+        assertArrayEquals(ISOUtil.hex2byte("1122334455667788"), ((ISODatasetField) clone.getComponent(55)).getBytes(55, 0x9F26));
+        assertNull(((ISODatasetField) clone.getComponent(55)).getBytes(55, 0x9F10));
+        assertArrayEquals(ISOUtil.hex2byte("0000000000"), ((ISODatasetField) clone.getComponent(55)).getBytes(55, 0x95));
+
+        clone.without("55.0x9F26", "55.0x95");
+        assertFalse(clone.hasField(55));
+        assertTrue(original.hasField(55));
+        assertArrayEquals(ISOUtil.hex2byte("1122334455667788"), ((ISODatasetField) original.getComponent(55)).getBytes(55, 0x9F26));
+        assertArrayEquals(ISOUtil.hex2byte("06011203A0B800"), ((ISODatasetField) original.getComponent(55)).getBytes(55, 0x9F10));
+    }
+
+    private DatasetPackager createBinaryDatasetPackager(int maxElement) throws Exception {
+        DatasetPackager packager = new DatasetPackager();
+        ISOFieldPackager[] fieldPackagers = new ISOFieldPackager[maxElement + 1];
+        for (int i = 1; i <= maxElement; i++) {
+            fieldPackagers[i] = new IFB_BINARY(1, "dataset-element-" + i);
+        }
+        packager.setFieldPackager(fieldPackagers);
+        return packager;
+    }
+
+    private GenericPackager createLegacyCMFPackager() throws Exception {
+        return new GenericPackager("jar:packager/cmf.xml");
+    }
+
+    private GenericPackager createCMFV3Packager() throws Exception {
+        return new GenericPackager("jar:packager/cmfv3.xml");
+    }
+
+    private void assertTLVListsEqual(TLVList expected, TLVList actual) {
+        List<TLVMsg> expectedTags = expected.getTags();
+        List<TLVMsg> actualTags = actual.getTags();
+        assertEquals(expectedTags.size(), actualTags.size());
+        for (int i = 0; i < expectedTags.size(); i++) {
+            TLVMsg expectedTag = expectedTags.get(i);
+            TLVMsg actualTag = actualTags.get(i);
+            assertEquals(expectedTag.getTag(), actualTag.getTag());
+            assertArrayEquals(expectedTag.getValue(), actualTag.getValue());
+            assertArrayEquals(expectedTag.getTLV(), actualTag.getTLV());
+        }
+    }
+
+    private void assertDatasetMatchesTLVList(TLVList expected, ISODataset actual) throws ISOException {
+        List<TLVMsg> expectedTags = expected.getTags();
+        assertEquals(expectedTags.size(), actual.getElements().size());
+        for (TLVMsg expectedTag : expectedTags) {
+            assertArrayEquals(expectedTag.getValue(), actual.getBytes(expectedTag.getTag()));
+        }
+    }
+}

--- a/jpos/src/test/java/org/jpos/iso/packager/XMLPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/XMLPackagerTest.java
@@ -38,6 +38,10 @@ import org.custommonkey.xmlunit.XMLUnit;
 import org.jpos.iso.ISOComponent;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOField;
+import org.jpos.iso.ISOBinaryField;
+import org.jpos.iso.ISODataset;
+import org.jpos.iso.ISODatasetField;
+import org.jpos.iso.DatasetFormat;
 import org.jpos.iso.ISOMsg;
 import org.jpos.iso.ISOUtil;
 import org.jpos.util.Logger;
@@ -178,22 +182,47 @@ public class XMLPackagerTest {
         isoMsg.set(12, "20110224112759");
         isoMsg.set(24, "");
         byte[] data = isoMsg.pack();
-        // System.out.println(new String(data));
-        String expected = "<isomsg><!-- org.jpos.iso.packager.XMLPackager --><field id=\"0\" value=\"0800\"/>"
-                + "<field id=\"7\" value=\"7654321\"/><field id=\"11\" value=\"12345678\"/>"
-                + "<field id=\"12\" value=\"20110224112759\"/><field id=\"24\" value=\"\"/></isomsg>";
+        String expected = """
+                <isomsg>
+                  <field id="0" value="0800"/>
+                  <field id="7" value="7654321"/>
+                  <field id="11" value="12345678"/>
+                  <field id="12" value="20110224112759"/>
+                  <field id="24" value=""/>
+                </isomsg>
+                """;
         XMLUnit.setIgnoreWhitespace(true);
-        // XMLAssert.assertXMLEqual(expected, new String(data));
+        XMLUnit.setIgnoreComments(true);
         DetailedDiff myDiff = new DetailedDiff(XMLUnit.compareXML(expected, new String(data)));
         List allDifferences = myDiff.getAllDifferences();
         assertEquals(0, allDifferences.size(), myDiff.toString());
     }
 
     @Test
+    public void testPackDatasetFieldUsesHexTLVElementIds() throws Exception {
+        ISODatasetField field55 = new ISODatasetField(55);
+        ISODataset dataset = new ISODataset(0x37, DatasetFormat.TLV);
+        dataset.addElement(0x9F26, new ISOBinaryField(0x9F26, hex2byte("1122334455667788")));
+        field55.addDataset(dataset);
+        isoMsg.set(field55);
+
+        String xml = new String(xMLPackager.pack(isoMsg));
+
+        assertThat(xml.contains("<element id=\"0x9F26\" value=\"1122334455667788\"/>"), is(true));
+    }
+
+    @Test
     public void testUnpackBytes() throws IOException, ISOException {
-        String input = "<isomsg><!-- org.jpos.iso.packager.XMLPackager --><header>686561646572</header><field id=\"0\" value=\"0800\"/>"
-                + "<field id=\"7\" value=\"7654321\"/><field id=\"11\" value=\"12345678\"/>"
-                + "<field id=\"12\" value=\"20110224112759\"/><field id=\"24\" value=\"831\"/></isomsg>";
+        String input = """
+                <isomsg>
+                  <header>686561646572</header>
+                  <field id="0" value="0800"/>
+                  <field id="7" value="7654321"/>
+                  <field id="11" value="12345678"/>
+                  <field id="12" value="20110224112759"/>
+                  <field id="24" value="831"/>
+                </isomsg>
+                """;
         isoMsg.setHeader("header".getBytes());
         isoMsg.setMTI("0800");
         isoMsg.set(7, "7654321");
@@ -202,7 +231,7 @@ public class XMLPackagerTest {
         isoMsg.set(24, "");
         ISOMsg result = xMLPackager.createISOMsg();
         int consumedBytes = xMLPackager.unpack(result, input.getBytes());
-        assertThat(consumedBytes, is(247));
+        assertThat(consumedBytes, is(input.getBytes().length));
         assertThat(result.getHeader(), is("header".getBytes()));
         assertThat(result.getMTI(), is("0800"));
         assertThat(result.getString(7), is("7654321"));
@@ -214,10 +243,12 @@ public class XMLPackagerTest {
     @Test
     public void testUnpackLargeXmlBytes() throws IOException, ISOException {
         String veryLongXml = "<large-xml><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element><element><nested-element>Some very very long text</nested-element></element></large-xml>";
-        String input = "<isomsg>  <!-- org.jpos.iso.packager.XMLPackager -->" +
-                "<field id=\"0\" value=\"0800\"/>" +
-                "<field id=\"1\"><![CDATA[" + veryLongXml + "]]></field>" +
-                "</isomsg>";
+        String input = """
+                <isomsg>
+                  <field id="0" value="0800"/>
+                  <field id="1"><![CDATA[%s]]></field>
+                </isomsg>
+                """.formatted(veryLongXml);
         isoMsg.setHeader("header".getBytes());
         ISOMsg result = xMLPackager.createISOMsg();
         int consumedBytes = xMLPackager.unpack(result, input.getBytes());
@@ -226,9 +257,16 @@ public class XMLPackagerTest {
 
     @Test
     public void testUnpackStream() throws IOException, ISOException {
-        String input = "<isomsg><!-- org.jpos.iso.packager.XMLPackager --><header>686561646572</header><field id=\"0\" value=\"0800\"/>"
-                + "<field id=\"7\" value=\"7654321\"/><field id=\"11\" value=\"12345678\"/>"
-                + "<field id=\"12\" value=\"20110224112759\"/><field id=\"24\" value=\"\"/></isomsg>";
+        String input = """
+                <isomsg>
+                  <header>686561646572</header>
+                  <field id="0" value="0800"/>
+                  <field id="7" value="7654321"/>
+                  <field id="11" value="12345678"/>
+                  <field id="12" value="20110224112759"/>
+                  <field id="24" value=""/>
+                </isomsg>
+                """;
         isoMsg.setHeader("header".getBytes());
         isoMsg.setMTI("0800");
         isoMsg.set(7, "7654321");
@@ -243,6 +281,41 @@ public class XMLPackagerTest {
         assertThat(result.getString(11), is("12345678"));
         assertThat(result.getString(12), is("20110224112759"));
         assertThat(result.getString(24), is(""));
+    }
+
+    @Test
+    public void testXML2003PackagerUnpacksDatasetXml() throws Exception {
+        XML2003Packager packager = new XML2003Packager();
+        ISOMsg result = packager.createISOMsg();
+        String input = """
+                <isomsg>
+                  <field id="0" value="0100"/>
+                  <field id="55" type="dataset">
+                    <dataset id="37" format="TLV">
+                      <element id="0x9F26" value="1122334455667788"/>
+                      <element id="0x9F10" value="06011203A0B800"/>
+                    </dataset>
+                  </field>
+                  <field id="49" type="dataset">
+                    <dataset id="71" format="DBM">
+                      <element id="1" value="31"/>
+                      <element id="2" value="31323334"/>
+                    </dataset>
+                  </field>
+                </isomsg>
+                """;
+
+        packager.unpack(result, input.getBytes());
+
+        assertEquals("0100", result.getMTI());
+        assertThat(result.getComponent(55) instanceof ISODatasetField, is(true));
+        assertThat(result.getComponent(49) instanceof ISODatasetField, is(true));
+        ISODataset field55 = (ISODataset) ((ISODatasetField) result.getComponent(55)).getDataset(0x37);
+        ISODataset field49 = (ISODataset) ((ISODatasetField) result.getComponent(49)).getDataset(0x71);
+        assertThat(ISOUtil.hexString(field55.getBytes(0x9F26)), is("1122334455667788"));
+        assertThat(ISOUtil.hexString(field55.getBytes(0x9F10)), is("06011203A0B800"));
+        assertThat(ISOUtil.hexString(field49.getBytes(1)), is("31"));
+        assertThat(ISOUtil.hexString(field49.getBytes(2)), is("31323334"));
     }
 
     @Test
@@ -291,15 +364,6 @@ public class XMLPackagerTest {
 
     @Test
     public void testStartElementThrowsNullPointerException1() throws Throwable {
-        try {
-            xMLPackager.startElement("testXMLPackagerNs", "testXMLPackagerName", "testXMLPackagerQName", null);
-            fail("Expected NullPointerException to be thrown");
-        } catch (NullPointerException ex) {
-            if (isJavaVersionAtMost(JAVA_14)) {
-                assertNull(ex.getMessage(), "ex.getMessage()");
-            } else {
-                assertEquals("Cannot invoke \"org.xml.sax.Attributes.getValue(String)\" because \"atts\" is null", ex.getMessage(), "ex.getMessage()");
-            }
-        }
+        xMLPackager.startElement("testXMLPackagerNs", "testXMLPackagerName", "testXMLPackagerQName", null);
     }
 }


### PR DESCRIPTION
Introduce first-class dataset handling in jPOS for composite data elements using TLV and DBM formats, including raw ICC data support for DE 55.

Add dataset model classes and packagers, integrate them with GenericPackager and XML packagers, add fluent with/without helpers, support deep cloning of dataset fields, and document the new API.

Keep legacy cmf.xml unchanged for backward compatibility and add cmfv3.xml with dataset-aware definitions and tests.