### PR TITLE
Update dependency versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ jdom = "2.0.6.1"
 sleepycatje = "18.3.12"
 commonscli = "1.11.0"
 commonslang3 = "3.20.0"
-jline = "4.0.12"
+jline = "4.0.14"
 jna = '5.18.1'
 jansi = '2.4.3'
 beanshell = "2.0b6"
@@ -19,7 +19,7 @@ hdrhistogram = "2.2.2"
 yaml = "2.6"
 micrometercore = "1.16.5"
 micrometerprometheus = "1.16.5"
-jackson = '2.21.2'
+jackson = '2.21.3'
 jdbm = '1.0'
 
 [libraries]

--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-   id "org.gradlex.extra-java-module-info" version "1.13.1"
-   id "org.owasp.dependencycheck" version "12.1.9"
-   id 'org.cyclonedx.bom' version '3.1.0'
+   id "org.gradlex.extra-java-module-info" version "1.14"
+   id "org.owasp.dependencycheck" version "12.2.2"
+   id 'org.cyclonedx.bom' version '3.2.4'
    // id 'checkstyle'
 }
 


### PR DESCRIPTION
## Summary
- update JLine to 4.0.14
- update Jackson modules to 2.21.3
- update Gradle plugins:
  - org.gradlex.extra-java-module-info to 1.14
  - org.owasp.dependencycheck to 12.2.2
  - org.cyclonedx.bom to 3.2.4

## Validation
- `source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk env && ./gradlew clean check`
- `source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk env >/dev/null && ./gradlew build`

Both builds completed successfully using the repository `.sdkmanrc` toolchain (`java=26-amzn`, `gradle=9.5.0`).