### PR TITLE
fix(cmfv3): widen DE-113.14 state/province/region code from 2 to 3 chars

### DIFF
--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -966,8 +966,8 @@
           class="org.jpos.iso.IFB_LLCHAR" />
       <isofield
           id="14"
-          length="2"
-          name="State"
+          length="3"
+          name="State, province, or region code"
           class="org.jpos.iso.IF_CHAR" />
       <isofield
           id="15"


### PR DESCRIPTION
DE-113.14 was defined as `AN2` with a US-only description. Widening to `ANS3` aligns with ISO 8583:2023 DE-043 sub-field 5 (card acceptor state, province, or region code) and accommodates 3-character subdivision codes (e.g., `NSW`, `ENG`).

Field renamed from `State` to `State, province, or region code`.