### PR TITLE
feat(cmfv3): add DE-051 Customer Related Data with DatasetPackager

### DIFF
--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -490,11 +490,13 @@
       length="9999"
       name="Reserved for ISO"
       class="org.jpos.iso.IFB_LLLLBINARY"/>
-  <isofield
+  <isofieldpackager
       id="51"
       length="9999"
-      name="Reserved for ISO"
-      class="org.jpos.iso.IFB_LLLLBINARY"/>
+      name="Customer related data"
+      class="org.jpos.iso.IFB_LLLLBINARY"
+      packager="org.jpos.iso.packager.DatasetPackager">
+  </isofieldpackager>
   <isofield
       id="52"
       length="8"


### PR DESCRIPTION
Implements ISO 8583:2023 **DE-051 Customer Related Data** (`LLLLVAR ansb..9999`) using `DatasetPackager`.

Five datasets defined per ISO 8583:2023 Annex C:

| Dataset | Contents |
|---------|----------|
| `0x71` | PAR (Payment Account Reference) + PAN reference identifier |
| `0x72` | Customer contact data (phone, email) |
| `0x73` | Customer identification (passport, national ID, driver license, SSN, etc.) |
| `0x74` | Wallet provider data (ID, assigner, country, short name) |
| `0x75` | Account owner name + address |

The PAR (dataset 0x71) is the primary motivation — it is a stable, token-agnostic identifier that links all tokens and the underlying PAN for a given account, now widely required by Visa and Mastercard tokenization schemes.

Note: DE-113.67 sub-fields 4 (Wallet Provider Account Hash) and 5 (Tokenization Cardholder Name) overlap with DE-051 datasets 0x74 and 0x75 and will be removed from DE-113.67 in a follow-up (pending PR #693 merge).