### PR TITLE
fix(cmfv3): convert DE-113.69/70/71 to variable-length packagers

### DIFF
--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -1181,17 +1181,17 @@
           id="69"
           length="40"
           name="Card Token"
-          class="org.jpos.iso.IF_CHAR" />
+          class="org.jpos.iso.IFB_LLCHAR" />
       <isofield
           id="70"
           length="19"
           name="Transaction ID"
-          class="org.jpos.iso.IFB_NUMERIC" />
+          class="org.jpos.iso.IFB_LLNUM" />
       <isofield
           id="71"
           length="19"
-          name="Transaction GroupID"
-          class="org.jpos.iso.IFB_NUMERIC" />
+          name="Transaction Group ID"
+          class="org.jpos.iso.IFB_LLNUM" />
   </isofieldpackager>
   <isofield
       id="114"


### PR DESCRIPTION
DE-113.69 (Card Token), 70 (Transaction ID), and 71 (Transaction Group ID) were defined as fixed-length in the packager, but should be variable-length to match the `AN..40` / `N..19` design intent.

| Field | Before | After |
|-------|--------|-------|
| 69 Card Token | `IF_CHAR length=40` (fixed) | `IFB_LLCHAR length=40` (LLVAR) |
| 70 Transaction ID | `IFB_NUMERIC length=19` (fixed BCD) | `IFB_LLNUM length=19` (LLVAR BCD) |
| 71 Transaction Group ID | `IFB_NUMERIC length=19` (fixed BCD) | `IFB_LLNUM length=19` (LLVAR BCD) |