### PR TITLE
packager: fix DE49 verification-data bitmap length

### DIFF
--- a/jpos/src/main/resources/packager/cmf-858.xml
+++ b/jpos/src/main/resources/packager/cmf-858.xml
@@ -451,7 +451,7 @@
       packager="org.jpos.iso.packager.GenericSubFieldPackager">
       <isofield
           id="0"
-          length="16"
+          length="8"
           name="Bit Map"
           class="org.jpos.iso.IFB_BITMAP"/>
       <isofield

--- a/jpos/src/main/resources/packager/cmf.xml
+++ b/jpos/src/main/resources/packager/cmf.xml
@@ -451,7 +451,7 @@
       packager="org.jpos.iso.packager.GenericSubFieldPackager">
       <isofield
           id="0"
-          length="16"
+          length="8"
           name="Bit Map"
           class="org.jpos.iso.IFB_BITMAP"/>
       <isofield

--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -450,6 +450,11 @@
       length="999"
       name="Additional data private"
       class="org.jpos.iso.IFB_LLLCHAR"/>
+  <!--
+      DE-049 in cmfv3 is modeled as a DatasetPackager (DBM), not as a GenericSubFieldPackager
+      with an IFB_BITMAP field 0. DatasetPackager reserves bit 1 as continuation, so element 1
+      does not collide with bitmap extension semantics.
+  -->
   <isofieldpackager
       id="49"
       length="9999"


### PR DESCRIPTION
## Summary

Fix DE49 (Verification data) in the CMF packagers by changing its bitmap length from 16 bytes to 8 bytes in:

- `jpos/src/main/resources/packager/cmf.xml`
- `jpos/src/main/resources/packager/cmf-858.xml`

`cmfv3.xml` does not use `IFB_BITMAP` for DE49, it uses `DatasetPackager`, so this PR only adds a clarifying comment there.

## Why

DE49 defines subfield 1 as a real data element (`Additional identification type`).

With `IFB_BITMAP(16)`, bit 1 collides with the secondary-bitmap extension indicator used by `IFB_BITMAP.unpack()`, which causes pack/unpack asymmetry when subfield 1 is present.

Using an 8-byte bitmap matches the actual DE49 definition and avoids the issue reported in #701.

## Notes

- `cmf.xml`: DE49 bitmap changed from 16 to 8
- `cmf-858.xml`: DE49 bitmap changed from 16 to 8
- `cmfv3.xml`: added comment only, because DE49 is modeled as `DatasetPackager` there

## Testing

Ran:

- `./gradlew --no-daemon :jpos:test --tests org.jpos.iso.DatasetPackagerTest --tests org.jpos.iso.TPPDataElementsTest`

Also verified the XML definitions directly:

- `cmf.xml` DE49 bitmap length = 8
- `cmf-858.xml` DE49 bitmap length = 8

## Related

This addresses the root cause described in #701 and supersedes that reproducer-only PR.
