### PR TITLE
build: bump minor dependencies and harden JESpace timing tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ commonscli = "1.11.0"
 commonslang3 = "3.20.0"
 jline = "3.30.6"
 jna = '5.18.1'
-jansi = '2.4.2'
+jansi = '2.4.3'
 beanshell = "2.0b6"
 javatuples = "1.2"
 mapdb = "3.1.0"
@@ -17,9 +17,9 @@ bouncycastle = "1.83"
 hamcrest = "3.0"
 hdrhistogram = "2.2.2"
 yaml = "2.6"
-micrometercore = "1.16.1"
-micrometerprometheus = "1.16.1"
-jackson = '2.21.1'
+micrometercore = "1.16.4"
+micrometerprometheus = "1.16.4"
+jackson = '2.21.2'
 jdbm = '1.0'
 
 [libraries]

--- a/jpos/src/test/java/org/jpos/space/JESpaceTestCase.java
+++ b/jpos/src/test/java/org/jpos/space/JESpaceTestCase.java
@@ -142,14 +142,16 @@ public class JESpaceTestCase {
     @Test
     @DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true")
     public void testOutExpire() {
-        sp.out ("OUT", "ONE", 1000L);
-        sp.out ("OUT", "TWO", 2000L);
-        sp.out ("OUT", "THREE", 3000L);
-        sp.out  ("OUT", "FOUR", 4000L);
+        // JESpace uses transactional Berkeley DB operations, so use wider expiration gaps
+        // than the in-memory spaces to avoid timing-sensitive boundary failures on slower hosts.
+        sp.out ("OUT", "ONE", 1500L);
+        sp.out ("OUT", "TWO", 3000L);
+        sp.out ("OUT", "THREE", 4500L);
+        sp.out  ("OUT", "FOUR", 6000L);
         assertEquals ("ONE", sp.rdp ("OUT"));
-        ISOUtil.sleep (1500L);
+        ISOUtil.sleep (2000L);
         assertEquals ("TWO", sp.rdp ("OUT"));
-        ISOUtil.sleep (1000L);
+        ISOUtil.sleep (1500L);
         assertEquals ("THREE", sp.rdp ("OUT"));
         assertEquals ("THREE", sp.inp ("OUT"));
         assertEquals ("FOUR", sp.inp ("OUT"));
@@ -158,14 +160,14 @@ public class JESpaceTestCase {
     @Test
     @DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true")
     public void testPushExpire() {
-        sp.push ("PUSH", "FOUR", 4000L);
-        sp.push ("PUSH", "THREE", 3000L);
-        sp.push ("PUSH", "TWO", 2000L);
-        sp.push  ("PUSH", "ONE", 1000L);
+        sp.push ("PUSH", "FOUR", 6000L);
+        sp.push ("PUSH", "THREE", 4500L);
+        sp.push ("PUSH", "TWO", 3000L);
+        sp.push  ("PUSH", "ONE", 1500L);
         assertEquals ("ONE", sp.rdp ("PUSH"));
-        ISOUtil.sleep (1500L);
+        ISOUtil.sleep (2000L);
         assertEquals ("TWO", sp.rdp ("PUSH"));
-        ISOUtil.sleep (1000L);
+        ISOUtil.sleep (1500L);
         assertEquals ("THREE", sp.rdp ("PUSH"));
         assertEquals ("THREE", sp.inp ("PUSH"));
         assertEquals ("FOUR", sp.inp ("PUSH"));


### PR DESCRIPTION
## Summary
- bump `jansi` from `2.4.2` to `2.4.3`
- bump `micrometer-core` and `micrometer-prometheus` from `1.16.1` to `1.16.4`
- bump `jackson` from `2.21.1` to `2.21.2`
- harden `JESpaceTestCase` expiration timing so it stays stable on slower hosts

## Notes
While validating the dependency bumps, `JESpaceTestCase.testPushExpire()` failed on this machine. I reproduced the same failure on plain latest `main`, so this was a pre-existing timing-sensitive test rather than a bump regression.

## Testing
- `./gradlew test`
