### PR TITLE
fix(cmfv3): remove dead emitBitmap/bitmapField attrs from DE-043 and DE-049

### DIFF
--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -356,13 +356,7 @@
       length="9999"
       name="Card acceptor name/location"
       class="org.jpos.iso.IFB_LLLLBINARY"
-      emitBitmap="true" bitmapField="0"
       packager="org.jpos.iso.packager.DatasetPackager">
-      <isofield
-          id="0"
-          length="16"
-          name="Bit Map"
-          class="org.jpos.iso.IFB_BITMAP"/>
       <isofield
           id="2"
           length="50"
@@ -449,13 +443,7 @@
       length="9999"
       name="Verification data"
       class="org.jpos.iso.IFB_LLLLBINARY"
-      emitBitmap="true" bitmapField="0"
       packager="org.jpos.iso.packager.DatasetPackager">
-      <isofield
-          id="0"
-          length="16"
-          name="Bit Map"
-          class="org.jpos.iso.IFB_BITMAP"/>
       <isofield
         id="1"
         length="1"


### PR DESCRIPTION
## Problem

`cmfv3.xml` declared `emitBitmap="true" bitmapField="0"` and an `id=0 IFB_BITMAP` sub-field for DE-043 (Card acceptor name/location) and DE-049 (Verification data).

These attributes are **dead configuration**: `DatasetPackager` completely overrides `GenericPackager.pack()`/`unpack()` and never calls `isEmitBitmap()` or reads `bitmapField`. The IFB_BITMAP sub-field at id=0 was also never consulted.

Both fields already correctly encode as standard dataset envelopes:
```
[identifier 1 byte][content length 2 bytes][DBM or TLV content]
```

## Fix

Remove the dead attributes and the unused bitmap sub-field from both field definitions.

## Tests

All `DatasetPackagerTest` tests pass — no behavioral change.