### PR TITLE
Add verified license text API

### DIFF
--- a/jpos/src/main/java/org/jpos/util/PGPHelper.java
+++ b/jpos/src/main/java/org/jpos/util/PGPHelper.java
@@ -111,6 +111,26 @@ public class PGPHelper {
         return verify;
     }
 
+    private static String readClearText(InputStream in) throws IOException {
+        boolean newl = false;
+        int ch;
+        ArmoredInputStream ain = new ArmoredInputStream(in, true);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        while ((ch = ain.read()) >= 0 && ain.isClearText()) {
+            if (newl) {
+                out.write((byte) '\n');
+                newl = false;
+            }
+            if (ch == '\n') {
+                newl = true;
+                continue;
+            }
+            out.write((byte) ch);
+        }
+        return out.toString(StandardCharsets.UTF_8.name());
+    }
+
     private static PGPPublicKey readPublicKey(InputStream in, String id)
             throws IOException, PGPException
     {
@@ -163,11 +183,20 @@ public class PGPHelper {
     }
 
     public static int checkLicense() {
+        try (InputStream in = getLicenseeStream()){
+            return checkLicense(in);
+        } catch (Exception ignored) {
+            // NOPMD: signature isn't good
+        }
+        return 0x90000;
+    }
+
+    private static int checkLicense(InputStream in) {
         int rc = 0x90000;
         boolean newl = false;
         int ch;
 
-        try (InputStream in = getLicenseeStream()){
+        try {
             InputStream ks = Q2.class.getClassLoader().getResourceAsStream(PUBRING);
             PGPPublicKey pk = readPublicKey(ks, SIGNER);
             ArmoredInputStream ain = new ArmoredInputStream(in, true);
@@ -242,6 +271,40 @@ public class PGPHelper {
             // NOPMD: signature isn't good
         }
         return rc;
+    }
+
+    /**
+     * Returns the verified clear-text license payload.
+     * <p>
+     * The returned value is the text covered by the clear-text PGP signature, not
+     * the armored license block. If the bundled or configured license cannot be
+     * signature-verified, or if {@link #checkLicense()} reports an unacceptable
+     * status, this method returns {@code null}.
+     * <p>
+     * Status bit {@code 0x10000} (license not bound to this system hash, used by
+     * the Community Edition license) is considered acceptable. Critical status
+     * bits {@code 0xE0000} are not.
+     *
+     * @return verified clear-text license payload, or {@code null}
+     * @throws IOException if the license stream cannot be read
+     */
+    public static String getVerifiedLicenseText() throws IOException {
+        byte[] license;
+        try (InputStream is = getLicenseeStream()) {
+            if (is == null)
+                return null;
+            license = is.readAllBytes();
+        }
+        try (InputStream ks = Q2.class.getClassLoader().getResourceAsStream(PUBRING)) {
+            PGPPublicKey pk = readPublicKey(ks, SIGNER);
+            if (!verifySignature(new ByteArrayInputStream(license), pk))
+                return null;
+        } catch (PGPException | RuntimeException e) {
+            return null;
+        }
+        if ((checkLicense(new ByteArrayInputStream(license)) & 0xE0000) != 0)
+            return null;
+        return readClearText(new ByteArrayInputStream(license));
     }
 
     static InputStream getLicenseeStream() throws FileNotFoundException {

--- a/jpos/src/test/java/org/jpos/util/PGPHelperTest.java
+++ b/jpos/src/test/java/org/jpos/util/PGPHelperTest.java
@@ -21,10 +21,48 @@ package org.jpos.util;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PGPHelperTest {
+    @Test
+    public void testGetVerifiedLicenseText() throws Exception {
+        String licenseText = PGPHelper.getVerifiedLicenseText();
+
+        assertNotNull(licenseText);
+        assertTrue(licenseText.contains("jPOS Community Edition"));
+        assertFalse(licenseText.contains("BEGIN PGP SIGNATURE"));
+    }
+
+    @Test
+    public void testGetVerifiedLicenseTextRejectsTamperedLicense() throws Exception {
+        String previousLicensee = System.getProperty("LICENSEE");
+        Path license = Path.of("src/main/resources/LICENSEE.asc");
+        Path tamperedLicense = Files.createTempFile("licensee", ".asc");
+        Files.writeString(
+          tamperedLicense,
+          Files.readString(license, StandardCharsets.UTF_8).replace("jPOS Community Edition", "jPOS Tampered Edition"),
+          StandardCharsets.UTF_8
+        );
+
+        try {
+            System.setProperty("LICENSEE", tamperedLicense.toString());
+            assertNull(PGPHelper.getVerifiedLicenseText());
+        } finally {
+            if (previousLicensee != null)
+                System.setProperty("LICENSEE", previousLicensee);
+            else
+                System.clearProperty("LICENSEE");
+            Files.deleteIfExists(tamperedLicense);
+        }
+    }
+
     @Test
     public void testEncryptDecrypt() throws Exception {
         String s = "The quick brown fox jumps over the lazy dog 0123456789";


### PR DESCRIPTION
Adds `PGPHelper.getVerifiedLicenseText()` to return only the clear-text license payload after validating the clear-text PGP signature and checking for acceptable license status.

The API returns `null` when the license cannot be verified or has critical license status bits set. The Community Edition `0x10000` status remains acceptable.

Tests added:
- bundled CE license returns clear text and excludes PGP armor
- tampered license text is rejected

Validation:
- `./gradlew :jpos:test --tests org.jpos.util.PGPHelperTest`
- `./gradlew :jpos:check`