### PR TITLE
Use ThreadPoolExecutor in LogCompressor

### DIFF
--- a/jpos/src/main/java/org/jpos/util/DailyLogListener.java
+++ b/jpos/src/main/java/org/jpos/util/DailyLogListener.java
@@ -513,7 +513,7 @@ public class DailyLogListener extends RotateLogListener{
      */
     protected void compress(File logFile) {
         if (getCompressionFormat() != NONE) {
-            LogCompressor.getInstance().submit(new Compressor(logFile));
+            LogCompressor.getInstance().submit(logFile, new Compressor(logFile));
         }
     }
 

--- a/jpos/src/main/java/org/jpos/util/LogCompressor.java
+++ b/jpos/src/main/java/org/jpos/util/LogCompressor.java
@@ -18,6 +18,9 @@
 
 package org.jpos.util;
 
+import org.jpos.q2.Q2;
+
+import java.io.File;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -63,12 +66,15 @@ public class LogCompressor {
         return instance;
     }
 
-    public void submit(Runnable task) {
+    public void submit(File logFile, Runnable task) {
         executor.execute(() -> {
             try {
                 task.run();
             } catch (Throwable t) {
-                t.printStackTrace(System.err);
+                Q2.getQ2().getLog().warn(
+                  String.format("error running log compression task for '%s'", logFile),
+                  t
+                );
             }
         });
     }

--- a/jpos/src/main/java/org/jpos/util/LogCompressor.java
+++ b/jpos/src/main/java/org/jpos/util/LogCompressor.java
@@ -18,24 +18,40 @@
 
 package org.jpos.util;
 
-import org.jpos.space.TSpace;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Serializes log file compression across all log listener instances
- * through a single on-demand background thread backed by a TSpace work queue.
+ * through a single on-demand background worker.
  *
- * <p>The consumer thread is started when work is submitted and exits
- * after {@link #IDLE_TIMEOUT} milliseconds of inactivity.</p>
+ * <p>The worker thread is created on demand, runs as a low-priority daemon,
+ * and exits after {@link #IDLE_TIMEOUT} milliseconds of inactivity.</p>
  */
-public class LogCompressor implements Runnable {
-    private static final String QUEUE_KEY = "compression";
+public class LogCompressor {
     private static final long IDLE_TIMEOUT = 30_000L;
 
     private static volatile LogCompressor instance;
-    private final TSpace<String, Runnable> space = new TSpace<>();
-    private Thread thread;
+    private final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+      0,
+      1,
+      IDLE_TIMEOUT,
+      TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue<>(),
+      r -> {
+          Thread t = Thread.ofPlatform()
+            .daemon(true)
+            .name("log-compressor", 0)
+            .unstarted(r);
+          t.setPriority(Thread.NORM_PRIORITY - 1);
+          return t;
+      }
+    );
 
-    private LogCompressor() { }
+    private LogCompressor() {
+        executor.allowCoreThreadTimeOut(true);
+    }
 
     public static LogCompressor getInstance() {
         if (instance == null) {
@@ -47,33 +63,13 @@ public class LogCompressor implements Runnable {
         return instance;
     }
 
-    public synchronized void submit(Runnable task) {
-        space.out(QUEUE_KEY, task);
-        if (thread == null || !thread.isAlive()) {
-            thread = Thread.ofPlatform()
-              .daemon(true)
-              .name("log-compressor")
-              .priority(Thread.NORM_PRIORITY - 1)
-              .start(this);
-        }
-    }
-
-    @Override
-    public void run() {
-        try {
-            Runnable task;
-            while ((task = space.in(QUEUE_KEY, IDLE_TIMEOUT)) != null) {
-                try {
-                    task.run();
-                } catch (Throwable t) {
-                    t.printStackTrace(System.err);
-                }
+    public void submit(Runnable task) {
+        executor.execute(() -> {
+            try {
+                task.run();
+            } catch (Throwable t) {
+                t.printStackTrace(System.err);
             }
-        } finally {
-            synchronized (this) {
-                if (space.rdp(QUEUE_KEY) == null)
-                    thread = null;
-            }
-        }
+        });
     }
 }


### PR DESCRIPTION
This replaces the new `LogCompressor` internal queue/thread management with a single-thread `ThreadPoolExecutor`.

Why:
- preserves the same behavior, one compression at a time
- keeps the worker on-demand and idle-timeout based
- keeps the low-priority daemon thread requirement
- uses the JDK's standard concurrency abstraction instead of a hand-rolled queue/worker built on `TSpace`
- routes compression failures through the Q2 logger instead of printing to stderr

Implementation details:
- single worker thread
- `allowCoreThreadTimeOut(true)`
- 30s keepalive
- custom thread factory for daemon name and lower priority
- compression failures now log through `Q2.getQ2().getLog().warn(...)`, including the target filename

Also, this follows Andrés Alcarraz's direction to serialize compression globally instead of spawning one thread per rotation. This PR only changes the internal execution mechanism, not the overall behavior.

Validation:
- `source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk env install && sdk env && ./gradlew --no-daemon :jpos:compileJava :jpos:testClasses` ✅
