### PR TITLE
ProtectDebugInfo: enhanced config

### DIFF
--- a/jpos/src/main/java/org/jpos/transaction/ProtectDebugInfo.java
+++ b/jpos/src/main/java/org/jpos/transaction/ProtectDebugInfo.java
@@ -41,14 +41,17 @@ import java.util.Arrays;
  *        &lt;property name="protect-entry" value="PAN, EXP, REQUEST_ICC_DATA" /&gt;
  *        &lt;property name="wipe-entry"    value="EXPDATE" /&gt;
  *
+ *        &lt;-- if the protected ctx entry is an ISOMsg --&gt;
  *        &lt;property name="protect-ISOMsg" value="2" /&gt;
  *        &lt;property name="protect-ISOMsg" value="35, 45" /&gt;
  *        &lt;property name="wipe-ISOMsg"    value="52, 55" /&gt;
  *
+ *        &lt;-- if the protected ctx entry is a TLVList --&gt;
  *        &lt;property name="wipe-TLVList" value="0x56" /&gt;
  *        &lt;property name="wipe-TLVList" value="0x57" /&gt;
  *        &lt;property name="wipe-TLVList" value="0x5a, 0x5f20" /&gt;
  *
+ *        &lt;-- if the protected ctx entry is a FSDMsg --&gt;
  *        &lt;property name="protect-FSDMsg" value="account-number" /&gt;
  *        &lt;property name="protect-FSDMsg" value="track2-data" /&gt;
  *        &lt;property name="wipe-FSDMsg"    value="secret-key" /&gt;
@@ -72,6 +75,7 @@ public class ProtectDebugInfo implements AbortParticipant, Configurable {
      private String[] protectFSD;
      private String[] protectISO;
      private String[] wipeISO;
+     private String[] wipeFSD;
      private String[] wipeTLV;
 
      public int prepare (long id, Serializable o) {
@@ -113,14 +117,18 @@ public class ProtectDebugInfo implements AbortParticipant, Configurable {
                  if (m != null) {
                      for (String p: protectFSD)
                          protectField(m,p);
+                     for (String p: wipeFSD)
+                         wipeField(m,p);
                  }
              }
+
              if (o instanceof String){
                  String p = ctx.get(s);
                  if (p != null){
                      ctx.put(s, protect (p));
                  }
              }
+
              if (o instanceof TLVList) {
                  TLVList tlv = ctx.get(s);
                  if (tlv != null) {
@@ -148,7 +156,7 @@ public class ProtectDebugInfo implements AbortParticipant, Configurable {
                         m.set(f, ProtectedLogListener.BINARY_WIPED);
                 }
             } catch (ISOException ignored) {
-                //ignore, valid routes for some messages in the context may not be vaild for others
+                //ignore, valid routes for some messages in the context may not be valid for others
                 //e.g. in transaction switches with protocol conversion
             }
         }
@@ -191,6 +199,7 @@ public class ProtectDebugInfo implements AbortParticipant, Configurable {
          this.protectFSD = getValues(cfg, "protect-FSDMsg");
          this.protectISO = getValues(cfg, "protect-ISOMsg");
          this.wipeISO = getValues(cfg, "wipe-ISOMsg");
+         this.wipeFSD = getValues(cfg, "wipe-FSDMsg");
          this.wipeTLV = getValues(cfg, "wipe-TLVList");
      }
      private String[] getValues (Configuration cfg, String name) {

--- a/jpos/src/main/java/org/jpos/transaction/ProtectDebugInfo.java
+++ b/jpos/src/main/java/org/jpos/transaction/ProtectDebugInfo.java
@@ -41,17 +41,17 @@ import java.util.Arrays;
  *        &lt;property name="protect-entry" value="PAN, EXP, REQUEST_ICC_DATA" /&gt;
  *        &lt;property name="wipe-entry"    value="EXPDATE" /&gt;
  *
- *        &lt;-- if the protected ctx entry is an ISOMsg --&gt;
+ *        &lt;!-- if the protected ctx entry is an ISOMsg --&gt;
  *        &lt;property name="protect-ISOMsg" value="2" /&gt;
  *        &lt;property name="protect-ISOMsg" value="35, 45" /&gt;
  *        &lt;property name="wipe-ISOMsg"    value="52, 55" /&gt;
  *
- *        &lt;-- if the protected ctx entry is a TLVList --&gt;
+ *        &lt;!-- if the protected ctx entry is a TLVList --&gt;
  *        &lt;property name="wipe-TLVList" value="0x56" /&gt;
  *        &lt;property name="wipe-TLVList" value="0x57" /&gt;
  *        &lt;property name="wipe-TLVList" value="0x5a, 0x5f20" /&gt;
  *
- *        &lt;-- if the protected ctx entry is a FSDMsg --&gt;
+ *        &lt;!-- if the protected ctx entry is a FSDMsg --&gt;
  *        &lt;property name="protect-FSDMsg" value="account-number" /&gt;
  *        &lt;property name="protect-FSDMsg" value="track2-data" /&gt;
  *        &lt;property name="wipe-FSDMsg"    value="secret-key" /&gt;
@@ -59,7 +59,7 @@ import java.util.Arrays;
  *    &lt;/participant&gt;
  *</pre>
  *
- * Configuration properties admit comma/space-separated values, but can also be given in occurrences.
+ * Configuration properties accept comma/space-separated values, but can also be given in multiple occurrences.
  * All occurrences of the same property will be merged into a single list.
  * <p>
  * @author Alejandro Revilla

--- a/jpos/src/main/java/org/jpos/transaction/ProtectDebugInfo.java
+++ b/jpos/src/main/java/org/jpos/transaction/ProtectDebugInfo.java
@@ -29,44 +29,44 @@ import org.jpos.util.FSDMsg;
 import org.jpos.util.ProtectedLogListener;
 
 import java.io.Serializable;
-
-/**
- * @author Alejandro Revilla
- * @author David Bergert
- * @author Barspi
- */
+import java.util.Arrays;
 
 /**
  *Sample Usage:
  *<pre>
- *    &lt;participant class="org.jpos.transaction.ProtectDebugInfo" logger="Q2" realm="debug"&gt;
+ *    &lt;participant class="org.jpos.transaction.ProtectDebugInfo"&gt;
  *
  *        &lt;property name="protect-entry" value="REQUEST" /&gt;
  *        &lt;property name="protect-entry" value="RESPONSE" /&gt;
- *        &lt;property name="protect-entry" value="PAN" /&gt;
- *        &lt;property name="protect-entry" value="REQUEST_ICC_DATA" /&gt;
- *
- *        &lt;property name="wipe-entry" value="EXPDATE" /&gt;
+ *        &lt;property name="protect-entry" value="PAN, EXP, REQUEST_ICC_DATA" /&gt;
+ *        &lt;property name="wipe-entry"    value="EXPDATE" /&gt;
  *
  *        &lt;property name="protect-ISOMsg" value="2" /&gt;
- *        &lt;property name="protect-ISOMsg" value="35" /&gt;
- *        &lt;property name="protect-ISOMsg" value="45" /&gt;
- *        &lt;property name="wipe-ISOMsg" value="52" /&gt;
- *        &lt;property name="wipe-ISOMsg" value="55" /&gt;
+ *        &lt;property name="protect-ISOMsg" value="35, 45" /&gt;
+ *        &lt;property name="wipe-ISOMsg"    value="52, 55" /&gt;
  *
  *        &lt;property name="wipe-TLVList" value="0x56" /&gt;
  *        &lt;property name="wipe-TLVList" value="0x57" /&gt;
- *        &lt;property name="wipe-TLVList" value="0x5a" /&gt;
- *        &lt;property name="wipe-TLVList" value="0x5f20" /&gt;
+ *        &lt;property name="wipe-TLVList" value="0x5a, 0x5f20" /&gt;
  *
  *        &lt;property name="protect-FSDMsg" value="account-number" /&gt;
  *        &lt;property name="protect-FSDMsg" value="track2-data" /&gt;
+ *        &lt;property name="wipe-FSDMsg"    value="secret-key" /&gt;
  *
- *        &lt;/participant&gt;
+ *    &lt;/participant&gt;
  *</pre>
+ *
+ * Configuration properties admit comma/space-separated values, but can also be given in occurrences.
+ * All occurrences of the same property will be merged into a single list.
+ * <p>
+ * @author Alejandro Revilla
+ * @author David Bergert
+ * @author Barzilai Spinak
+ * </p>
  **/
 
- public class ProtectDebugInfo implements AbortParticipant, Configurable {
+public class ProtectDebugInfo implements AbortParticipant, Configurable {
+     private static final String COMMA_SPACE_SEPARATOR = "[,\\s]+";
      private String[] protectedEntries;
      private String[] wipedEntries;
      private String[] protectFSD;
@@ -86,14 +86,17 @@ import java.io.Serializable;
      public void abort  (long id, Serializable o) {
          protect ((Context) o);
      }
+
      private void protect (Context ctx) {
          /* wipe by removing entries from the context  */
          for (String s: wipedEntries)
              ctx.remove(s);
+
          /* Protect entry items */
          for (String s: protectedEntries) {
              Object o = ctx.get (s);
-             if (o instanceof ISOMsg){
+
+             if (o instanceof ISOMsg) {
                  ISOMsg m = ctx.get (s);
                  if (m != null) {
                      m = (ISOMsg) m.clone();
@@ -104,6 +107,7 @@ import java.io.Serializable;
                          wipeField(m,p);
                  }
              }
+
              if (o instanceof FSDMsg){
                  FSDMsg m = ctx.get (s);
                  if (m != null) {
@@ -126,16 +130,17 @@ import java.io.Serializable;
              }
          }
      }
+
      private void protectField (ISOMsg m, String f) {
          if (m != null) {
              m.set (f, protect (m.getString (f)));
          }
      }
+
     private void wipeField (ISOMsg m, String f) {
         if (m != null) {
-            Object v = null;
             try {
-                v = m.getValue(f);
+                Object v = m.getValue(f);
                 if (v != null) {
                     if (v instanceof String)
                         m.set(f, ProtectedLogListener.WIPED);
@@ -169,20 +174,30 @@ import java.io.Serializable;
                  m.set (f, ISOUtil.protect (s));
          }
      }
+
      private void wipeField (FSDMsg m, String f) {
          if (m != null && m.get(f) != null) {
              m.set (f, "*");
          }
      }
+
      private String protect (String s) {
          return s != null ? ISOUtil.protect (s) : s;
      }
+
      public void setConfiguration (Configuration cfg) throws ConfigurationException {
-         this.protectedEntries = cfg.getAll("protect-entry");
-         this.wipedEntries = cfg.getAll("wipe-entry");
-         this.protectFSD = cfg.getAll("protect-FSDMsg");
-         this.protectISO = cfg.getAll("protect-ISOMsg");
-         this.wipeISO = cfg.getAll("wipe-ISOMsg");
-         this.wipeTLV = cfg.getAll("wipe-TLVList");
+         this.protectedEntries = getValues(cfg, "protect-entry");
+         this.wipedEntries = getValues(cfg, "wipe-entry");
+         this.protectFSD = getValues(cfg, "protect-FSDMsg");
+         this.protectISO = getValues(cfg, "protect-ISOMsg");
+         this.wipeISO = getValues(cfg, "wipe-ISOMsg");
+         this.wipeTLV = getValues(cfg, "wipe-TLVList");
+     }
+     private String[] getValues (Configuration cfg, String name) {
+         return Arrays.stream(cfg.getAll(name))
+             .flatMap(v -> Arrays.stream(v.split(COMMA_SPACE_SEPARATOR)))
+             .map(String::trim)
+             .filter(v -> !v.isEmpty())
+             .toArray(String[]::new);
      }
 }

--- a/jpos/src/test/java/org/jpos/transaction/ProtectDebugInfoTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/ProtectDebugInfoTest.java
@@ -18,26 +18,29 @@
 
 package org.jpos.transaction;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.jpos.core.ConfigurationException;
 import org.jpos.core.SimpleConfiguration;
+import org.jpos.iso.ISOMsg;
+import org.jpos.iso.ISOUtil;
 import org.jpos.tlv.TLVList;
+import org.jpos.util.ProtectedLogListener;
 import org.junit.jupiter.api.Test;
 
 public final class ProtectDebugInfoTest {
 
     @Test
     void test_wipe_tag() throws ConfigurationException {
-
         TLVList tlv = new TLVList();
         tlv.append(0x54, "AABBCCDDEEFF");
         tlv.append(0x55, "BBDDFFEEDDAA");
+        tlv.append(0x56, "112233445566");
 
         SimpleConfiguration cfg = new SimpleConfiguration();
         cfg.put("protect-entry", "TEST_ENTRY");
-        cfg.put("wipe-TLVList", "0x54");
+        cfg.put("wipe-TLVList", new String[] {  "0x54,  ",
+                                                ",,0x56, " });  // noisy junk separators
 
         ProtectDebugInfo participant = new ProtectDebugInfo();
         participant.setConfiguration(cfg);
@@ -47,8 +50,73 @@ public final class ProtectDebugInfoTest {
 
         participant.commit(0, ctx);
 
-        ctx.dump(System.out, " ");
         assertNotEquals("AABBCCDDEEFF", tlv.getString(0x54));
         assertEquals("BBDDFFEEDDAA", tlv.getString(0x55));
+        assertNotEquals("112233445566", tlv.getString(0x56));
+    }
+
+    @Test
+    void test_protect_and_wipe_iso_fields() throws ConfigurationException {
+        ISOMsg original = new ISOMsg();
+        original.set(2, "4761739001010119");
+        original.set(8, "12345678");
+        original.set(13, "0427");
+        original.set(38, "ABC123");
+        original.set(52, "A1B2C3D4E5F60708");
+        original.set(55, ISOUtil.hex2byte("11223344"));
+        original.set(70, "001");
+
+        SimpleConfiguration cfg = new SimpleConfiguration();
+        cfg.put("protect-entry", "REQUEST");
+        cfg.put("protect-ISOMsg", new String[] { "2,", "8,,  38" });    // noisy junk separators
+        cfg.put("wipe-ISOMsg", "52,   55,,");
+
+        ProtectDebugInfo participant = new ProtectDebugInfo();
+        participant.setConfiguration(cfg);
+
+        Context ctx = new Context();
+        ctx.put("REQUEST", original.clone());
+
+        participant.commit(0, ctx);
+
+        ISOMsg protectedMsg = ctx.get("REQUEST");
+
+        // untouched fields
+        assertEquals(original.getString(13), protectedMsg.getString(13));
+        assertEquals(original.getString(70), protectedMsg.getString(70));
+
+        // protected/wiped fields
+        assertEquals(ISOUtil.protect(original.getString(2)),  protectedMsg.getString(2));
+        assertEquals(ISOUtil.protect(original.getString(8)),  protectedMsg.getString(8));
+        assertEquals(ISOUtil.protect(original.getString(38)), protectedMsg.getString(38));
+        assertEquals(ProtectedLogListener.WIPED, protectedMsg.getString(52));
+        assertArrayEquals(ProtectedLogListener.BINARY_WIPED, (byte[]) protectedMsg.getValue(55));
+    }
+
+    @Test
+    void test_protect_and_wipe_entries() throws ConfigurationException {
+        SimpleConfiguration cfg = new SimpleConfiguration();
+        cfg.put("protect-entry", new String[] { "PAN,   TRACK2", "EXPDATE,,," });
+        cfg.put("wipe-entry", "SECRET,  , TEMP");
+
+        ProtectDebugInfo participant = new ProtectDebugInfo();
+        participant.setConfiguration(cfg);
+
+        Context ctx = new Context();
+        ctx.put("PAN", "4761739001010119");
+        ctx.put("TRACK2", "4761739001010119=29041010000012345678");
+        ctx.put("EXPDATE", "2904");
+        ctx.put("SECRET", "very-secret");
+        ctx.put("TEMP", "remove-me");
+        ctx.put("SAFE", "untouched");
+
+        participant.commit(0, ctx);
+
+        assertEquals(ISOUtil.protect("4761739001010119"), ctx.get("PAN"));
+        assertEquals(ISOUtil.protect("4761739001010119=29041010000012345678"), ctx.get("TRACK2"));
+        assertEquals(ISOUtil.protect("2904"), ctx.get("EXPDATE"));
+        assertFalse(ctx.hasKey("SECRET"));
+        assertFalse(ctx.hasKey("TEMP"));
+        assertEquals("untouched", ctx.get("SAFE"));
     }
 }


### PR DESCRIPTION
The original `ProtectDebugInfo` can be configured with **individual, repeatable properties** for all the elements we want to protect or wipe (context entries, iso fields, etc.) as shown in the javadoc.

This is nice but a bit verbose, and in particular does not allow to easily use build-time replacement configs, or run-time configurations (such as given in a jPOS env variable).

This PR adds the possibility for a protect/wipe property to also accept a comma/space-separated list of values.
This does not replace the current multi-property configuration but it's **in addition to**.
So backwards compatibility is maintained while allowing for other options.

For example, we can say:
```xml
<property name="protect-entry" value="RESPONSE" />
<property name="protect-entry" value="PAN, EXP, REQUEST_ICC_DATA" />
```

And both sets would be merged into one, giving the equivalent of having configured every `protect-entry` separately  (the classic way), or all in one line such as
```xml
<property name="protect-entry" value="RESPONSE, PAN, EXP, REQUEST_ICC_DATA" />
```
or we could have defined a set of fields to protect in a **single jPOS environment attribute** and then say

```xml
<property name="protect-ISOMsg" value="${protect.isofields}" />
```

The test cases in `ProtectDebugInfoTest` have also been expanded to consider these cases.