### PR TITLE
fix(cmfv3): correct DE-096 to Key Management Data LLLVAR b..999

### DIFF
--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -770,10 +770,10 @@
       pad="false"
       class="org.jpos.iso.IFB_LLLLBINARY"/>
   <isofield id="96"
-      length="9999"
-      name="Reserved for ISO use"
+      length="999"
+      name="Key management data"
       pad="false"
-      class="org.jpos.iso.IFB_LLLLBINARY"/>
+      class="org.jpos.iso.IFB_LLLBINARY"/>
   <isofield id="92"
       length="9999"
       name="Reserved for ISO use"


### PR DESCRIPTION
ISO 8583:2023 defines DE-096 as **Key management data**, `LLLVAR b..999`.

`cmfv3.xml` had it labeled as "Reserved for ISO use" with `IFB_LLLLBINARY length=9999`.

Fix: rename to `Key management data`, change to `IFB_LLLBINARY length=999`.

`cmf.xml` is intentionally left unchanged (ISO 8583:2003 backward compatibility).