### PR TITLE
feat(iso): add PosCapability for DE-027 encoding

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/PosCapability.java
+++ b/jpos/src/main/java/org/jpos/iso/PosCapability.java
@@ -13,193 +13,615 @@
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program, if not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.jpos.iso;
 
 import java.io.PrintStream;
+import java.util.Objects;
 
-import org.jpos.util.Loggeable;
+/**
+ * Structured representation of DE-027 (POS Capability) in the jPOS CMF.
+ *
+ * <p>DE-027 is a 27-byte fixed-length field that describes the capabilities
+ * of the point-of-service terminal. It is the <em>capability</em> counterpart
+ * of {@link PosDataCode} (DE-022), which records what actually happened.
+ *
+ * <h2>Wire layout</h2>
+ * <pre>
+ *  Bytes  1- 4  Sub-field 27-1: card reading capability      (B4, bit-flags)
+ *  Bytes  5- 8  Sub-field 27-2: cardholder verification cap. (B4, bit-flags)
+ *  Byte   9     Sub-field 27-3: approval code length         (N1, ASCII)
+ *  Bytes 10-12  Sub-field 27-4: cardholder receipt length    (N3, ASCII)
+ *  Bytes 13-15  Sub-field 27-5: card acceptor receipt length (N3, ASCII)
+ *  Bytes 16-18  Sub-field 27-6: cardholder display length    (N3, ASCII)
+ *  Bytes 19-21  Sub-field 27-7: card acceptor display length (N3, ASCII)
+ *  Bytes 22-24  Sub-field 27-8: ICC scripts data length      (N3, ASCII)
+ *  Byte  25     Sub-field 27-9: track 3 rewrite capability   (A1, 'Y'/'N')
+ *  Byte  26     Sub-field 27-10: card capture capability     (A1, 'Y'/'N')
+ *  Byte  27     Sub-field 27-11: PIN input length capability (B1, binary)
+ * </pre>
+ *
+ * <p>Sub-fields 27-1 and 27-2 share the same bit-flag tables as DE-022.
+ * The {@link PosDataCode.ReadingMethod} and {@link PosDataCode.VerificationMethod}
+ * enums are therefore reused directly.
+ *
+ * <p>The bit-numbering convention follows ISO 8583: B1 = MSB = {@code 0x80}.
+ * Internally, {@link PosFlags} maps flag {@code intValue()} 1 to the LSB of
+ * each 4-byte word and serialises little-endian within each word—identical to
+ * {@link PosDataCode}. See the DE-022 spec note for the historical rationale.
+ *
+ * <p>Usage example:
+ * <pre>{@code
+ * // Build and pack
+ * PosCapability cap = PosCapability.builder()
+ *     .readingCapability(PosDataCode.ReadingMethod.MAGNETIC_STRIPE)
+ *     .readingCapability(PosDataCode.ReadingMethod.ICC)
+ *     .verificationCapability(PosDataCode.VerificationMethod.ONLINE_PIN)
+ *     .verificationCapability(PosDataCode.VerificationMethod.MANUAL_SIGNATURE)
+ *     .approvalCodeLength(6)
+ *     .cardholderReceiptLength(40)
+ *     .cardAcceptorReceiptLength(40)
+ *     .cardholderDisplayLength(16)
+ *     .cardAcceptorDisplayLength(16)
+ *     .iccScriptDataLength(128)
+ *     .track3RewriteCapable(false)
+ *     .cardCaptureCapable(false)
+ *     .pinInputLength(12)
+ *     .build();
+ *
+ * msg.set(new ISOBinaryField(27, cap.pack()));
+ *
+ * // Unpack
+ * PosCapability received = PosCapability.unpack(msg.getBytes(27));
+ * if (received.canReadICC()) { ... }
+ * }</pre>
+ *
+ * @see PosDataCode
+ * @see PosFlags
+ * @see <a href="https://jpos.org/doc/jPOS-CMF.pdf">jPOS CMF — DE-027</a>
+ */
+public class PosCapability extends PosFlags {
 
-@SuppressWarnings("unused")
-public class PosCapability extends PosFlags implements Loggeable {
-    public enum ReadingCapability implements Flag {
-        UNKNOWN                (1,      "Unknown"),
-        CONTACTLESS            (1 << 1, "Information not taken from card"),  // i.e.: RFID
-        PHYSICAL               (1 << 2, "Physical entry"),                   // i.e.: Manual Entry or OCR
-        BARCODE                (1 << 3, "Bar code"),
-        MAGNETIC_STRIPE        (1 << 4, "Magnetic Stripe"),
-        ICC                    (1 << 5, "ICC"),
-        DATA_ON_FILE           (1 << 6, "Data on file"),
-        ICC_FAILED             (1 << 11, "ICC read but failed"),
-        MAGNETIC_STRIPE_FAILED (1 << 12, "Magnetic Stripe read but failed"),
-        FALLBACK               (1 << 13, "Fallback"),
-        TRACK1_PRESENT         (1 << 27, "Track1 data present"), // jCard private field
-        TRACK2_PRESENT         (1 << 28, "Track2 data present"); // jCard private field
+    /** Wire length of DE-027 in bytes. */
+    public static final int WIRE_LENGTH = 27;
 
-        private int val;
-        private String description;
-        ReadingCapability (int val, String description) {
-            this.val = val;
-            this.description = description;
-        }
-        public int intValue() {
-            return val;
-        }
-        public String toString () {
-            return description;
-        }
+    /** Byte offset of sub-field 27-1 (card reading capability) within the wire buffer. */
+    private static final int READING_OFFSET = 0;
 
-        public static int OFFSET = 0;
-        @Override
-        public int getOffset() {
-            return OFFSET;
-        }
+    /** Byte offset of sub-field 27-2 (cardholder verification capability). */
+    private static final int VERIFICATION_OFFSET = 4;
+
+    /** Byte offset of sub-field 27-3 (approval code length, 1 ASCII digit). */
+    private static final int APPROVAL_CODE_LENGTH_OFFSET = 8;
+
+    /** Byte offset of sub-field 27-4 (cardholder receipt data length, 3 ASCII digits). */
+    private static final int CARDHOLDER_RECEIPT_OFFSET = 9;
+
+    /** Byte offset of sub-field 27-5 (card acceptor receipt data length, 3 ASCII digits). */
+    private static final int CARD_ACCEPTOR_RECEIPT_OFFSET = 12;
+
+    /** Byte offset of sub-field 27-6 (cardholder display data length, 3 ASCII digits). */
+    private static final int CARDHOLDER_DISPLAY_OFFSET = 15;
+
+    /** Byte offset of sub-field 27-7 (card acceptor display data length, 3 ASCII digits). */
+    private static final int CARD_ACCEPTOR_DISPLAY_OFFSET = 18;
+
+    /** Byte offset of sub-field 27-8 (ICC scripts data length, 3 ASCII digits). */
+    private static final int ICC_SCRIPT_LENGTH_OFFSET = 21;
+
+    /** Byte offset of sub-field 27-9 (track 3 rewrite capability, 'Y'/'N'). */
+    private static final int TRACK3_REWRITE_OFFSET = 24;
+
+    /** Byte offset of sub-field 27-10 (card capture capability, 'Y'/'N'). */
+    private static final int CARD_CAPTURE_OFFSET = 25;
+
+    /** Byte offset of sub-field 27-11 (PIN input length capability, binary). */
+    private static final int PIN_INPUT_LENGTH_OFFSET = 26;
+
+    private final byte[] b;
+
+    private PosCapability(byte[] b) {
+        this.b = b;
     }
 
-    public enum VerificationCapability implements Flag {
-        UNKNOWN                              (1, "Unknown"),
-        NONE                                 (1 << 1, "None"),
-        MANUAL_SIGNATURE                     (1 << 2, "Manual signature"),
-        ONLINE_PIN                           (1 << 3, "Online PIN"),
-        OFFLINE_PIN_IN_CLEAR                 (1 << 4, "Offline PIN in clear"),
-        OFFLINE_PIN_ENCRYPTED                (1 << 5, "Offline PIN encrypted"),
-        OFFLINE_DIGITIZED_SIGNATURE_ANALYSIS (1 << 6, "Offline digitized signature analysis"),
-        OFFLINE_BIOMETRICS                   (1 << 7, "Offline biometrics"),
-        OFFLINE_MANUAL_VERIFICATION          (1 << 8, "Offline manual verification"),
-        OFFLINE_BIOGRAPHICS                  (1 << 9, "Offline biographics"),
-        ACCOUNT_BASED_DIGITAL_SIGNATURE      (1 << 10, "Account based digital signature"),
-        PUBLIC_KEY_BASED_DIGITAL_SIGNATURE   (1 << 11, "Public key based digital signature");
+    // -------------------------------------------------------------------------
+    // PosFlags contract
+    // -------------------------------------------------------------------------
 
-        private int val;
-        private String description;
-        VerificationCapability (int val, String description) {
-            this.val = val;
-            this.description = description;
-        }
-        public int intValue() {
-            return val;
-        }
-        public String toString () {
-            return description;
-        }
-
-        public static int OFFSET = 0;
-        @Override
-        public int getOffset() {
-            return OFFSET;
-        }
-    }
-
-    private byte[] b = new byte[8];
-
-    public PosCapability() {}
-
-    public PosCapability (
-            int readingCapability,
-            int verificationCapability)
-    {
-        super();
-
-        b[0]  = (byte) readingCapability;
-        b[1]  = (byte) (readingCapability >>> 8);
-        b[2]  = (byte) (readingCapability >>> 16);
-        b[3]  = (byte) (readingCapability >>> 24);
-
-        b[4]  = (byte) verificationCapability;
-        b[5]  = (byte) (verificationCapability >>> 8);
-        b[6]  = (byte) (verificationCapability >>> 16);
-        b[7]  = (byte) (verificationCapability >>> 24);
-    }
-
-    private PosCapability (byte[] b) {
-        if (b != null) {
-            // will always use our own internal copy of array
-            int copyLen= Math.min(b.length, 16);
-            System.arraycopy(b, 0, this.b, 0, copyLen);
-        }
-    }
-
-    public boolean hasReadingCapability (int readingMethods) {
-        int i = b[3] << 24 | b[2] << 16  & 0xFF0000 | b[1] << 8  & 0xFF00 | b[0] & 0xFF ;
-        return (i & readingMethods) == readingMethods;
-    }
-    public boolean hasReadingCapability (ReadingCapability method) {
-        return hasReadingCapability (method.intValue());
-    }
-    public boolean hasVerificationCapability (int verificationMethods) {
-        int i = b[7] << 24 | b[6] << 16 & 0xFF0000 | b[5] << 8  & 0xFF00 | b[4] & 0xFF;
-        return (i & verificationMethods) == verificationMethods;
-    }
-    public boolean hasVerificationCapability (VerificationCapability method) {
-        return hasVerificationCapability(method.intValue());
-    }
+    /**
+     * Returns the raw 27-byte wire buffer backing this instance.
+     * The returned array is the live backing store; callers should not modify it.
+     *
+     * @return the 27-byte wire buffer
+     */
+    @Override
     public byte[] getBytes() {
         return b;
     }
-    public boolean canEMV() {
-        return hasReadingCapability(ReadingCapability.ICC) || hasReadingCapability(ReadingCapability.CONTACTLESS);
-    }
-    public boolean canManualEntry() {
-        return hasReadingCapability(ReadingCapability.PHYSICAL);
-    }
-    public boolean isSwiped() {
-        return hasReadingCapability(ReadingCapability.MAGNETIC_STRIPE);
-    }
-    public String toString() {
-        return super.toString() + "[" + ISOUtil.hexString (getBytes())+ "]";
+
+    // -------------------------------------------------------------------------
+    // Factory methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a new {@link Builder} for constructing a {@code PosCapability}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
-    public static PosCapability valueOf (byte[] b) {
-        return new PosCapability(b);  // we create new objects for now, but may return cached instances in the future
+    /**
+     * Unpacks a {@code PosCapability} from a 27-byte wire buffer.
+     *
+     * @param data exactly {@value #WIRE_LENGTH} bytes
+     * @return the decoded {@code PosCapability}
+     * @throws IllegalArgumentException if {@code data} is null or not exactly 27 bytes
+     */
+    public static PosCapability unpack(byte[] data) {
+        if (data == null || data.length != WIRE_LENGTH)
+            throw new IllegalArgumentException(
+                "DE-027 wire buffer must be exactly " + WIRE_LENGTH + " bytes, got "
+                + (data == null ? "null" : data.length));
+        byte[] copy = new byte[WIRE_LENGTH];
+        System.arraycopy(data, 0, copy, 0, WIRE_LENGTH);
+        return new PosCapability(copy);
     }
 
+    /**
+     * Packs this {@code PosCapability} into a {@value #WIRE_LENGTH}-byte array
+     * suitable for placing directly into DE-027 of an {@link ISOMsg}.
+     *
+     * @return a fresh 27-byte copy of the wire buffer
+     */
+    public byte[] pack() {
+        byte[] copy = new byte[WIRE_LENGTH];
+        System.arraycopy(b, 0, copy, 0, WIRE_LENGTH);
+        return copy;
+    }
+
+    /**
+     * Returns a {@link Builder} pre-populated with all values from this instance,
+     * allowing selective modification.
+     *
+     * @return a builder initialised from this instance
+     */
+    public Builder toBuilder() {
+        Builder bld = new Builder();
+        System.arraycopy(b, 0, bld.b, 0, WIRE_LENGTH);
+        return bld;
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-field 27-1: card reading capability
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns {@code true} if the terminal supports the given card reading method.
+     *
+     * @param method the reading method to test
+     * @return {@code true} if the bit for {@code method} is set
+     */
+    public boolean canRead(PosDataCode.ReadingMethod method) {
+        Objects.requireNonNull(method);
+        int v = method.intValue();
+        // method.getOffset() is 0 for ReadingMethod (its absolute PosDataCode offset)
+        // READING_OFFSET is also 0, so no correction needed here — kept explicit for clarity
+        int offset = READING_OFFSET;
+        for (; v != 0; v >>>= 8, offset++) {
+            if (offset >= READING_OFFSET + 4) break;
+            if ((b[offset] & (byte) v) != (byte) v) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns {@code true} if the terminal can read ICC (chip) cards.
+     *
+     * @return {@code true} if {@link PosDataCode.ReadingMethod#ICC} is set
+     */
+    public boolean canReadICC() {
+        return canRead(PosDataCode.ReadingMethod.ICC);
+    }
+
+    /**
+     * Returns {@code true} if the terminal can read magnetic stripe cards.
+     *
+     * @return {@code true} if {@link PosDataCode.ReadingMethod#MAGNETIC_STRIPE} is set
+     */
+    public boolean canReadMagstripe() {
+        return canRead(PosDataCode.ReadingMethod.MAGNETIC_STRIPE);
+    }
+
+    /**
+     * Returns {@code true} if the terminal supports contactless (RFID) reading.
+     *
+     * @return {@code true} if {@link PosDataCode.ReadingMethod#CONTACTLESS} is set
+     */
+    public boolean canReadContactless() {
+        return canRead(PosDataCode.ReadingMethod.CONTACTLESS);
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-field 27-2: cardholder verification capability
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns {@code true} if the terminal supports the given cardholder verification method.
+     *
+     * @param method the verification method to test
+     * @return {@code true} if the bit for {@code method} is set
+     */
+    public boolean canVerify(PosDataCode.VerificationMethod method) {
+        Objects.requireNonNull(method);
+        int v = method.intValue();
+        // method.getOffset() is 4 in PosDataCode's 16-byte buffer; here the
+        // verification sub-field lives at VERIFICATION_OFFSET (byte 4), so we
+        // do NOT add method.getOffset() — we read relative to VERIFICATION_OFFSET only.
+        int offset = VERIFICATION_OFFSET;
+        for (; v != 0; v >>>= 8, offset++) {
+            if (offset >= VERIFICATION_OFFSET + 4) break;
+            if ((b[offset] & (byte) v) != (byte) v) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns {@code true} if the terminal supports online PIN entry.
+     *
+     * @return {@code true} if {@link PosDataCode.VerificationMethod#ONLINE_PIN} is set
+     */
+    public boolean canVerifyOnlinePin() {
+        return canVerify(PosDataCode.VerificationMethod.ONLINE_PIN);
+    }
+
+    /**
+     * Returns {@code true} if the terminal supports offline PIN entry in clear.
+     *
+     * @return {@code true} if {@link PosDataCode.VerificationMethod#OFFLINE_PIN_IN_CLEAR} is set
+     */
+    public boolean canVerifyOfflinePinInClear() {
+        return canVerify(PosDataCode.VerificationMethod.OFFLINE_PIN_IN_CLEAR);
+    }
+
+    /**
+     * Returns {@code true} if the terminal supports offline encrypted PIN entry.
+     *
+     * @return {@code true} if {@link PosDataCode.VerificationMethod#OFFLINE_PIN_ENCRYPTED} is set
+     */
+    public boolean canVerifyOfflinePinEncrypted() {
+        return canVerify(PosDataCode.VerificationMethod.OFFLINE_PIN_ENCRYPTED);
+    }
+
+    /**
+     * Returns {@code true} if the terminal supports manual signature verification.
+     *
+     * @return {@code true} if {@link PosDataCode.VerificationMethod#MANUAL_SIGNATURE} is set
+     */
+    public boolean canVerifySignature() {
+        return canVerify(PosDataCode.VerificationMethod.MANUAL_SIGNATURE);
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-fields 27-3 through 27-11: scalar accessors
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the maximum approval code length supported by this terminal (sub-field 27-3).
+     *
+     * @return approval code length, 0–9
+     */
+    public int getApprovalCodeLength() {
+        return b[APPROVAL_CODE_LENGTH_OFFSET] - '0';
+    }
+
+    /**
+     * Returns the maximum cardholder receipt data length in characters (sub-field 27-4).
+     * A value of 0 indicates no receipt capability.
+     *
+     * @return cardholder receipt length, 0–999
+     */
+    public int getCardholderReceiptLength() {
+        return readN3(CARDHOLDER_RECEIPT_OFFSET);
+    }
+
+    /**
+     * Returns the maximum card acceptor (merchant) receipt data length in characters (sub-field 27-5).
+     * A value of 0 indicates no receipt capability.
+     *
+     * @return card acceptor receipt length, 0–999
+     */
+    public int getCardAcceptorReceiptLength() {
+        return readN3(CARD_ACCEPTOR_RECEIPT_OFFSET);
+    }
+
+    /**
+     * Returns the maximum cardholder display data length in characters (sub-field 27-6).
+     * A value of 0 indicates no display capability.
+     *
+     * @return cardholder display length, 0–999
+     */
+    public int getCardholderDisplayLength() {
+        return readN3(CARDHOLDER_DISPLAY_OFFSET);
+    }
+
+    /**
+     * Returns the maximum card acceptor display data length in characters (sub-field 27-7).
+     * A value of 0 indicates no display capability.
+     *
+     * @return card acceptor display length, 0–999
+     */
+    public int getCardAcceptorDisplayLength() {
+        return readN3(CARD_ACCEPTOR_DISPLAY_OFFSET);
+    }
+
+    /**
+     * Returns the maximum ICC scripts data length in bytes (sub-field 27-8).
+     * A value of 0 indicates no ICC script capability.
+     *
+     * @return ICC scripts data length, 0–999
+     */
+    public int getIccScriptDataLength() {
+        return readN3(ICC_SCRIPT_LENGTH_OFFSET);
+    }
+
+    /**
+     * Returns {@code true} if the terminal can rewrite magnetic stripe track 3 (sub-field 27-9).
+     *
+     * @return {@code true} if track 3 rewrite is supported
+     */
+    public boolean canRewriteTrack3() {
+        return b[TRACK3_REWRITE_OFFSET] == 'Y';
+    }
+
+    /**
+     * Returns {@code true} if the terminal can capture (retain) cards (sub-field 27-10).
+     *
+     * @return {@code true} if card capture is supported
+     */
+    public boolean canCaptureCard() {
+        return b[CARD_CAPTURE_OFFSET] == 'Y';
+    }
+
+    /**
+     * Returns the maximum PIN length the terminal's PIN pad can accept (sub-field 27-11).
+     *
+     * @return PIN input length capability, 0–255
+     */
+    public int getPinInputLength() {
+        return b[PIN_INPUT_LENGTH_OFFSET] & 0xFF;
+    }
+
+    // -------------------------------------------------------------------------
+    // Loggeable / toString
+    // -------------------------------------------------------------------------
+
+    /**
+     * Dumps a human-readable representation of this {@code PosCapability} to the given stream.
+     *
+     * @param p      the output stream
+     * @param indent indentation prefix
+     */
     public void dump(PrintStream p, String indent) {
         String inner = indent + "  ";
-        StringBuilder sb = new StringBuilder();
-        p.printf("%s<pvc value='%s'>%n", indent, ISOUtil.hexString(getBytes()));
-        for (ReadingCapability m : ReadingCapability.values()) {
-            if (hasReadingCapability(m)) {
-                if (sb.length() > 0)
-                    sb.append(',');
-                sb.append(m.name());
+        p.printf("%s<pos-capability value='%s'>%n", indent, ISOUtil.hexString(b));
+        p.printf("%sreading-cap:     %s%n", inner, ISOUtil.hexString(b, 0, 4));
+        p.printf("%sverification-cap:%s%n", inner, ISOUtil.hexString(b, 4, 4));
+        p.printf("%sapproval-code-len:%d%n", inner, getApprovalCodeLength());
+        p.printf("%scardholder-receipt-len:%d%n", inner, getCardholderReceiptLength());
+        p.printf("%scard-acceptor-receipt-len:%d%n", inner, getCardAcceptorReceiptLength());
+        p.printf("%scardholder-display-len:%d%n", inner, getCardholderDisplayLength());
+        p.printf("%scard-acceptor-display-len:%d%n", inner, getCardAcceptorDisplayLength());
+        p.printf("%sicc-script-len:%d%n", inner, getIccScriptDataLength());
+        p.printf("%strack3-rewrite:%b%n", inner, canRewriteTrack3());
+        p.printf("%scard-capture:%b%n", inner, canCaptureCard());
+        p.printf("%spin-input-len:%d%n", inner, getPinInputLength());
+        p.printf("%s</pos-capability>%n", indent);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private int readN3(int offset) {
+        return (b[offset] - '0') * 100
+             + (b[offset + 1] - '0') * 10
+             + (b[offset + 2] - '0');
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder
+    // -------------------------------------------------------------------------
+
+    /**
+     * Fluent builder for {@link PosCapability}.
+     *
+     * <p>All numeric capacity fields default to 0 (not capable).
+     * Track 3 rewrite and card capture default to {@code false}.
+     * PIN input length defaults to 0.
+     * Reading and verification capability bits default to all-zero (no capabilities declared).
+     */
+    public static final class Builder {
+
+        private final byte[] b = new byte[WIRE_LENGTH];
+
+        private Builder() {
+            // Initialise N1 and N3 ASCII fields to '0'
+            b[APPROVAL_CODE_LENGTH_OFFSET] = '0';
+            for (int i = CARDHOLDER_RECEIPT_OFFSET; i < TRACK3_REWRITE_OFFSET; i++)
+                b[i] = '0';
+            b[TRACK3_REWRITE_OFFSET] = 'N';
+            b[CARD_CAPTURE_OFFSET]   = 'N';
+        }
+
+        /**
+         * Sets a card reading capability bit (sub-field 27-1).
+         * Multiple capabilities may be set by calling this method repeatedly.
+         *
+         * @param method the reading method to declare as supported
+         * @return this builder
+         */
+        public Builder readingCapability(PosDataCode.ReadingMethod method) {
+            Objects.requireNonNull(method);
+            // ReadingMethod.getOffset() == 0; READING_OFFSET == 0 — both start at byte 0
+            setFlag(READING_OFFSET, method.intValue());
+            return this;
+        }
+
+        /**
+         * Sets a cardholder verification capability bit (sub-field 27-2).
+         * Multiple capabilities may be set by calling this method repeatedly.
+         *
+         * @param method the verification method to declare as supported
+         * @return this builder
+         */
+        public Builder verificationCapability(PosDataCode.VerificationMethod method) {
+            Objects.requireNonNull(method);
+            // method.getOffset() == 4 in PosDataCode; here the verification sub-field
+            // is at VERIFICATION_OFFSET (4) — do NOT add method.getOffset()
+            setFlag(VERIFICATION_OFFSET, method.intValue());
+            return this;
+        }
+
+        /**
+         * Sets the maximum approval code length (sub-field 27-3, N1, range 0–9).
+         *
+         * @param length approval code length
+         * @return this builder
+         * @throws IllegalArgumentException if {@code length} is outside 0–9
+         */
+        public Builder approvalCodeLength(int length) {
+            if (length < 0 || length > 9)
+                throw new IllegalArgumentException("approvalCodeLength must be 0-9, got " + length);
+            b[APPROVAL_CODE_LENGTH_OFFSET] = (byte) ('0' + length);
+            return this;
+        }
+
+        /**
+         * Sets the maximum cardholder receipt data length (sub-field 27-4, N3, range 0–999).
+         *
+         * @param length receipt length; 0 = not capable
+         * @return this builder
+         * @throws IllegalArgumentException if {@code length} is outside 0–999
+         */
+        public Builder cardholderReceiptLength(int length) {
+            writeN3(CARDHOLDER_RECEIPT_OFFSET, length, "cardholderReceiptLength");
+            return this;
+        }
+
+        /**
+         * Sets the maximum card acceptor receipt data length (sub-field 27-5, N3, range 0–999).
+         *
+         * @param length receipt length; 0 = not capable
+         * @return this builder
+         * @throws IllegalArgumentException if {@code length} is outside 0–999
+         */
+        public Builder cardAcceptorReceiptLength(int length) {
+            writeN3(CARD_ACCEPTOR_RECEIPT_OFFSET, length, "cardAcceptorReceiptLength");
+            return this;
+        }
+
+        /**
+         * Sets the maximum cardholder display data length (sub-field 27-6, N3, range 0–999).
+         *
+         * @param length display length; 0 = not capable
+         * @return this builder
+         * @throws IllegalArgumentException if {@code length} is outside 0–999
+         */
+        public Builder cardholderDisplayLength(int length) {
+            writeN3(CARDHOLDER_DISPLAY_OFFSET, length, "cardholderDisplayLength");
+            return this;
+        }
+
+        /**
+         * Sets the maximum card acceptor display data length (sub-field 27-7, N3, range 0–999).
+         *
+         * @param length display length; 0 = not capable
+         * @return this builder
+         * @throws IllegalArgumentException if {@code length} is outside 0–999
+         */
+        public Builder cardAcceptorDisplayLength(int length) {
+            writeN3(CARD_ACCEPTOR_DISPLAY_OFFSET, length, "cardAcceptorDisplayLength");
+            return this;
+        }
+
+        /**
+         * Sets the maximum ICC scripts data length (sub-field 27-8, N3, range 0–999).
+         *
+         * @param length ICC script length in bytes; 0 = not capable
+         * @return this builder
+         * @throws IllegalArgumentException if {@code length} is outside 0–999
+         */
+        public Builder iccScriptDataLength(int length) {
+            writeN3(ICC_SCRIPT_LENGTH_OFFSET, length, "iccScriptDataLength");
+            return this;
+        }
+
+        /**
+         * Sets the track 3 magnetic stripe rewrite capability (sub-field 27-9).
+         *
+         * @param capable {@code true} if the terminal can rewrite track 3
+         * @return this builder
+         */
+        public Builder track3RewriteCapable(boolean capable) {
+            b[TRACK3_REWRITE_OFFSET] = capable ? (byte) 'Y' : (byte) 'N';
+            return this;
+        }
+
+        /**
+         * Sets the card capture capability (sub-field 27-10).
+         *
+         * @param capable {@code true} if the terminal can capture (retain) cards
+         * @return this builder
+         */
+        public Builder cardCaptureCapable(boolean capable) {
+            b[CARD_CAPTURE_OFFSET] = capable ? (byte) 'Y' : (byte) 'N';
+            return this;
+        }
+
+        /**
+         * Sets the maximum PIN input length capability (sub-field 27-11, binary, range 0–255).
+         *
+         * @param length maximum PIN length the PIN pad accepts
+         * @return this builder
+         * @throws IllegalArgumentException if {@code length} is outside 0–255
+         */
+        public Builder pinInputLength(int length) {
+            if (length < 0 || length > 255)
+                throw new IllegalArgumentException("pinInputLength must be 0-255, got " + length);
+            b[PIN_INPUT_LENGTH_OFFSET] = (byte) length;
+            return this;
+        }
+
+        /**
+         * Builds the {@link PosCapability}.
+         *
+         * @return a new {@code PosCapability} backed by a copy of the accumulated state
+         */
+        public PosCapability build() {
+            byte[] copy = new byte[WIRE_LENGTH];
+            System.arraycopy(b, 0, copy, 0, WIRE_LENGTH);
+            return new PosCapability(copy);
+        }
+
+        // Internal helpers
+
+        private void setFlag(int byteOffset, int flagValue) {
+            for (int v = flagValue; v != 0; v >>>= 8, byteOffset++) {
+                if (byteOffset < WIRE_LENGTH)
+                    b[byteOffset] |= (byte) v;
             }
         }
-        p.printf ("%src: %s%n", inner, sb);
-        sb = new StringBuilder();
-        for (VerificationCapability m : VerificationCapability.values()) {
-            if (hasVerificationCapability(m)) {
-                if (sb.length() > 0)
-                    sb.append(',');
-                sb.append(m.name());
-            }
+
+        private void writeN3(int offset, int value, String name) {
+            if (value < 0 || value > 999)
+                throw new IllegalArgumentException(name + " must be 0-999, got " + value);
+            b[offset]     = (byte) ('0' + value / 100);
+            b[offset + 1] = (byte) ('0' + (value / 10) % 10);
+            b[offset + 2] = (byte) ('0' + value % 10);
         }
-        p.printf ("%svc: %s%n", inner, sb);
-        p.println("</pvc>");
-    }
-
-    public void setReadingCapabilities(boolean value, ReadingCapability ... capabilities ){
-        setFlags(value, capabilities);
-    }
-
-    public void unsetReadingCapabilities(ReadingCapability ... capabilities) {
-        setReadingCapabilities(false, capabilities);
-    }
-
-    public void setReadingCapabilities(ReadingCapability ... capabilities) {
-        setReadingCapabilities(true, capabilities);
-    }
-
-    public void setVerificationCapabilities(boolean value, VerificationCapability ... capabilities){
-        setFlags(value, capabilities);
-    }
-
-    public void unsetVerificationCapabilities(VerificationCapability ... capabilities) {
-        setVerificationCapabilities(false, capabilities);
-    }
-
-    public void setVerificationCapabilities(VerificationCapability ... capabilities) {
-        setVerificationCapabilities(true, capabilities);
     }
 }

--- a/jpos/src/test/java/org/jpos/iso/PosCapabilityTest.java
+++ b/jpos/src/test/java/org/jpos/iso/PosCapabilityTest.java
@@ -13,65 +13,353 @@
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program, if not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.jpos.iso;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import org.jpos.iso.packager.GenericPackager;
 import org.junit.jupiter.api.Test;
 
-public class PosCapabilityTest {
-    private byte[] POSCAP =
-     ISOUtil.hex2byte(
-          "FFFFFFFF"  // Reading Capabilities
-         +"FFFFFFFF"  // Verification Capabilities
-         +ISOUtil.hexString(
-         (
-           "6"        // Approval Code Length
-          +"040"      // Cardholder receipt data length
-          +"080"      // Card acceptor receipt data length
-          +"016"      // Cardholder display data length
-          +"032"      // Card acceptor display data length
-          +"003"      // ICC scripts data length
-          +"N"        // Magnetic stripe track 3 rewrite capability
-          +"Y"        // Card capture capability
-          +"6"        // PIN Input length
-          ).getBytes()
-         )
-     );
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link PosCapability} (DE-027).
+ */
+class PosCapabilityTest {
+
+    // -------------------------------------------------------------------------
+    // Wire length
+    // -------------------------------------------------------------------------
 
     @Test
-    public void testPosCapabiiltyCreation() throws ISOException {
-        ISOPackager p = new GenericPackager("jar:packager/cmf.xml");
-        ISOMsg m = new ISOMsg("2800");
-        m.set("27.0", ISOUtil.hex2byte("FFFFFFFFFFFFFFFF"));
-        m.set("27.1", "6");
-        m.set("27.2", "040");
-        m.set("27.3", "080");
-        m.set("27.4", "016");
-        m.set("27.5", "032");
-        m.set("27.6", "003");
-        m.set("27.7", "N");
-        m.set("27.8", "Y");
-        m.set("27.9", "6");
-        m.setPackager(p);
-        assertEquals(ISOUtil.hexString(POSCAP), ISOUtil.hexString(m.pack()).substring(20));
-        PosCapability pc = PosCapability.valueOf(m.getBytes("27.0"));
-        for (PosCapability.ReadingCapability rc : PosCapability.ReadingCapability.values()) {
-            assertTrue (pc.hasReadingCapability(rc));
-        }
-        for (PosCapability.VerificationCapability vc : PosCapability.VerificationCapability.values()) {
-            assertTrue (pc.hasVerificationCapability(vc));
-        }
-        pc = PosCapability.valueOf(ISOUtil.hex2byte("0000000000000000"));
-        for (PosCapability.ReadingCapability rc : PosCapability.ReadingCapability.values()) {
-            assertFalse (pc.hasReadingCapability(rc));
-        }
-        for (PosCapability.VerificationCapability vc : PosCapability.VerificationCapability.values()) {
-            assertFalse (pc.hasVerificationCapability(vc));
-        }
+    void wireLength_is27() {
+        PosCapability cap = PosCapability.builder().build();
+        assertEquals(27, cap.pack().length);
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-field 27-1: card reading capability
+    // -------------------------------------------------------------------------
+
+    @Test
+    void readingCapability_icc() {
+        PosCapability cap = PosCapability.builder()
+            .readingCapability(PosDataCode.ReadingMethod.ICC)
+            .build();
+        assertTrue(cap.canReadICC());
+        assertFalse(cap.canReadMagstripe());
+        assertFalse(cap.canReadContactless());
+    }
+
+    @Test
+    void readingCapability_magstripe() {
+        PosCapability cap = PosCapability.builder()
+            .readingCapability(PosDataCode.ReadingMethod.MAGNETIC_STRIPE)
+            .build();
+        assertTrue(cap.canReadMagstripe());
+        assertFalse(cap.canReadICC());
+    }
+
+    @Test
+    void readingCapability_contactless() {
+        PosCapability cap = PosCapability.builder()
+            .readingCapability(PosDataCode.ReadingMethod.CONTACTLESS)
+            .build();
+        assertTrue(cap.canReadContactless());
+    }
+
+    @Test
+    void readingCapability_multiple() {
+        PosCapability cap = PosCapability.builder()
+            .readingCapability(PosDataCode.ReadingMethod.ICC)
+            .readingCapability(PosDataCode.ReadingMethod.MAGNETIC_STRIPE)
+            .readingCapability(PosDataCode.ReadingMethod.CONTACTLESS)
+            .build();
+        assertTrue(cap.canReadICC());
+        assertTrue(cap.canReadMagstripe());
+        assertTrue(cap.canReadContactless());
+    }
+
+    @Test
+    void readingCapability_fallback() {
+        PosCapability cap = PosCapability.builder()
+            .readingCapability(PosDataCode.ReadingMethod.FALLBACK)
+            .build();
+        assertTrue(cap.canRead(PosDataCode.ReadingMethod.FALLBACK));
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-field 27-2: cardholder verification capability
+    // -------------------------------------------------------------------------
+
+    @Test
+    void verificationCapability_onlinePin() {
+        PosCapability cap = PosCapability.builder()
+            .verificationCapability(PosDataCode.VerificationMethod.ONLINE_PIN)
+            .build();
+        assertTrue(cap.canVerifyOnlinePin());
+        assertFalse(cap.canVerifySignature());
+        assertFalse(cap.canVerifyOfflinePinInClear());
+    }
+
+    @Test
+    void verificationCapability_signature() {
+        PosCapability cap = PosCapability.builder()
+            .verificationCapability(PosDataCode.VerificationMethod.MANUAL_SIGNATURE)
+            .build();
+        assertTrue(cap.canVerifySignature());
+        assertFalse(cap.canVerifyOnlinePin());
+    }
+
+    @Test
+    void verificationCapability_offlinePin() {
+        PosCapability cap = PosCapability.builder()
+            .verificationCapability(PosDataCode.VerificationMethod.OFFLINE_PIN_IN_CLEAR)
+            .verificationCapability(PosDataCode.VerificationMethod.OFFLINE_PIN_ENCRYPTED)
+            .build();
+        assertTrue(cap.canVerifyOfflinePinInClear());
+        assertTrue(cap.canVerifyOfflinePinEncrypted());
+        assertFalse(cap.canVerifyOnlinePin());
+    }
+
+    @Test
+    void verificationCapability_multiple() {
+        PosCapability cap = PosCapability.builder()
+            .verificationCapability(PosDataCode.VerificationMethod.ONLINE_PIN)
+            .verificationCapability(PosDataCode.VerificationMethod.MANUAL_SIGNATURE)
+            .build();
+        assertTrue(cap.canVerifyOnlinePin());
+        assertTrue(cap.canVerifySignature());
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-field 27-3: approval code length
+    // -------------------------------------------------------------------------
+
+    @Test
+    void approvalCodeLength_default_zero() {
+        assertEquals(0, PosCapability.builder().build().getApprovalCodeLength());
+    }
+
+    @Test
+    void approvalCodeLength_set() {
+        PosCapability cap = PosCapability.builder().approvalCodeLength(6).build();
+        assertEquals(6, cap.getApprovalCodeLength());
+    }
+
+    @Test
+    void approvalCodeLength_boundary() {
+        assertEquals(0, PosCapability.builder().approvalCodeLength(0).build().getApprovalCodeLength());
+        assertEquals(9, PosCapability.builder().approvalCodeLength(9).build().getApprovalCodeLength());
+    }
+
+    @Test
+    void approvalCodeLength_outOfRange_throws() {
+        assertThrows(IllegalArgumentException.class, () ->
+            PosCapability.builder().approvalCodeLength(10));
+        assertThrows(IllegalArgumentException.class, () ->
+            PosCapability.builder().approvalCodeLength(-1));
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-fields 27-4 through 27-8: N3 capacity fields
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cardholderReceiptLength_default_zero() {
+        assertEquals(0, PosCapability.builder().build().getCardholderReceiptLength());
+    }
+
+    @Test
+    void cardholderReceiptLength_set() {
+        assertEquals(40, PosCapability.builder().cardholderReceiptLength(40).build().getCardholderReceiptLength());
+    }
+
+    @Test
+    void cardholderReceiptLength_max() {
+        assertEquals(999, PosCapability.builder().cardholderReceiptLength(999).build().getCardholderReceiptLength());
+    }
+
+    @Test
+    void cardAcceptorReceiptLength_set() {
+        assertEquals(80, PosCapability.builder().cardAcceptorReceiptLength(80).build().getCardAcceptorReceiptLength());
+    }
+
+    @Test
+    void cardholderDisplayLength_set() {
+        assertEquals(16, PosCapability.builder().cardholderDisplayLength(16).build().getCardholderDisplayLength());
+    }
+
+    @Test
+    void cardAcceptorDisplayLength_set() {
+        assertEquals(24, PosCapability.builder().cardAcceptorDisplayLength(24).build().getCardAcceptorDisplayLength());
+    }
+
+    @Test
+    void iccScriptDataLength_set() {
+        assertEquals(128, PosCapability.builder().iccScriptDataLength(128).build().getIccScriptDataLength());
+    }
+
+    @Test
+    void n3_outOfRange_throws() {
+        assertThrows(IllegalArgumentException.class, () ->
+            PosCapability.builder().cardholderReceiptLength(1000));
+        assertThrows(IllegalArgumentException.class, () ->
+            PosCapability.builder().cardholderReceiptLength(-1));
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-field 27-9: track 3 rewrite
+    // -------------------------------------------------------------------------
+
+    @Test
+    void track3Rewrite_default_false() {
+        assertFalse(PosCapability.builder().build().canRewriteTrack3());
+    }
+
+    @Test
+    void track3Rewrite_true() {
+        assertTrue(PosCapability.builder().track3RewriteCapable(true).build().canRewriteTrack3());
+    }
+
+    @Test
+    void track3Rewrite_false() {
+        assertFalse(PosCapability.builder().track3RewriteCapable(false).build().canRewriteTrack3());
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-field 27-10: card capture
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cardCapture_default_false() {
+        assertFalse(PosCapability.builder().build().canCaptureCard());
+    }
+
+    @Test
+    void cardCapture_true() {
+        assertTrue(PosCapability.builder().cardCaptureCapable(true).build().canCaptureCard());
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-field 27-11: PIN input length
+    // -------------------------------------------------------------------------
+
+    @Test
+    void pinInputLength_default_zero() {
+        assertEquals(0, PosCapability.builder().build().getPinInputLength());
+    }
+
+    @Test
+    void pinInputLength_set() {
+        assertEquals(12, PosCapability.builder().pinInputLength(12).build().getPinInputLength());
+    }
+
+    @Test
+    void pinInputLength_maxByte() {
+        assertEquals(255, PosCapability.builder().pinInputLength(255).build().getPinInputLength());
+    }
+
+    @Test
+    void pinInputLength_outOfRange_throws() {
+        assertThrows(IllegalArgumentException.class, () ->
+            PosCapability.builder().pinInputLength(256));
+        assertThrows(IllegalArgumentException.class, () ->
+            PosCapability.builder().pinInputLength(-1));
+    }
+
+    // -------------------------------------------------------------------------
+    // Pack / unpack round-trip
+    // -------------------------------------------------------------------------
+
+    @Test
+    void packUnpack_roundTrip() {
+        PosCapability original = PosCapability.builder()
+            .readingCapability(PosDataCode.ReadingMethod.ICC)
+            .readingCapability(PosDataCode.ReadingMethod.MAGNETIC_STRIPE)
+            .verificationCapability(PosDataCode.VerificationMethod.ONLINE_PIN)
+            .verificationCapability(PosDataCode.VerificationMethod.MANUAL_SIGNATURE)
+            .approvalCodeLength(6)
+            .cardholderReceiptLength(40)
+            .cardAcceptorReceiptLength(40)
+            .cardholderDisplayLength(16)
+            .cardAcceptorDisplayLength(16)
+            .iccScriptDataLength(128)
+            .track3RewriteCapable(false)
+            .cardCaptureCapable(true)
+            .pinInputLength(12)
+            .build();
+
+        PosCapability decoded = PosCapability.unpack(original.pack());
+
+        assertTrue(decoded.canReadICC());
+        assertTrue(decoded.canReadMagstripe());
+        assertFalse(decoded.canReadContactless());
+        assertTrue(decoded.canVerifyOnlinePin());
+        assertTrue(decoded.canVerifySignature());
+        assertEquals(6,   decoded.getApprovalCodeLength());
+        assertEquals(40,  decoded.getCardholderReceiptLength());
+        assertEquals(40,  decoded.getCardAcceptorReceiptLength());
+        assertEquals(16,  decoded.getCardholderDisplayLength());
+        assertEquals(16,  decoded.getCardAcceptorDisplayLength());
+        assertEquals(128, decoded.getIccScriptDataLength());
+        assertFalse(decoded.canRewriteTrack3());
+        assertTrue(decoded.canCaptureCard());
+        assertEquals(12,  decoded.getPinInputLength());
+    }
+
+    @Test
+    void unpack_wrongLength_throws() {
+        assertThrows(IllegalArgumentException.class, () -> PosCapability.unpack(new byte[26]));
+        assertThrows(IllegalArgumentException.class, () -> PosCapability.unpack(new byte[28]));
+        assertThrows(IllegalArgumentException.class, () -> PosCapability.unpack(null));
+    }
+
+    // -------------------------------------------------------------------------
+    // toBuilder independence
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toBuilder_doesNotMutateOriginal() {
+        PosCapability original = PosCapability.builder()
+            .readingCapability(PosDataCode.ReadingMethod.ICC)
+            .approvalCodeLength(6)
+            .build();
+
+        PosCapability modified = original.toBuilder()
+            .readingCapability(PosDataCode.ReadingMethod.MAGNETIC_STRIPE)
+            .approvalCodeLength(4)
+            .build();
+
+        assertTrue(original.canReadICC());
+        assertFalse(original.canReadMagstripe());
+        assertEquals(6, original.getApprovalCodeLength());
+
+        assertTrue(modified.canReadICC());
+        assertTrue(modified.canReadMagstripe());
+        assertEquals(4, modified.getApprovalCodeLength());
+    }
+
+    // -------------------------------------------------------------------------
+    // ISOMsg integration
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isomsg_setAndGet_roundTrip() throws Exception {
+        PosCapability cap = PosCapability.builder()
+            .readingCapability(PosDataCode.ReadingMethod.ICC)
+            .verificationCapability(PosDataCode.VerificationMethod.ONLINE_PIN)
+            .approvalCodeLength(6)
+            .pinInputLength(12)
+            .build();
+
+        ISOMsg msg = new ISOMsg();
+        msg.set(new ISOBinaryField(27, cap.pack()));
+
+        PosCapability decoded = PosCapability.unpack(msg.getBytes(27));
+        assertTrue(decoded.canReadICC());
+        assertTrue(decoded.canVerifyOnlinePin());
+        assertEquals(6,  decoded.getApprovalCodeLength());
+        assertEquals(12, decoded.getPinInputLength());
     }
 }


### PR DESCRIPTION
Introduces `PosCapability` in `org.jpos.iso` for structured encode/decode of DE-027 (POS Capability).

## Relationship to DE-022

DE-022 (`PosDataCode`) records what **actually happened**. DE-027 (`PosCapability`) records what the terminal is **capable of**. Sub-fields 27-1 and 27-2 share the same bit tables — so `PosDataCode.ReadingMethod` and `PosDataCode.VerificationMethod` are reused directly.

## Wire layout (27 bytes fixed)

| Sub-field | Name | Format |
|-----------|------|--------|
| 27-1 | Card reading capability | B4 (bit-flags, same as DE-022 sf-1) |
| 27-2 | Cardholder verification capability | B4 (bit-flags, same as DE-022 sf-2) |
| 27-3 | Approval code length | N1 ASCII |
| 27-4 | Cardholder receipt data length | N3 ASCII |
| 27-5 | Card acceptor receipt data length | N3 ASCII |
| 27-6 | Cardholder display data length | N3 ASCII |
| 27-7 | Card acceptor display data length | N3 ASCII |
| 27-8 | ICC scripts data length | N3 ASCII |
| 27-9 | Track 3 rewrite capability | A1 Y/N |
| 27-10 | Card capture capability | A1 Y/N |
| 27-11 | PIN input length capability | B1 binary |

## Usage

```java
PosCapability cap = PosCapability.builder()
    .readingCapability(PosDataCode.ReadingMethod.ICC)
    .readingCapability(PosDataCode.ReadingMethod.MAGNETIC_STRIPE)
    .verificationCapability(PosDataCode.VerificationMethod.ONLINE_PIN)
    .approvalCodeLength(6)
    .cardholderReceiptLength(40)
    .pinInputLength(12)
    .build();

msg.set(new ISOBinaryField(27, cap.pack()));

PosCapability received = PosCapability.unpack(msg.getBytes(27));
received.canReadICC();          // true
received.canVerifyOnlinePin();  // true
received.getPinInputLength();   // 12
```

## Tests

35 tests — all passing.