### PR TITLE
ci: avoid duplicate workflow runs on branch pushes

### DIFF
--- a/.github/workflows/jpos.yml
+++ b/.github/workflows/jpos.yml
@@ -1,6 +1,10 @@
 ---
 name: "Run jPOS Tests"
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Restrict the `jpos.yml` workflow triggers to avoid duplicate CI runs for the same change.

## Change

Replace:

```yaml
on: [push, pull_request]
```

with:

```yaml
on:
  push:
    branches: [ main ]
  pull_request:
    branches: [ main ]
```

## Why

Right now the workflow runs the same build twice for a typical PR branch update:

- once on `push`
- once on `pull_request`

Since the workflow contains a single `build` job with the same steps in both cases, this duplicates CI work and noise without adding coverage.

This change keeps:

- PR validation for changes targeting `main`
- CI on changes pushed or merged to `main`

while avoiding redundant runs for feature branches.
