### PR TITLE
ci: move GitHub Actions workflows to Node 24-compatible actions

### DIFF
--- a/.github/workflows/jpos.yml
+++ b/.github/workflows/jpos.yml
@@ -32,7 +32,7 @@ jobs:
         TERM: dumb
     - name: Upload test results
       if: success() || failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-results
         path: jpos/build/reports/tests/*

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -10,8 +10,8 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           java-version: '22'
           distribution: 'corretto'


### PR DESCRIPTION
This updates GitHub Actions workflow dependencies that are still pinned to Node 20-based JavaScript actions.

Why:
- recent jPOS workflow runs emitted GitHub's Node 20 deprecation warning
- jPOS itself is not using Node directly, the warning comes from JavaScript-based GitHub Actions
- `actions/upload-artifact@v4` in `jpos.yml` still runs on Node 20
- `actions/checkout@v4` and `actions/setup-java@v4` in `publish-snapshot.yml` also run on Node 20

Changes:
- `actions/upload-artifact@v4` -> `@v7`
- `actions/checkout@v4` -> `@v5`
- `actions/setup-java@v4` -> `@v5`

This moves the workflow dependencies to Node 24-compatible action versions and should eliminate the deprecation warning on future runs.
