### PR TITLE
fix(cmfv3): add missing DE-113 sub-fields 64, 65, 66

### DIFF
--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -1080,6 +1080,21 @@
           name="Additional Data - reserved for private use"
           class="org.jpos.iso.IFB_LLLLCHAR" />
       <isofield
+          id="64"
+          length="50"
+          name="Source Station"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="65"
+          length="50"
+          name="Destination Station"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
+          id="66"
+          length="32"
+          name="Card Scheme"
+          class="org.jpos.iso.IFB_LLCHAR" />
+      <isofield
           id="69"
           length="40"
           name="Card Token"


### PR DESCRIPTION
Three jCard sub-fields were absent from the DE-113 packager definition in `cmfv3.xml`:

| Sub-field | Name | Format |
|-----------|------|--------|
| 64 | Source Station | `IFB_LLCHAR length=50` |
| 65 | Destination Station | `IFB_LLCHAR length=50` |
| 66 | Card Scheme | `IFB_LLCHAR length=32` |