### PR TITLE
fix(packager): correct DE-072 Data Record to LLLLVAR b..9999

### DIFF
--- a/jpos/src/main/resources/packager/cmf.xml
+++ b/jpos/src/main/resources/packager/cmf.xml
@@ -605,9 +605,9 @@
       class="org.jpos.iso.IFB_LLLLBINARY"/>
   <isofield
       id="72"
-      length="999"
+      length="9999"
       name="Data record"
-      class="org.jpos.iso.IFB_LLLBINARY"/>
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
   <isofield
       id="73"
       length="8"

--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -611,9 +611,9 @@
   </isofieldpackager>
   <isofield
       id="72"
-      length="999"
+      length="9999"
       name="Data record"
-      class="org.jpos.iso.IFB_LLLBINARY"/>
+      class="org.jpos.iso.IFB_LLLLBINARY"/>
   <isofield
       id="73"
       length="8"


### PR DESCRIPTION
ISO 8583 defines DE-072 (Data Record) as `LLLLVAR ansb..9999`.

Both `cmf.xml` and `cmfv3.xml` were using `IFB_LLLBINARY` with `length=999`, which:
- Uses a 3-digit BCD length prefix (LLL) instead of the correct 4-digit (LLLL)
- Caps the field at 999 bytes instead of 9999

Fix: change both packagers to `IFB_LLLLBINARY` with `length=9999`.