### PR TITLE
Add Track1 IC card service code indicators

### DIFF
--- a/jpos/src/main/java/org/jpos/core/Track1.java
+++ b/jpos/src/main/java/org/jpos/core/Track1.java
@@ -83,6 +83,28 @@ public class Track1 {
         return track;
     }
 
+    /**
+     * @return true if the Track 1 service code indicates an IC card.
+     */
+    public boolean isEMV() {
+        return isICCard();
+    }
+
+    /**
+     * @return true if the Track 1 service code indicates an IC card.
+     */
+    public boolean isICCard() {
+        return serviceCode != null && serviceCode.length() == 3 &&
+          (serviceCode.charAt(0) == '2' || serviceCode.charAt(0) == '6');
+    }
+
+    /**
+     * @return true if the Track 1 service code indicates an international IC card.
+     */
+    public boolean isInternationalICCard() {
+        return serviceCode != null && serviceCode.length() == 3 && serviceCode.charAt(0) == '2';
+    }
+
     @Override
     public String toString() {
         return pan != null ? ISOUtil.protect(pan) : "nil";

--- a/jpos/src/test/java/org/jpos/core/CardTest.java
+++ b/jpos/src/test/java/org/jpos/core/CardTest.java
@@ -25,6 +25,8 @@ import java.util.Date;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class CardTest  {
@@ -59,6 +61,52 @@ public class CardTest  {
         assertEquals("123", t1.getServiceCode(), "serviceCode");
         assertEquals("4567", t1.getCvv(), "cvv");
         assertEquals("1234567890", t1.getDiscretionaryData(), "discretionaryData");
+    }
+
+    @Test
+    public void testTrack1InternationalICCard() throws Throwable {
+        Track1 t1 = Track1.builder()
+          .track("%B4111111111111111^FAT ALBERT                ^401122645671234567890?").build();
+
+        assertEquals("226", t1.getServiceCode(), "serviceCode");
+        assertTrue(t1.isEMV(), "emv");
+        assertTrue(t1.isICCard(), "icCard");
+        assertTrue(t1.isInternationalICCard(), "internationalICCard");
+    }
+
+    @Test
+    public void testTrack1NationalICCard() throws Throwable {
+        Track1 t1 = Track1.builder()
+          .track("%B4111111111111111^FAT ALBERT                ^401162645671234567890?").build();
+
+        assertEquals("626", t1.getServiceCode(), "serviceCode");
+        assertTrue(t1.isEMV(), "emv");
+        assertTrue(t1.isICCard(), "icCard");
+        assertFalse(t1.isInternationalICCard(), "internationalICCard");
+    }
+
+    @Test
+    public void testTrack1NonICCard() throws Throwable {
+        Track1 t1 = Track1.builder()
+          .track("%B4111111111111111^FAT ALBERT                ^401110145671234567890?").build();
+
+        assertEquals("101", t1.getServiceCode(), "serviceCode");
+        assertFalse(t1.isEMV(), "emv");
+        assertFalse(t1.isICCard(), "icCard");
+        assertFalse(t1.isInternationalICCard(), "internationalICCard");
+    }
+
+    @Test
+    public void testTrack1WithoutServiceCode() throws Throwable {
+        Track1 t1 = Track1.builder()
+          .pan("4111111111111111")
+          .nameOnCard("FAT ALBERT")
+          .exp("4011")
+          .build();
+
+        assertFalse(t1.isEMV(), "emv");
+        assertFalse(t1.isICCard(), "icCard");
+        assertFalse(t1.isInternationalICCard(), "internationalICCard");
     }
 
     @Test


### PR DESCRIPTION
This adds convenience methods to `Track1` for identifying IC-card service codes parsed from Track 1 data:

- `isEMV()`
- `isICCard()`
- `isInternationalICCard()`

The existing Track 1 parser and regexp are unchanged. The new methods interpret the already-parsed service code, keeping EMV/IC-card detection as a semantic check rather than a separate Track 1 grammar.

Tests cover:

- international IC-card service code (`2xx`)
- national IC-card service code (`6xx`)
- non-IC service code
- missing service code

Tested with:

```sh
./gradlew --no-daemon :jpos:test --tests org.jpos.core.CardTest
```
