### PR TITLE
fix(cmfv3): add missing DE-043 sub-fields — geographic location and additional address

### DIFF
--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -418,6 +418,16 @@
           length="99"
           name="Card acceptor e-mail address"
           class="org.jpos.iso.IFB_LLCHAR"/>
+      <isofield
+          id="13"
+          length="19"
+          name="Card acceptor geographic location"
+          class="org.jpos.iso.IFB_LLCHAR"/>
+      <isofield
+          id="14"
+          length="255"
+          name="Card acceptor additional address information"
+          class="org.jpos.iso.IFB_LLLCHAR"/>
   </isofieldpackager>
   <isofield
       id="44"


### PR DESCRIPTION
ISO 8583:2023 Annex C defines two sub-fields for DE-043 (Card Acceptor Name/Location) that were missing from `cmfv3.xml`:

| Bit | Name | Format |
|-----|------|--------|
| 13 | Card acceptor geographic location | `LLVAR ans..19` |
| 14 | Card acceptor additional address information | `LLLVAR an..255` |