### PR TITLE
Feature/emv sm adapter

### DIFF
--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1157,6 +1157,29 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public EMVDerivedKey<T> deriveEMVSessionKey(SKDMethod skdm, T iccMk,
+            byte[] atc, byte[] upn) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "skd method", skdm));
+        cmdParameters.add(new SimpleMsg("parameter", "icc-mk", iccMk));
+        cmdParameters.add(new SimpleMsg("parameter", "atc", atc == null ? "" : ISOUtil.hexString(atc)));
+        cmdParameters.add(new SimpleMsg("parameter", "upn", upn == null ? "" : ISOUtil.hexString(upn)));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Derive EMV Session Key", cmdParameters));
+        try {
+            EMVDerivedKey<T> result = deriveEMVSessionKeyImpl(skdm, iccMk, atc, upn);
+            evt.addMessage(new SimpleMsg("result", "Session Key", result == null ? "" : result.toString()));
+            return result;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public byte[] generateARPC(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
@@ -2234,6 +2257,20 @@ public class BaseSMAdapter<T>
      */
     protected EMVDerivedKey<T> deriveICCMasterKeyImpl(MKDMethod mkdm, T imk,
             String pan, String psn) throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality
+     * @param skdm session-key derivation method
+     * @param iccMk ICC Master Key
+     * @param atc application transaction counter
+     * @param upn unpredictable number; may be {@code null} when unused
+     * @return derived session key paired with its KCV
+     * @throws SMException on security module error
+     */
+    protected EMVDerivedKey<T> deriveEMVSessionKeyImpl(SKDMethod skdm, T iccMk,
+            byte[] atc, byte[] upn) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1415,6 +1415,31 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public byte[] verifySDA(EMVIssuerPublicKey issuerPublicKey,
+            byte[] signedStaticApplicationData,
+            byte[] staticApplicationData) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "issuer public key", issuerPublicKey));
+        cmdParameters.add(new SimpleMsg("parameter", "ssad",
+                signedStaticApplicationData == null ? "" : ISOUtil.hexString(signedStaticApplicationData)));
+        cmdParameters.add(new SimpleMsg("parameter", "static app data length",
+                staticApplicationData == null ? "0" : Integer.toString(staticApplicationData.length)));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Verify SDA", cmdParameters));
+        try {
+            byte[] dac = verifySDAImpl(issuerPublicKey, signedStaticApplicationData, staticApplicationData);
+            evt.addMessage(new SimpleMsg("result", "DAC", dac == null ? "" : ISOUtil.hexString(dac)));
+            return dac;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public EMVICCPublicKey recoverICCPublicKey(EMVIssuerPublicKey issuerPublicKey,
             byte[] iccPublicKeyCertificate, byte[] iccPublicKeyRemainder,
             byte[] iccPublicKeyExponent, byte[] staticApplicationData,
@@ -2645,6 +2670,21 @@ public class BaseSMAdapter<T>
             byte[] iccPublicKeyExponent,
             byte[] staticApplicationData,
             String pan) throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality.
+     * Verify Signed Static Application Data (SSAD, EMV tag 0x93).
+     * @param issuerPublicKey the recovered issuer public key
+     * @param signedStaticApplicationData EMV tag 0x93 contents
+     * @param staticApplicationData SAD bytes assembled per EMV §10.3
+     * @return the 2-byte Data Authentication Code (DAC)
+     * @throws SMException on RSA recovery or EMV validation failure
+     */
+    protected byte[] verifySDAImpl(EMVIssuerPublicKey issuerPublicKey,
+            byte[] signedStaticApplicationData,
+            byte[] staticApplicationData) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1385,6 +1385,36 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public EMVIssuerPublicKey recoverIssuerPublicKey(EMVCAPublicKey caPublicKey,
+            byte[] issuerPublicKeyCertificate, byte[] issuerPublicKeyRemainder,
+            byte[] issuerPublicKeyExponent, String pan) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "ca public key", caPublicKey));
+        cmdParameters.add(new SimpleMsg("parameter", "issuer pk cert",
+                issuerPublicKeyCertificate == null ? "" : ISOUtil.hexString(issuerPublicKeyCertificate)));
+        cmdParameters.add(new SimpleMsg("parameter", "issuer pk remainder",
+                issuerPublicKeyRemainder == null ? "" : ISOUtil.hexString(issuerPublicKeyRemainder)));
+        cmdParameters.add(new SimpleMsg("parameter", "issuer pk exponent",
+                issuerPublicKeyExponent == null ? "" : ISOUtil.hexString(issuerPublicKeyExponent)));
+        cmdParameters.add(new SimpleMsg("parameter", "pan", pan));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Recover Issuer Public Key", cmdParameters));
+        try {
+            EMVIssuerPublicKey result = recoverIssuerPublicKeyImpl(
+                    caPublicKey, issuerPublicKeyCertificate,
+                    issuerPublicKeyRemainder, issuerPublicKeyExponent, pan);
+            evt.addMessage(new SimpleMsg("result", "Issuer Public Key", result == null ? "" : result.toString()));
+            return result;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MAC(MKDMethod mkdm
            ,SKDMethod skdm, PaddingMethod padm, T imksmi
            ,String accountNo, String acctSeqNo, byte[] atc, byte[] arqc
@@ -2538,6 +2568,26 @@ public class BaseSMAdapter<T>
             EncryptedPIN newPIN, T kd1, byte destinationPINBlockFormat,
             PaddingMethod paddingMethod, EncryptedPIN currentPIN, T udkAc)
             throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality.
+     * Recover an Issuer Public Key from a CA-signed Issuer Public Key Certificate.
+     * @param caPublicKey the CA public key
+     * @param issuerPublicKeyCertificate EMV tag 0x90 contents
+     * @param issuerPublicKeyRemainder EMV tag 0x92 contents (may be {@code null})
+     * @param issuerPublicKeyExponent EMV tag 0x9F32 contents
+     * @param pan cardholder PAN; {@code null} skips the issuer-identifier check
+     * @return the recovered Issuer Public Key
+     * @throws SMException on RSA recovery or EMV validation failure
+     */
+    protected EMVIssuerPublicKey recoverIssuerPublicKeyImpl(
+            EMVCAPublicKey caPublicKey,
+            byte[] issuerPublicKeyCertificate,
+            byte[] issuerPublicKeyRemainder,
+            byte[] issuerPublicKeyExponent,
+            String pan) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1106,6 +1106,34 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public byte[] generateApplicationCryptogram(MKDMethod mkdm, SKDMethod skdm, T imkac
+            ,String accountNo, String acctSeqNo, byte[] atc, byte[] upn, byte[] txnData)
+            throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "mkd method", mkdm));
+        cmdParameters.add(new SimpleMsg("parameter", "skd method", skdm));
+        cmdParameters.add(new SimpleMsg("parameter", "imk-ac", imkac));
+        cmdParameters.add(new SimpleMsg("parameter", "account number", accountNo));
+        cmdParameters.add(new SimpleMsg("parameter", "accnt seq no", acctSeqNo));
+        cmdParameters.add(new SimpleMsg("parameter", "atc", atc == null ? "" : ISOUtil.hexString(atc)));
+        cmdParameters.add(new SimpleMsg("parameter", "upn", upn == null ? "" : ISOUtil.hexString(upn)));
+        cmdParameters.add(new SimpleMsg("parameter", "txn data", txnData == null ? "" : ISOUtil.hexString(txnData)));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Generate Application Cryptogram", cmdParameters));
+        try {
+            byte[] result = generateApplicationCryptogramImpl(mkdm, skdm, imkac, accountNo, acctSeqNo, atc, upn, txnData);
+            evt.addMessage(new SimpleMsg("result", "Application Cryptogram", result == null ? "" : ISOUtil.hexString(result)));
+            return result;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public byte[] generateARPC(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
@@ -2150,6 +2178,25 @@ public class BaseSMAdapter<T>
     protected boolean verifyARQCImpl(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accountNo, String acctSeqNo, byte[] arqc, byte[] atc
             ,byte[] upn, byte[] txnData) throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality
+     * @param mkdm master-key derivation method
+     * @param skdm session-key derivation method
+     * @param imkac issuer master key for application cryptograms
+     * @param accountNo card account number
+     * @param acctSeqNo PAN sequence number
+     * @param atc application transaction counter
+     * @param upn unpredictable number
+     * @param txnData transaction data
+     * @return calculated 8-byte Application Cryptogram (ARQC/TC/AAC)
+     * @throws SMException on security module error
+     */
+    protected byte[] generateApplicationCryptogramImpl(MKDMethod mkdm, SKDMethod skdm, T imkac
+            ,String accountNo, String acctSeqNo, byte[] atc, byte[] upn, byte[] txnData)
+            throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1415,6 +1415,33 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public byte[] verifyDDA(EMVICCPublicKey iccPublicKey,
+            byte[] signedDynamicApplicationData,
+            byte[] ddolData) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "icc public key", iccPublicKey));
+        cmdParameters.add(new SimpleMsg("parameter", "sdad",
+                signedDynamicApplicationData == null ? "" : ISOUtil.hexString(signedDynamicApplicationData)));
+        cmdParameters.add(new SimpleMsg("parameter", "ddol data",
+                ddolData == null ? "" : ISOUtil.hexString(ddolData)));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Verify DDA", cmdParameters));
+        try {
+            byte[] iccDynamicNumber = verifyDDAImpl(iccPublicKey,
+                    signedDynamicApplicationData, ddolData);
+            evt.addMessage(new SimpleMsg("result", "ICC Dynamic Number",
+                    iccDynamicNumber == null ? "" : ISOUtil.hexString(iccDynamicNumber)));
+            return iccDynamicNumber;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public byte[] verifySDA(EMVIssuerPublicKey issuerPublicKey,
             byte[] signedStaticApplicationData,
             byte[] staticApplicationData) throws SMException {
@@ -2685,6 +2712,21 @@ public class BaseSMAdapter<T>
     protected byte[] verifySDAImpl(EMVIssuerPublicKey issuerPublicKey,
             byte[] signedStaticApplicationData,
             byte[] staticApplicationData) throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality.
+     * Verify Signed Dynamic Application Data (SDAD, EMV tag 0x9F4B).
+     * @param iccPublicKey the recovered ICC public key
+     * @param signedDynamicApplicationData EMV tag 0x9F4B contents
+     * @param ddolData the DDOL bytes the terminal sent to INTERNAL AUTHENTICATE
+     * @return the ICC Dynamic Number
+     * @throws SMException on RSA recovery or EMV validation failure
+     */
+    protected byte[] verifyDDAImpl(EMVICCPublicKey iccPublicKey,
+            byte[] signedDynamicApplicationData,
+            byte[] ddolData) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1415,6 +1415,40 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public EMVICCPublicKey recoverICCPublicKey(EMVIssuerPublicKey issuerPublicKey,
+            byte[] iccPublicKeyCertificate, byte[] iccPublicKeyRemainder,
+            byte[] iccPublicKeyExponent, byte[] staticApplicationData,
+            String pan) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "issuer public key", issuerPublicKey));
+        cmdParameters.add(new SimpleMsg("parameter", "icc pk cert",
+                iccPublicKeyCertificate == null ? "" : ISOUtil.hexString(iccPublicKeyCertificate)));
+        cmdParameters.add(new SimpleMsg("parameter", "icc pk remainder",
+                iccPublicKeyRemainder == null ? "" : ISOUtil.hexString(iccPublicKeyRemainder)));
+        cmdParameters.add(new SimpleMsg("parameter", "icc pk exponent",
+                iccPublicKeyExponent == null ? "" : ISOUtil.hexString(iccPublicKeyExponent)));
+        cmdParameters.add(new SimpleMsg("parameter", "static app data length",
+                staticApplicationData == null ? "0" : Integer.toString(staticApplicationData.length)));
+        cmdParameters.add(new SimpleMsg("parameter", "pan", pan));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Recover ICC Public Key", cmdParameters));
+        try {
+            EMVICCPublicKey result = recoverICCPublicKeyImpl(
+                    issuerPublicKey, iccPublicKeyCertificate,
+                    iccPublicKeyRemainder, iccPublicKeyExponent,
+                    staticApplicationData, pan);
+            evt.addMessage(new SimpleMsg("result", "ICC Public Key", result == null ? "" : result.toString()));
+            return result;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MAC(MKDMethod mkdm
            ,SKDMethod skdm, PaddingMethod padm, T imksmi
            ,String accountNo, String acctSeqNo, byte[] atc, byte[] arqc
@@ -2587,6 +2621,29 @@ public class BaseSMAdapter<T>
             byte[] issuerPublicKeyCertificate,
             byte[] issuerPublicKeyRemainder,
             byte[] issuerPublicKeyExponent,
+            String pan) throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality.
+     * Recover an ICC Public Key from an issuer-signed ICC Public Key Certificate.
+     * @param issuerPublicKey the recovered issuer public key
+     * @param iccPublicKeyCertificate EMV tag 0x9F46 contents
+     * @param iccPublicKeyRemainder EMV tag 0x9F48 contents (may be {@code null})
+     * @param iccPublicKeyExponent EMV tag 0x9F47 contents
+     * @param staticApplicationData data assembled from the AFL, included in
+     *        the SHA-1 hash validation
+     * @param pan cardholder PAN; {@code null} skips the PAN check
+     * @return the recovered ICC Public Key
+     * @throws SMException on RSA recovery or EMV validation failure
+     */
+    protected EMVICCPublicKey recoverICCPublicKeyImpl(
+            EMVIssuerPublicKey issuerPublicKey,
+            byte[] iccPublicKeyCertificate,
+            byte[] iccPublicKeyRemainder,
+            byte[] iccPublicKeyExponent,
+            byte[] staticApplicationData,
             String pan) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -52,7 +52,7 @@ import java.util.Map;
  * @param <T> the SecureKey implementation type
  */
 public class BaseSMAdapter<T>
-        implements SMAdapter<T>, Configurable, LogSource {
+        implements EMVSMAdapter<T>, Configurable, LogSource {
     /** Logger for this security module adapter. */
     protected Logger logger = null;
     /** Log realm for this security module adapter. */
@@ -1018,6 +1018,62 @@ public class BaseSMAdapter<T>
       } finally {
         logEvent(evt);
       }
+    }
+
+    @Override
+    public String generateCVC3(T imkcvc3, String accountNo, String acctSeqNo,
+                     byte[] atc, byte[] upn, byte[] data, MKDMethod mkdm)
+                     throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "imk-cvc3", imkcvc3 == null ? "" : imkcvc3));
+        cmdParameters.add(new SimpleMsg("parameter", "account number", accountNo));
+        cmdParameters.add(new SimpleMsg("parameter", "accnt seq no", acctSeqNo));
+        cmdParameters.add(new SimpleMsg("parameter", "atc", atc == null ? "" : ISOUtil.hexString(atc)));
+        cmdParameters.add(new SimpleMsg("parameter", "upn", upn == null ? "" : ISOUtil.hexString(upn)));
+        cmdParameters.add(new SimpleMsg("parameter", "data", data == null ? "" : ISOUtil.hexString(data)));
+        cmdParameters.add(new SimpleMsg("parameter", "mkd method", mkdm));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Generate CVC3", cmdParameters));
+        try {
+            String r = generateCVC3Impl(imkcvc3, accountNo, acctSeqNo, atc, upn, data, mkdm);
+            evt.addMessage(new SimpleMsg("result", "cvc3", r));
+            return r;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
+    public String generatedCVV(String accountNo, T imkac, String expDate,
+                     String serviceCode, byte[] atc, MKDMethod mkdm)
+                     throws SMException {
+
+        if (accountNo == null || accountNo.trim().length() == 0)
+            throw new IllegalArgumentException("Account number not set.");
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "account number", accountNo));
+        cmdParameters.add(new SimpleMsg("parameter", "imk-ac", imkac == null ? "" : imkac));
+        cmdParameters.add(new SimpleMsg("parameter", "Exp date", expDate));
+        cmdParameters.add(new SimpleMsg("parameter", "Service code", serviceCode));
+        cmdParameters.add(new SimpleMsg("parameter", "atc", atc == null ? "" : ISOUtil.hexString(atc)));
+        cmdParameters.add(new SimpleMsg("parameter", "mkd method", mkdm));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Generate dCVV", cmdParameters));
+        try {
+            String r = generatedCVVImpl(accountNo, imkac, expDate, serviceCode, atc, mkdm);
+            evt.addMessage(new SimpleMsg("result", "dCVV", r));
+            return r;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
     }
 
     @Override
@@ -2038,6 +2094,41 @@ public class BaseSMAdapter<T>
      */
     protected boolean verifyCVC3Impl(T imkcvc3, String accountNo, String acctSeqNo,
                      byte[] atc, byte[] upn, byte[] data, MKDMethod mkdm, String cvc3)
+                     throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality
+     * @param imkcvc3 issuer master key for CVC3
+     * @param accountNo card account number
+     * @param acctSeqNo PAN sequence number
+     * @param atc application transaction counter
+     * @param upn unpredictable number
+     * @param data input data
+     * @param mkdm master-key derivation method
+     * @return the 5-digit CVC3
+     * @throws SMException on security module error
+     */
+    protected String generateCVC3Impl(T imkcvc3, String accountNo, String acctSeqNo,
+                     byte[] atc, byte[] upn, byte[] data, MKDMethod mkdm)
+                     throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality
+     * @param accountNo card account number
+     * @param imkac issuer master key for application cryptograms
+     * @param expDate card expiration date as {@code yyMM}
+     * @param serviceCode card service code
+     * @param atc application transaction counter
+     * @param mkdm master-key derivation method
+     * @return the dCVV
+     * @throws SMException on security module error
+     */
+    protected String generatedCVVImpl(String accountNo, T imkac, String expDate,
+                     String serviceCode, byte[] atc, MKDMethod mkdm)
                      throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1180,6 +1180,33 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public EMVDerivedKey<T> deriveSecureMessagingSessionKey(MKDMethod mkdm, SKDMethod skdm,
+            T imk, String pan, String psn, byte[] atc, byte[] arqc) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "mkd method", mkdm));
+        cmdParameters.add(new SimpleMsg("parameter", "skd method", skdm));
+        cmdParameters.add(new SimpleMsg("parameter", "imk", imk));
+        cmdParameters.add(new SimpleMsg("parameter", "pan", pan));
+        cmdParameters.add(new SimpleMsg("parameter", "psn", psn));
+        cmdParameters.add(new SimpleMsg("parameter", "atc", atc == null ? "" : ISOUtil.hexString(atc)));
+        cmdParameters.add(new SimpleMsg("parameter", "arqc", arqc == null ? "" : ISOUtil.hexString(arqc)));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Derive Secure Messaging Session Key", cmdParameters));
+        try {
+            EMVDerivedKey<T> result = deriveSecureMessagingSessionKeyImpl(
+                    mkdm, skdm, imk, pan, psn, atc, arqc);
+            evt.addMessage(new SimpleMsg("result", "SM Session Key", result == null ? "" : result.toString()));
+            return result;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public byte[] generateARPC(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
@@ -2297,6 +2324,23 @@ public class BaseSMAdapter<T>
      */
     protected EMVDerivedKey<T> deriveEMVSessionKeyImpl(SKDMethod skdm, T iccMk,
             byte[] atc, byte[] upn) throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality
+     * @param mkdm master-key derivation method
+     * @param skdm session-key derivation method
+     * @param imk Secure Messaging Issuer Master Key (IMK-SMI or IMK-SMC)
+     * @param pan account number
+     * @param psn PAN sequence number
+     * @param atc application transaction counter (VSDC diversifier)
+     * @param arqc the per-session diversifier (MCHIP / EMV_CSKD)
+     * @return derived SM session key paired with its KCV
+     * @throws SMException on security module error
+     */
+    protected EMVDerivedKey<T> deriveSecureMessagingSessionKeyImpl(MKDMethod mkdm, SKDMethod skdm,
+            T imk, String pan, String psn, byte[] atc, byte[] arqc) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1354,6 +1354,37 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public EncryptedPIN encryptSecureMessagingPIN(T sessionKey, EncryptedPIN newPIN,
+            T kd1, byte destinationPINBlockFormat, PaddingMethod paddingMethod,
+            EncryptedPIN currentPIN, T udkAc) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "session key", sessionKey));
+        cmdParameters.add(new SimpleMsg("parameter", "new pin", newPIN));
+        cmdParameters.add(new SimpleMsg("parameter", "kd1", kd1));
+        cmdParameters.add(new SimpleMsg("parameter", "dest pin block format",
+                String.format("%02X", destinationPINBlockFormat & 0xff)));
+        cmdParameters.add(new SimpleMsg("parameter", "padding method", paddingMethod));
+        cmdParameters.add(new SimpleMsg("parameter", "current pin",
+                currentPIN == null ? "" : currentPIN));
+        cmdParameters.add(new SimpleMsg("parameter", "udk-ac", udkAc == null ? "" : udkAc));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Encrypt Secure Messaging PIN", cmdParameters));
+        try {
+            EncryptedPIN result = encryptSecureMessagingPINImpl(
+                    sessionKey, newPIN, kd1, destinationPINBlockFormat,
+                    paddingMethod, currentPIN, udkAc);
+            evt.addMessage(new SimpleMsg("result", "Encrypted PIN", result == null ? "" : result));
+            return result;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MAC(MKDMethod mkdm
            ,SKDMethod skdm, PaddingMethod padm, T imksmi
            ,String accountNo, String acctSeqNo, byte[] atc, byte[] arqc
@@ -2487,6 +2518,26 @@ public class BaseSMAdapter<T>
            ,byte[] data, EncryptedPIN currentPIN, EncryptedPIN newPIN
            ,T kd1, T imksmc, T imkac
            ,byte destinationPINBlockFormat) throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality.
+     * Direct SM PIN encryption from a supplied SM session encryption key.
+     * @param sessionKey the SM session encryption key (SK-SMC)
+     * @param newPIN the PIN currently wrapped under kd1
+     * @param kd1 the key currently wrapping newPIN
+     * @param destinationPINBlockFormat the target PIN block format
+     * @param paddingMethod SM padding method; {@code null} defaults to MCHIP
+     * @param currentPIN current PIN (required for FORMAT42); may be {@code null}
+     * @param udkAc ICC AC Master Key (required for FORMAT41/42); may be {@code null}
+     * @return the PIN re-encrypted under sessionKey in destinationPINBlockFormat
+     * @throws SMException on security module error
+     */
+    protected EncryptedPIN encryptSecureMessagingPINImpl(T sessionKey,
+            EncryptedPIN newPIN, T kd1, byte destinationPINBlockFormat,
+            PaddingMethod paddingMethod, EncryptedPIN currentPIN, T udkAc)
+            throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1134,6 +1134,29 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public EMVDerivedKey<T> deriveICCMasterKey(MKDMethod mkdm, T imk,
+            String pan, String psn) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "mkd method", mkdm));
+        cmdParameters.add(new SimpleMsg("parameter", "imk", imk));
+        cmdParameters.add(new SimpleMsg("parameter", "pan", pan));
+        cmdParameters.add(new SimpleMsg("parameter", "psn", psn));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Derive ICC Master Key", cmdParameters));
+        try {
+            EMVDerivedKey<T> result = deriveICCMasterKeyImpl(mkdm, imk, pan, psn);
+            evt.addMessage(new SimpleMsg("result", "ICC Master Key", result == null ? "" : result.toString()));
+            return result;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public byte[] generateARPC(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
@@ -2197,6 +2220,20 @@ public class BaseSMAdapter<T>
     protected byte[] generateApplicationCryptogramImpl(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accountNo, String acctSeqNo, byte[] atc, byte[] upn, byte[] txnData)
             throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality
+     * @param mkdm master-key derivation method
+     * @param imk issuer master key
+     * @param pan account number
+     * @param psn PAN sequence number
+     * @return derived ICC master key paired with its KCV
+     * @throws SMException on security module error
+     */
+    protected EMVDerivedKey<T> deriveICCMasterKeyImpl(MKDMethod mkdm, T imk,
+            String pan, String psn) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1415,6 +1415,39 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public EMVCDAResult verifyCDA(EMVICCPublicKey iccPublicKey,
+            byte[] signedDynamicApplicationData,
+            byte[] unpredictableNumber,
+            byte[] applicationCryptogram,
+            byte[] transactionData) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "icc public key", iccPublicKey));
+        cmdParameters.add(new SimpleMsg("parameter", "sdad",
+                signedDynamicApplicationData == null ? "" : ISOUtil.hexString(signedDynamicApplicationData)));
+        cmdParameters.add(new SimpleMsg("parameter", "unpredictable number",
+                unpredictableNumber == null ? "" : ISOUtil.hexString(unpredictableNumber)));
+        cmdParameters.add(new SimpleMsg("parameter", "application cryptogram",
+                applicationCryptogram == null ? "" : ISOUtil.hexString(applicationCryptogram)));
+        cmdParameters.add(new SimpleMsg("parameter", "transaction data length",
+                transactionData == null ? "0" : Integer.toString(transactionData.length)));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Verify CDA", cmdParameters));
+        try {
+            EMVCDAResult result = verifyCDAImpl(iccPublicKey,
+                    signedDynamicApplicationData, unpredictableNumber,
+                    applicationCryptogram, transactionData);
+            evt.addMessage(new SimpleMsg("result", "CDA outcome", result == null ? "" : result.toString()));
+            return result;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public byte[] verifyDDA(EMVICCPublicKey iccPublicKey,
             byte[] signedDynamicApplicationData,
             byte[] ddolData) throws SMException {
@@ -2727,6 +2760,25 @@ public class BaseSMAdapter<T>
     protected byte[] verifyDDAImpl(EMVICCPublicKey iccPublicKey,
             byte[] signedDynamicApplicationData,
             byte[] ddolData) throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality.
+     * Verify Combined DDA + AC (CDA) per EMV 4.4 Book 2 §6.6.
+     * @param iccPublicKey the recovered ICC public key
+     * @param signedDynamicApplicationData EMV tag 0x9F4B contents
+     * @param unpredictableNumber terminal UN (4 bytes)
+     * @param applicationCryptogram AC from tag 0x9F26 (8 bytes)
+     * @param transactionData bytes hashed for the transaction-data-hash field
+     * @return the CDA outcome (ICC Dynamic Number + CID)
+     * @throws SMException on RSA recovery, EMV validation, or binding failure
+     */
+    protected EMVCDAResult verifyCDAImpl(EMVICCPublicKey iccPublicKey,
+            byte[] signedDynamicApplicationData,
+            byte[] unpredictableNumber,
+            byte[] applicationCryptogram,
+            byte[] transactionData) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1334,6 +1334,26 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public byte[] generateSM_MAC(T sessionKey, byte[] data) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "session key", sessionKey));
+        cmdParameters.add(new SimpleMsg("parameter", "data", data == null ? "" : ISOUtil.hexString(data)));
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Generate Secure Messaging MAC (direct)", cmdParameters));
+        try {
+            byte[] mac = generateSM_MACImpl(sessionKey, data);
+            evt.addMessage(new SimpleMsg("result", "Generated MAC", mac != null ? ISOUtil.hexString(mac) : ""));
+            return mac;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MAC(MKDMethod mkdm
            ,SKDMethod skdm, PaddingMethod padm, T imksmi
            ,String accountNo, String acctSeqNo, byte[] atc, byte[] arqc
@@ -2426,6 +2446,18 @@ public class BaseSMAdapter<T>
     protected byte[] generateSM_MACImpl(MKDMethod mkdm, SKDMethod skdm
             ,T imksmi, String accountNo, String acctSeqNo
             ,byte[] atc, byte[] arqc, byte[] data) throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality.
+     * Direct SM-MAC generation from a supplied session key.
+     * @param sessionKey the SK-SMI
+     * @param data data to MAC
+     * @return generated 8-byte MAC
+     * @throws SMException on security module error
+     */
+    protected byte[] generateSM_MACImpl(T sessionKey, byte[] data) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/BaseSMAdapter.java
@@ -1215,6 +1215,32 @@ public class BaseSMAdapter<T>
     }
 
     @Override
+    public byte[] generateARPC(T key, byte[] arqc, ARPCMethod arpcMethod,
+            byte[] arc, byte[] propAuthData) throws SMException {
+
+        List<Loggeable> cmdParameters = new ArrayList<>();
+        cmdParameters.add(new SimpleMsg("parameter", "key", key));
+        cmdParameters.add(new SimpleMsg("parameter", "arqc", arqc == null ? "" : ISOUtil.hexString(arqc)));
+        cmdParameters.add(new SimpleMsg("parameter", "arpc gen. method", arpcMethod));
+        cmdParameters.add(new SimpleMsg("parameter", "auth. rc", arc == null ? "" : ISOUtil.hexString(arc)));
+        cmdParameters.add(new SimpleMsg("parameter", "prop auth. data",
+                propAuthData == null ? "" : ISOUtil.hexString(propAuthData))
+        );
+        LogEvent evt = new LogEvent(this, "s-m-operation");
+        evt.addMessage(new SimpleMsg("command", "Generate ARPC (direct)", cmdParameters));
+        try {
+            byte[] result = generateARPCImpl(key, arqc, arpcMethod, arc, propAuthData);
+            evt.addMessage(new SimpleMsg("result", "Generated ARPC", result == null ? "" : ISOUtil.hexString(result)));
+            return result;
+        } catch (Exception e) {
+            evt.addMessage(e);
+            throw e instanceof SMException ? (SMException) e : new SMException(e);
+        } finally {
+            logEvent(evt);
+        }
+    }
+
+    @Override
     public byte[] verifyARQCGenerateARPC(MKDMethod mkdm, SKDMethod skdm, T imkac
             ,String accoutNo, String acctSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,byte[] txnData, ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
@@ -2294,6 +2320,23 @@ public class BaseSMAdapter<T>
             ,String accountNo, String acctSeqNo, byte[] arqc, byte[] atc
             ,byte[] upn, ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
             throws SMException {
+        throw  new SMException("Operation not supported in: " + this.getClass().getName());
+    }
+
+    /**
+     * Your SMAdapter should override this method if it has this functionality.
+     * Direct ARPC generation from a supplied key.
+     * @param key the key under which the ARPC is computed (ICC MK for VSDC
+     *        and MCHIP; AC session key for EMV_CSKD)
+     * @param arqc application request cryptogram
+     * @param arpcMethod ARPC generation method
+     * @param arc authorization response code (or CSU for METHOD_2)
+     * @param propAuthData proprietary authentication data; may be {@code null}
+     * @return calculated ARPC
+     * @throws SMException on security module error
+     */
+    protected byte[] generateARPCImpl(T key, byte[] arqc, ARPCMethod arpcMethod,
+            byte[] arc, byte[] propAuthData) throws SMException {
         throw  new SMException("Operation not supported in: " + this.getClass().getName());
     }
 

--- a/jpos/src/main/java/org/jpos/security/EMVCAPublicKey.java
+++ b/jpos/src/main/java/org/jpos/security/EMVCAPublicKey.java
@@ -51,6 +51,27 @@ public record EMVCAPublicKey(byte[] rid, byte index, byte[] modulus,
                              byte[] exponent, byte hashAlgorithmIndicator,
                              byte publicKeyAlgorithmIndicator) {
 
+    public EMVCAPublicKey {
+        rid = copy(rid);
+        modulus = copy(modulus);
+        exponent = copy(exponent);
+    }
+
+    @Override
+    public byte[] rid() {
+        return copy(rid);
+    }
+
+    @Override
+    public byte[] modulus() {
+        return copy(modulus);
+    }
+
+    @Override
+    public byte[] exponent() {
+        return copy(exponent);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -83,5 +104,9 @@ public record EMVCAPublicKey(byte[] rid, byte index, byte[] modulus,
                 + ", hashAlg=" + String.format("%02X", hashAlgorithmIndicator & 0xff)
                 + ", pkAlg=" + String.format("%02X", publicKeyAlgorithmIndicator & 0xff)
                 + "]";
+    }
+
+    private static byte[] copy(byte[] bytes) {
+        return bytes == null ? null : bytes.clone();
     }
 }

--- a/jpos/src/main/java/org/jpos/security/EMVCAPublicKey.java
+++ b/jpos/src/main/java/org/jpos/security/EMVCAPublicKey.java
@@ -1,0 +1,87 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.Arrays;
+
+import org.jpos.iso.ISOUtil;
+
+/**
+ * EMV Certification Authority (CA) Public Key, as used to verify Issuer
+ * Public Key Certificates during offline data authentication.
+ * <p>
+ * CA public keys are published per scheme (Visa, Mastercard, JCB, etc.)
+ * and identified by the pair ({@link #rid}, {@link #index}). They are
+ * clear public values — there is no LMK wrapping involved — so this
+ * type holds the modulus and exponent as raw {@code byte[]}.
+ * <p>
+ * Used as input to
+ * {@link EMVSMAdapter#recoverIssuerPublicKey(EMVCAPublicKey, byte[], byte[], byte[], String)}.
+ *
+ * @param rid 5-byte Registered Application Provider Identifier
+ *        (scheme-specific; e.g. Visa = {@code A000000003})
+ * @param index 1-byte CA public key index within the RID
+ * @param modulus big-endian RSA modulus, variable length per spec
+ *        (EMV currently allows 1024 to 1984 bits)
+ * @param exponent big-endian RSA public exponent, typically
+ *        {@code {0x03}} or {@code {0x01, 0x00, 0x01}}
+ * @param hashAlgorithmIndicator hash algorithm identifier as defined by
+ *        EMV (0x01 = SHA-1; other values currently unsupported by the
+ *        JCE adapter)
+ * @param publicKeyAlgorithmIndicator public key algorithm identifier
+ *        (0x01 = RSA)
+ */
+public record EMVCAPublicKey(byte[] rid, byte index, byte[] modulus,
+                             byte[] exponent, byte hashAlgorithmIndicator,
+                             byte publicKeyAlgorithmIndicator) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EMVCAPublicKey other)) return false;
+        return index == other.index
+                && hashAlgorithmIndicator == other.hashAlgorithmIndicator
+                && publicKeyAlgorithmIndicator == other.publicKeyAlgorithmIndicator
+                && Arrays.equals(rid, other.rid)
+                && Arrays.equals(modulus, other.modulus)
+                && Arrays.equals(exponent, other.exponent);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = Arrays.hashCode(rid);
+        h = 31 * h + index;
+        h = 31 * h + Arrays.hashCode(modulus);
+        h = 31 * h + Arrays.hashCode(exponent);
+        h = 31 * h + hashAlgorithmIndicator;
+        h = 31 * h + publicKeyAlgorithmIndicator;
+        return h;
+    }
+
+    @Override
+    public String toString() {
+        return "EMVCAPublicKey[rid=" + (rid == null ? "" : ISOUtil.hexString(rid))
+                + ", index=" + String.format("%02X", index & 0xff)
+                + ", modulus=" + (modulus == null ? "" : ISOUtil.hexString(modulus))
+                + ", exponent=" + (exponent == null ? "" : ISOUtil.hexString(exponent))
+                + ", hashAlg=" + String.format("%02X", hashAlgorithmIndicator & 0xff)
+                + ", pkAlg=" + String.format("%02X", publicKeyAlgorithmIndicator & 0xff)
+                + "]";
+    }
+}

--- a/jpos/src/main/java/org/jpos/security/EMVCDAResult.java
+++ b/jpos/src/main/java/org/jpos/security/EMVCDAResult.java
@@ -1,0 +1,67 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.Arrays;
+
+import org.jpos.iso.ISOUtil;
+
+/**
+ * Outcome of a successful EMV CDA (Combined DDA + AC) verification, per
+ * EMV 4.4 Book 2 §6.6.
+ * <p>
+ * Returned by
+ * {@link EMVSMAdapter#verifyCDA(EMVICCPublicKey, byte[], byte[], byte[], byte[])}
+ * after all twelve validation steps pass. The terminal uses
+ * {@link #cid} to route the transaction (bits 7-6 of CID select
+ * ARQC / TC / AAC) and may use {@link #iccDynamicNumber} for
+ * downstream diagnostics.
+ *
+ * @param iccDynamicNumber the per-transaction nonce the card included
+ *        in its signed dynamic data (variable length, 2 to 8 bytes
+ *        per EMV §6.5.2)
+ * @param cid Cryptogram Information Data byte the card committed to
+ *        inside the signature (also returned in tag {@code 0x9F27}
+ *        out-of-band)
+ */
+public record EMVCDAResult(byte[] iccDynamicNumber, byte cid) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EMVCDAResult other)) return false;
+        return cid == other.cid
+                && Arrays.equals(iccDynamicNumber, other.iccDynamicNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = Arrays.hashCode(iccDynamicNumber);
+        h = 31 * h + cid;
+        return h;
+    }
+
+    @Override
+    public String toString() {
+        return "EMVCDAResult[iccDynamicNumber="
+                + (iccDynamicNumber == null ? "" : ISOUtil.hexString(iccDynamicNumber))
+                + ", cid=" + String.format("%02X", cid & 0xff)
+                + "]";
+    }
+}

--- a/jpos/src/main/java/org/jpos/security/EMVCDAResult.java
+++ b/jpos/src/main/java/org/jpos/security/EMVCDAResult.java
@@ -42,6 +42,15 @@ import org.jpos.iso.ISOUtil;
  */
 public record EMVCDAResult(byte[] iccDynamicNumber, byte cid) {
 
+    public EMVCDAResult {
+        iccDynamicNumber = copy(iccDynamicNumber);
+    }
+
+    @Override
+    public byte[] iccDynamicNumber() {
+        return copy(iccDynamicNumber);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -63,5 +72,9 @@ public record EMVCDAResult(byte[] iccDynamicNumber, byte cid) {
                 + (iccDynamicNumber == null ? "" : ISOUtil.hexString(iccDynamicNumber))
                 + ", cid=" + String.format("%02X", cid & 0xff)
                 + "]";
+    }
+
+    private static byte[] copy(byte[] bytes) {
+        return bytes == null ? null : bytes.clone();
     }
 }

--- a/jpos/src/main/java/org/jpos/security/EMVDerivedKey.java
+++ b/jpos/src/main/java/org/jpos/security/EMVDerivedKey.java
@@ -51,6 +51,15 @@ import org.jpos.iso.ISOUtil;
  */
 public record EMVDerivedKey<T>(T key, byte[] kcv) {
 
+    public EMVDerivedKey {
+        kcv = copy(kcv);
+    }
+
+    @Override
+    public byte[] kcv() {
+        return copy(kcv);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -68,5 +77,9 @@ public record EMVDerivedKey<T>(T key, byte[] kcv) {
         return "EMVDerivedKey[key=" + key
                 + ", kcv=" + (kcv == null ? "" : ISOUtil.hexString(kcv))
                 + "]";
+    }
+
+    private static byte[] copy(byte[] bytes) {
+        return bytes == null ? null : bytes.clone();
     }
 }

--- a/jpos/src/main/java/org/jpos/security/EMVDerivedKey.java
+++ b/jpos/src/main/java/org/jpos/security/EMVDerivedKey.java
@@ -1,0 +1,68 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.jpos.iso.ISOUtil;
+
+/**
+ * Result of an EMV key-derivation operation: the derived key paired with its
+ * Key Check Value.
+ * <p>
+ * The {@code key} component is parametric on {@link SecureKey} so that the
+ * type carries through whatever wrapping the underlying security module
+ * uses. The software JCE adapter populates it with a {@link SecureDESKey}
+ * (wrapped under the LMK); a future HSM adapter that speaks ANSI X9.143 /
+ * TR-31 key blocks would populate it with its own key-block type.
+ * <p>
+ * The KCV is the standard 3-byte short check value (the high-order bytes of
+ * encrypting an all-zero block with the clear derived key). It is held as a
+ * {@code byte[]} to match {@link SecureKey#getKeyCheckValue()}; the
+ * {@link #equals(Object)}, {@link #hashCode()} and {@link #toString()}
+ * overrides below compare and render it by content rather than by array
+ * identity.
+ *
+ * @param <T> the SecureKey implementation type carried by the underlying
+ *            security module
+ * @param key the derived key, wrapped per the adapter's convention
+ * @param kcv the Key Check Value, normally 3 bytes
+ */
+public record EMVDerivedKey<T extends SecureKey>(T key, byte[] kcv) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EMVDerivedKey<?> other)) return false;
+        return Objects.equals(key, other.key) && Arrays.equals(kcv, other.kcv);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Objects.hashCode(key) + Arrays.hashCode(kcv);
+    }
+
+    @Override
+    public String toString() {
+        return "EMVDerivedKey[key=" + key
+                + ", kcv=" + (kcv == null ? "" : ISOUtil.hexString(kcv))
+                + "]";
+    }
+}

--- a/jpos/src/main/java/org/jpos/security/EMVDerivedKey.java
+++ b/jpos/src/main/java/org/jpos/security/EMVDerivedKey.java
@@ -40,12 +40,16 @@ import org.jpos.iso.ISOUtil;
  * overrides below compare and render it by content rather than by array
  * identity.
  *
- * @param <T> the SecureKey implementation type carried by the underlying
- *            security module
+ * @param <T> the {@link SecureKey} implementation type carried by the
+ *            underlying security module. By convention {@code T} is always
+ *            a {@code SecureKey} subtype (matching {@code SMAdapter}'s
+ *            usage), though the bound is left unconstrained to stay
+ *            compatible with the rest of the {@code org.jpos.security}
+ *            public API surface.
  * @param key the derived key, wrapped per the adapter's convention
  * @param kcv the Key Check Value, normally 3 bytes
  */
-public record EMVDerivedKey<T extends SecureKey>(T key, byte[] kcv) {
+public record EMVDerivedKey<T>(T key, byte[] kcv) {
 
     @Override
     public boolean equals(Object o) {

--- a/jpos/src/main/java/org/jpos/security/EMVICCPublicKey.java
+++ b/jpos/src/main/java/org/jpos/security/EMVICCPublicKey.java
@@ -1,0 +1,97 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.Arrays;
+
+import org.jpos.iso.ISOUtil;
+
+/**
+ * EMV ICC Public Key recovered from an ICC Public Key Certificate.
+ * <p>
+ * Returned by
+ * {@link EMVSMAdapter#recoverICCPublicKey(EMVIssuerPublicKey, byte[], byte[], byte[], byte[], String)}
+ * after successful certificate recovery and validation per EMV 4.4
+ * Book 2 §6.4.
+ * <p>
+ * Unlike the Issuer PK certificate (PR 9) — which carries a 4-byte
+ * Issuer Identifier — the ICC PK certificate carries the full 10-byte
+ * Application PAN (BCD, right-padded with {@code 0xF} nibbles); see
+ * {@link #applicationPan}. The hash input over which the issuer signs
+ * the ICC PK certificate additionally includes the Static Application
+ * Data assembled by the terminal from the AFL, which is how the
+ * issuer cryptographically commits to a specific set of card records.
+ *
+ * @param applicationPan 10 BCD bytes — the cardholder PAN
+ *        right-padded with {@code 0xF} nibbles to 20 nibbles
+ * @param expirationDate 2 BCD bytes — {@code MM YY} per EMV
+ *        Book 2 §6.4
+ * @param serialNumber 3 bytes — assigned by the issuer
+ * @param modulus big-endian RSA modulus of the ICC public key, full
+ *        length (leftmost-in-cert + remainder)
+ * @param exponent big-endian RSA public exponent of the ICC public
+ *        key, as supplied by the caller
+ * @param hashAlgorithmIndicator hash algorithm identifier from the
+ *        certificate (0x01 = SHA-1)
+ * @param publicKeyAlgorithmIndicator public key algorithm identifier
+ *        from the certificate (0x01 = RSA)
+ */
+public record EMVICCPublicKey(byte[] applicationPan, byte[] expirationDate,
+                              byte[] serialNumber, byte[] modulus,
+                              byte[] exponent, byte hashAlgorithmIndicator,
+                              byte publicKeyAlgorithmIndicator) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EMVICCPublicKey other)) return false;
+        return hashAlgorithmIndicator == other.hashAlgorithmIndicator
+                && publicKeyAlgorithmIndicator == other.publicKeyAlgorithmIndicator
+                && Arrays.equals(applicationPan, other.applicationPan)
+                && Arrays.equals(expirationDate, other.expirationDate)
+                && Arrays.equals(serialNumber, other.serialNumber)
+                && Arrays.equals(modulus, other.modulus)
+                && Arrays.equals(exponent, other.exponent);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = Arrays.hashCode(applicationPan);
+        h = 31 * h + Arrays.hashCode(expirationDate);
+        h = 31 * h + Arrays.hashCode(serialNumber);
+        h = 31 * h + Arrays.hashCode(modulus);
+        h = 31 * h + Arrays.hashCode(exponent);
+        h = 31 * h + hashAlgorithmIndicator;
+        h = 31 * h + publicKeyAlgorithmIndicator;
+        return h;
+    }
+
+    @Override
+    public String toString() {
+        return "EMVICCPublicKey[applicationPan="
+                + (applicationPan == null ? "" : ISOUtil.hexString(applicationPan))
+                + ", expirationDate=" + (expirationDate == null ? "" : ISOUtil.hexString(expirationDate))
+                + ", serialNumber=" + (serialNumber == null ? "" : ISOUtil.hexString(serialNumber))
+                + ", modulus=" + (modulus == null ? "" : ISOUtil.hexString(modulus))
+                + ", exponent=" + (exponent == null ? "" : ISOUtil.hexString(exponent))
+                + ", hashAlg=" + String.format("%02X", hashAlgorithmIndicator & 0xff)
+                + ", pkAlg=" + String.format("%02X", publicKeyAlgorithmIndicator & 0xff)
+                + "]";
+    }
+}

--- a/jpos/src/main/java/org/jpos/security/EMVICCPublicKey.java
+++ b/jpos/src/main/java/org/jpos/security/EMVICCPublicKey.java
@@ -57,6 +57,39 @@ public record EMVICCPublicKey(byte[] applicationPan, byte[] expirationDate,
                               byte[] exponent, byte hashAlgorithmIndicator,
                               byte publicKeyAlgorithmIndicator) {
 
+    public EMVICCPublicKey {
+        applicationPan = copy(applicationPan);
+        expirationDate = copy(expirationDate);
+        serialNumber = copy(serialNumber);
+        modulus = copy(modulus);
+        exponent = copy(exponent);
+    }
+
+    @Override
+    public byte[] applicationPan() {
+        return copy(applicationPan);
+    }
+
+    @Override
+    public byte[] expirationDate() {
+        return copy(expirationDate);
+    }
+
+    @Override
+    public byte[] serialNumber() {
+        return copy(serialNumber);
+    }
+
+    @Override
+    public byte[] modulus() {
+        return copy(modulus);
+    }
+
+    @Override
+    public byte[] exponent() {
+        return copy(exponent);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -93,5 +126,9 @@ public record EMVICCPublicKey(byte[] applicationPan, byte[] expirationDate,
                 + ", hashAlg=" + String.format("%02X", hashAlgorithmIndicator & 0xff)
                 + ", pkAlg=" + String.format("%02X", publicKeyAlgorithmIndicator & 0xff)
                 + "]";
+    }
+
+    private static byte[] copy(byte[] bytes) {
+        return bytes == null ? null : bytes.clone();
     }
 }

--- a/jpos/src/main/java/org/jpos/security/EMVIssuerPublicKey.java
+++ b/jpos/src/main/java/org/jpos/security/EMVIssuerPublicKey.java
@@ -56,6 +56,39 @@ public record EMVIssuerPublicKey(byte[] issuerIdentifier, byte[] expirationDate,
                                  byte[] exponent, byte hashAlgorithmIndicator,
                                  byte publicKeyAlgorithmIndicator) {
 
+    public EMVIssuerPublicKey {
+        issuerIdentifier = copy(issuerIdentifier);
+        expirationDate = copy(expirationDate);
+        serialNumber = copy(serialNumber);
+        modulus = copy(modulus);
+        exponent = copy(exponent);
+    }
+
+    @Override
+    public byte[] issuerIdentifier() {
+        return copy(issuerIdentifier);
+    }
+
+    @Override
+    public byte[] expirationDate() {
+        return copy(expirationDate);
+    }
+
+    @Override
+    public byte[] serialNumber() {
+        return copy(serialNumber);
+    }
+
+    @Override
+    public byte[] modulus() {
+        return copy(modulus);
+    }
+
+    @Override
+    public byte[] exponent() {
+        return copy(exponent);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -92,5 +125,9 @@ public record EMVIssuerPublicKey(byte[] issuerIdentifier, byte[] expirationDate,
                 + ", hashAlg=" + String.format("%02X", hashAlgorithmIndicator & 0xff)
                 + ", pkAlg=" + String.format("%02X", publicKeyAlgorithmIndicator & 0xff)
                 + "]";
+    }
+
+    private static byte[] copy(byte[] bytes) {
+        return bytes == null ? null : bytes.clone();
     }
 }

--- a/jpos/src/main/java/org/jpos/security/EMVIssuerPublicKey.java
+++ b/jpos/src/main/java/org/jpos/security/EMVIssuerPublicKey.java
@@ -1,0 +1,96 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import java.util.Arrays;
+
+import org.jpos.iso.ISOUtil;
+
+/**
+ * EMV Issuer Public Key recovered from an Issuer Public Key Certificate.
+ * <p>
+ * Returned by
+ * {@link EMVSMAdapter#recoverIssuerPublicKey(EMVCAPublicKey, byte[], byte[], byte[], String)}
+ * after successful certificate recovery and validation per EMV 4.4
+ * Book 2 §6.
+ * <p>
+ * The issuer public key reconstructed in {@link #modulus} is the
+ * concatenation of the leftmost portion present in the certificate and
+ * the remainder supplied separately (EMV tag {@code 0x92}), if any. The
+ * exponent passes through unchanged from the caller-supplied tag
+ * {@code 0x9F32}.
+ *
+ * @param issuerIdentifier 4 BCD bytes — the leftmost digits of the PAN
+ *        right-padded with {@code 0xF} nibbles (e.g. PAN {@code 12345…}
+ *        → {@code 12 34 5F FF})
+ * @param expirationDate 2 BCD bytes — {@code MM YY} (per EMV
+ *        Book 2 §6.3)
+ * @param serialNumber 3 bytes — assigned by the CA
+ * @param modulus big-endian RSA modulus of the issuer public key, full
+ *        length (leftmost-in-cert + remainder)
+ * @param exponent big-endian RSA public exponent of the issuer public
+ *        key, as supplied by the caller
+ * @param hashAlgorithmIndicator hash algorithm identifier from the
+ *        certificate (0x01 = SHA-1)
+ * @param publicKeyAlgorithmIndicator public key algorithm identifier
+ *        from the certificate (0x01 = RSA)
+ */
+public record EMVIssuerPublicKey(byte[] issuerIdentifier, byte[] expirationDate,
+                                 byte[] serialNumber, byte[] modulus,
+                                 byte[] exponent, byte hashAlgorithmIndicator,
+                                 byte publicKeyAlgorithmIndicator) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EMVIssuerPublicKey other)) return false;
+        return hashAlgorithmIndicator == other.hashAlgorithmIndicator
+                && publicKeyAlgorithmIndicator == other.publicKeyAlgorithmIndicator
+                && Arrays.equals(issuerIdentifier, other.issuerIdentifier)
+                && Arrays.equals(expirationDate, other.expirationDate)
+                && Arrays.equals(serialNumber, other.serialNumber)
+                && Arrays.equals(modulus, other.modulus)
+                && Arrays.equals(exponent, other.exponent);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = Arrays.hashCode(issuerIdentifier);
+        h = 31 * h + Arrays.hashCode(expirationDate);
+        h = 31 * h + Arrays.hashCode(serialNumber);
+        h = 31 * h + Arrays.hashCode(modulus);
+        h = 31 * h + Arrays.hashCode(exponent);
+        h = 31 * h + hashAlgorithmIndicator;
+        h = 31 * h + publicKeyAlgorithmIndicator;
+        return h;
+    }
+
+    @Override
+    public String toString() {
+        return "EMVIssuerPublicKey[issuerIdentifier="
+                + (issuerIdentifier == null ? "" : ISOUtil.hexString(issuerIdentifier))
+                + ", expirationDate=" + (expirationDate == null ? "" : ISOUtil.hexString(expirationDate))
+                + ", serialNumber=" + (serialNumber == null ? "" : ISOUtil.hexString(serialNumber))
+                + ", modulus=" + (modulus == null ? "" : ISOUtil.hexString(modulus))
+                + ", exponent=" + (exponent == null ? "" : ISOUtil.hexString(exponent))
+                + ", hashAlg=" + String.format("%02X", hashAlgorithmIndicator & 0xff)
+                + ", pkAlg=" + String.format("%02X", publicKeyAlgorithmIndicator & 0xff)
+                + "]";
+    }
+}

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -35,6 +35,9 @@ package org.jpos.security;
  *       ARQC/TC/AAC accepted by {@link SMAdapter#verifyARQC}.
  * </ul>
  * <p>
+ * Some methods also return key-derivation results via
+ * {@link EMVDerivedKey}; see e.g. {@link #deriveICCMasterKey}.
+ * <p>
  * Implementations that cannot perform a given operation should leave the
  * default {@link BaseSMAdapter} implementation in place, which throws
  * {@link SMException}.
@@ -125,5 +128,36 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
     byte[] generateApplicationCryptogram(MKDMethod mkdm, SKDMethod skdm, T imkac,
                         String accountNo, String acctSeqNo, byte[] atc,
                         byte[] upn, byte[] txnData)
+            throws SMException;
+
+    /**
+     * Derive an ICC Master Key from an Issuer Master Key (IMK) and the
+     * cardholder's PAN / PAN Sequence Number.
+     * <p>
+     * The result wraps the derived ICC Master Key in whatever representation
+     * the underlying security module uses for {@link SecureKey} (the JCE
+     * adapter wraps it as a {@link SecureDESKey} under the LMK; a future
+     * ANSI X9.143 / TR-31 HSM adapter would wrap it as a key block). The
+     * derived key shares the IMK's usage family — the JCE adapter preserves
+     * the IMK's {@code keyType} and {@code keyLength} on the derived
+     * {@link SecureDESKey}.
+     * <p>
+     * The derivation follows EMV v4.2 Book 2, Annex A1.4. For {@code mkdm}
+     * equals {@link MKDMethod#OPTION_B} on a PAN longer than 16 digits, the
+     * Option B (SHA-1 decimalised) path is used; otherwise Option A is used.
+     * This matches the formatting used internally by
+     * {@link SMAdapter#verifyARQC}.
+     *
+     * @param mkdm ICC Master Key Derivation Method. If {@code null},
+     *        {@link MKDMethod#OPTION_A} is used.
+     * @param imk the issuer master key, wrapped per the adapter's convention
+     * @param pan account number including BIN and check digit
+     * @param psn PAN Sequence Number, 2 decimal digits; if {@code null} or
+     *        empty, treated as {@code "00"}
+     * @return the derived ICC Master Key paired with its 3-byte Key Check Value
+     * @throws SMException on security module error
+     */
+    EMVDerivedKey<T> deriveICCMasterKey(MKDMethod mkdm, T imk,
+                                        String pan, String psn)
             throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -301,4 +301,38 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
                                                     T imk, String pan, String psn,
                                                     byte[] atc, byte[] arqc)
             throws SMException;
+
+    /**
+     * Generate a Secure Messaging MAC directly from a supplied session key.
+     * <p>
+     * This is an overload of
+     * {@link SMAdapter#generateSM_MAC(MKDMethod, SKDMethod, Object, String, String, byte[], byte[], byte[])}
+     * that skips the IMK + PAN/PSN derivation. The caller passes the
+     * SK-SMI directly — typically the output of
+     * {@link #deriveSecureMessagingSessionKey(MKDMethod, SKDMethod, Object, String, String, byte[], byte[])}
+     * with an IMK-SMI — closing the loop on the SM-MAC derivation chain:
+     * <pre>
+     *   EMVDerivedKey&lt;T&gt; skSmi = deriveSecureMessagingSessionKey(
+     *           mkdm, skdm, imkSmi, pan, psn, atc, arqc);
+     *   byte[]           mac   = generateSM_MAC(skSmi.key(), data);
+     * </pre>
+     * <p>
+     * The implementation applies ISO/IEC 9797-1 padding method 2 (append
+     * {@code 0x80} then {@code 0x00} pad to the next 8-byte boundary) and
+     * computes the ISO/IEC 9797-1 MAC algorithm 3 (Triple-DES retail MAC).
+     * Both match the padding+MAC used internally by the master-key-based
+     * {@code generateSM_MAC} for VSDC, MCHIP, and EMV_CSKD, so the returned
+     * 8 bytes are bit-identical to what the integrated method would produce
+     * given the same inputs and derivation.
+     * <p>
+     * Callers requiring alternative padding (e.g. Visa, CCD, or M/Chip
+     * SM-MAC padding variants) should pre-pad the input themselves; this
+     * method does not provide a padding-method selector.
+     *
+     * @param sessionKey the SK-SMI, wrapped per the adapter's convention
+     * @param data the data to MAC (pre-padding)
+     * @return the 8-byte Secure Messaging MAC
+     * @throws SMException on security module error
+     */
+    byte[] generateSM_MAC(T sessionKey, byte[] data) throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -626,4 +626,71 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
             EMVICCPublicKey iccPublicKey,
             byte[] signedDynamicApplicationData,
             byte[] ddolData) throws SMException;
+
+    /**
+     * Verify a Combined DDA + AC (CDA) signature per EMV 4.4 Book 2 §6.6,
+     * cross-checking the Application Cryptogram and the terminal-side
+     * transaction data hash the card bound to its signature.
+     * <p>
+     * CDA is strictly stronger than {@link #verifyDDA}: it proves not
+     * only that the card holds the ICC private key, but that the card's
+     * cryptogram and transaction context are cryptographically bound to
+     * the dynamic signature. The natural caller flow is:
+     * <pre>
+     *   EMVIssuerPublicKey issuer = recoverIssuerPublicKey(...);
+     *   EMVICCPublicKey    icc    = recoverICCPublicKey(issuer, ...);
+     *   EMVCDAResult       cda    = verifyCDA(icc, sdad, unpredictableNumber,
+     *                                         applicationCryptogram, transactionData);
+     *   // cda.iccDynamicNumber() carries the card's nonce
+     *   // cda.cid() routes the transaction outcome
+     * </pre>
+     * <p>
+     * The implementation performs the same structural and hash
+     * validation as {@link #verifyDDA} (header {@code 0x6A},
+     * signed-data-format {@code 0x05}, trailer {@code 0xBC}, hash
+     * algorithm indicator, LDN sanity, mandatory {@code 0xBB} pad
+     * pattern, SHA-1 hash over the recovered payload concatenated with
+     * the supplied Unpredictable Number) plus two cross-bindings
+     * unique to CDA:
+     * <ul>
+     *   <li><b>AC binding</b> — the 8-byte AC embedded inside the SDAD
+     *       must equal the supplied {@code applicationCryptogram}.
+     *       Catches a malicious card that signs one AC but returns
+     *       another out-of-band.
+     *   <li><b>Transaction Data Hash binding</b> — the 20-byte hash
+     *       embedded inside the SDAD must equal
+     *       {@code SHA-1(transactionData)}. Catches a card that signed
+     *       a different transaction context than what the terminal sent.
+     * </ul>
+     * <p>
+     * The CDA SDAD shares EMV tag {@code 0x9F4B} with DDA SDAD; the two
+     * are distinguished by the LDD field — CDA mandates
+     * {@code LDD == LDN + 30} (LDN + Cryptogram Information Data + AC +
+     * Transaction Data Hash), DDA is just {@code LDN + 1}.
+     *
+     * @param iccPublicKey the recovered ICC Public Key
+     * @param signedDynamicApplicationData EMV tag {@code 0x9F4B} contents;
+     *        length must equal the ICC modulus length
+     * @param unpredictableNumber the terminal's Unpredictable Number
+     *        (EMV tag {@code 0x9F37}, 4 bytes) — same value sent to
+     *        the card and hashed by the card when signing
+     * @param applicationCryptogram the AC returned by the card in tag
+     *        {@code 0x9F26}, 8 bytes; cross-checked against the AC
+     *        embedded inside the SDAD
+     * @param transactionData the bytes the terminal hashed for the
+     *        Transaction Data Hash field (typically PDOL || CDOL
+     *        || optional additional data); SHA-1 of these is
+     *        cross-checked against the SDAD-embedded hash
+     * @return an {@link EMVCDAResult} carrying the ICC Dynamic Number
+     *         and the Cryptogram Information Data byte
+     * @throws SMException on RSA recovery failure, any structural or
+     *         hash validation failure, AC binding mismatch, or
+     *         Transaction Data Hash binding mismatch
+     */
+    EMVCDAResult verifyCDA(
+            EMVICCPublicKey iccPublicKey,
+            byte[] signedDynamicApplicationData,
+            byte[] unpredictableNumber,
+            byte[] applicationCryptogram,
+            byte[] transactionData) throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -197,4 +197,56 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
     EMVDerivedKey<T> deriveEMVSessionKey(SKDMethod skdm, T iccMk,
                                          byte[] atc, byte[] upn)
             throws SMException;
+
+    /**
+     * Generate an Authorisation Response Cryptogram (ARPC) directly from a
+     * supplied key.
+     * <p>
+     * This is an overload of
+     * {@link SMAdapter#generateARPC(MKDMethod, SKDMethod, Object, String, String, byte[], byte[], byte[], ARPCMethod, byte[], byte[])}
+     * that skips the IMK + PAN/PSN derivation. The caller passes in the key
+     * under which the ARPC is to be computed.
+     * <p>
+     * <b>Which key to pass</b> depends on the SKDMethod the card uses:
+     * <ul>
+     *   <li>{@link SKDMethod#VSDC} and {@link SKDMethod#MCHIP} — no
+     *       ARPC-session-key derivation in EMV; pass the <i>ICC Master Key</i>
+     *       directly (the output of
+     *       {@link #deriveICCMasterKey(MKDMethod, Object, String, String)}).
+     *   <li>{@link SKDMethod#EMV_CSKD} — pass the AC session key (the output of
+     *       {@link #deriveEMVSessionKey(SKDMethod, Object, byte[], byte[])}
+     *       with {@code EMV_CSKD}).
+     * </ul>
+     * Example for EMV_CSKD:
+     * <pre>
+     *   EMVDerivedKey&lt;T&gt; iccMk   = deriveICCMasterKey(mkdm, imk, pan, psn);
+     *   EMVDerivedKey&lt;T&gt; session = deriveEMVSessionKey(SKDMethod.EMV_CSKD,
+     *                                                   iccMk.key(), atc, null);
+     *   byte[]           arpc    = generateARPC(session.key(), arqc,
+     *                                           arpcMethod, arc, propAuthData);
+     * </pre>
+     * <p>
+     * <b>Constraint relaxation:</b> unlike the master-key-based overload, this
+     * direct method does <i>not</i> enforce SKDMethod/ARPCMethod compatibility
+     * (which the master-key variant enforces via {@code constraintARPCM},
+     * rejecting METHOD_2 for VSDC and MCHIP). The caller takes responsibility
+     * for choosing combinations the card will accept.
+     *
+     * @param key the key under which the ARPC is computed (see "Which key
+     *        to pass" above), wrapped per the adapter's convention
+     * @param arqc the Application Request Cryptogram, 8 bytes
+     * @param arpcMethod ARPC calculation method
+     * @param arc the Authorisation Response Code, 2 bytes for
+     *        {@link ARPCMethod#METHOD_1}; for {@link ARPCMethod#METHOD_2}
+     *        this is the 4-byte Card Status Update (CSU)
+     * @param propAuthData Proprietary Authentication Data, up to 8 bytes.
+     *        Used only for {@link ARPCMethod#METHOD_2}; ignored otherwise
+     *        and may be {@code null}.
+     * @return 8-byte ARPC for {@link ARPCMethod#METHOD_1}, 4-byte ARPC for
+     *         {@link ARPCMethod#METHOD_2}
+     * @throws SMException on security module error
+     */
+    byte[] generateARPC(T key, byte[] arqc, ARPCMethod arpcMethod,
+                        byte[] arc, byte[] propAuthData)
+            throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -30,7 +30,9 @@ package org.jpos.security;
  *   <li>{@link #generateCVC3} must produce a CVC3 accepted by
  *       {@link SMAdapter#verifyCVC3};
  *   <li>{@link #generatedCVV} must produce a dCVV accepted by
- *       {@link SMAdapter#verifydCVV}.
+ *       {@link SMAdapter#verifydCVV};
+ *   <li>{@link #generateApplicationCryptogram} must produce an
+ *       ARQC/TC/AAC accepted by {@link SMAdapter#verifyARQC}.
  * </ul>
  * <p>
  * Implementations that cannot perform a given operation should leave the
@@ -85,5 +87,43 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
      */
     String generatedCVV(String accountNo, T imkac, String expDate,
                         String serviceCode, byte[] atc, MKDMethod mkdm)
+            throws SMException;
+
+    /**
+     * Generate an Application Cryptogram (ARQC / TC / AAC).
+     * <p>
+     * The three cryptogram types share the same MAC computation; the type the
+     * card emits is determined by the {@code Cryptogram Information Data} byte
+     * supplied as part of {@code txnData}. This method is the generation
+     * counterpart of
+     * {@link SMAdapter#verifyARQC(MKDMethod, SKDMethod, Object, String, String, byte[], byte[], byte[], byte[])}
+     * and is expected to return bytes that the verifier would accept.
+     *
+     * @param mkdm ICC Master Key Derivation Method. For {@code skdm} equals
+     *        {@link SKDMethod#VSDC} and {@link SKDMethod#MCHIP} this parameter
+     *        is ignored and {@link MKDMethod#OPTION_A} is always used.
+     * @param skdm Session Key Derivation Method
+     * @param imkac the issuer master key for generating and verifying
+     *        Application Cryptograms, encrypted under the LMK
+     * @param accountNo account number including BIN and check digit
+     * @param acctSeqNo account sequence number, 2 decimal digits
+     * @param atc application transaction counter. This is used for Session
+     *        Key Generation. A 2 byte value must be supplied.
+     *        For {@code skdm} equals {@link SKDMethod#VSDC} is not used.
+     * @param upn unpredictable number. This is used for Session Key Generation.
+     *        A 4 byte value must be supplied. For {@code skdm} equals
+     *        {@link SKDMethod#VSDC} is not used.
+     * @param txnData transaction data. Transaction data elements and their
+     *        order is dependent to proper cryptogram version. If the data
+     *        supplied is a multiple of 8 bytes, no extra padding is added.
+     *        If it is not a multiple of 8 bytes, additional zero padding is added.
+     *        <b>If alternative padding methods are required, it has to be
+     *        applied before</b>.
+     * @return 8-byte computed Application Cryptogram
+     * @throws SMException on security module error
+     */
+    byte[] generateApplicationCryptogram(MKDMethod mkdm, SKDMethod skdm, T imkac,
+                        String accountNo, String acctSeqNo, byte[] atc,
+                        byte[] upn, byte[] txnData)
             throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -160,4 +160,41 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
     EMVDerivedKey<T> deriveICCMasterKey(MKDMethod mkdm, T imk,
                                         String pan, String psn)
             throws SMException;
+
+    /**
+     * Derive an EMV Application Cryptogram session key from an ICC Master
+     * Key and the per-transaction diversifiers.
+     * <p>
+     * The result wraps the session key in whatever representation the
+     * underlying security module uses for {@link SecureKey}. The derived
+     * key inherits the ICC Master Key's {@code keyType} and {@code keyLength}.
+     * <p>
+     * Per-{@code skdm} input usage:
+     * <ul>
+     *   <li>{@link SKDMethod#VSDC} — VSDC has no session-key derivation; the
+     *       application cryptogram is MAC'd with the ICC Master Key directly.
+     *       For API uniformity this method returns the ICC Master Key
+     *       rewrapped (same bytes, same KCV). {@code atc} and {@code upn}
+     *       are ignored.
+     *   <li>{@link SKDMethod#MCHIP} — uses both {@code atc} (2 bytes) and
+     *       {@code upn} (4 bytes) as diversifiers; both must be supplied.
+     *   <li>{@link SKDMethod#EMV_CSKD} — uses {@code atc} (2 bytes) only;
+     *       {@code upn} may be {@code null}.
+     * </ul>
+     *
+     * @param skdm Session Key Derivation Method
+     * @param iccMk the ICC Master Key, typically the output of
+     *        {@link #deriveICCMasterKey}
+     * @param atc Application Transaction Counter (2 bytes). Ignored for
+     *        {@link SKDMethod#VSDC}.
+     * @param upn Unpredictable Number (4 bytes). Used only for
+     *        {@link SKDMethod#MCHIP}; ignored otherwise and may be {@code null}.
+     * @return the derived session key paired with its 3-byte Key Check Value
+     * @throws SMException on security module error or if {@code skdm} is not
+     *         supported (e.g. {@link SKDMethod#AEPIS_V40} or
+     *         {@link SKDMethod#EMV2000_SKM})
+     */
+    EMVDerivedKey<T> deriveEMVSessionKey(SKDMethod skdm, T iccMk,
+                                         byte[] atc, byte[] upn)
+            throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -406,4 +406,58 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
     EncryptedPIN encryptSecureMessagingPIN(T sessionKey, EncryptedPIN newPIN,
             T kd1, byte destinationPINBlockFormat, PaddingMethod paddingMethod,
             EncryptedPIN currentPIN, T udkAc) throws SMException;
+
+    /**
+     * Recover an Issuer Public Key from an EMV Issuer Public Key Certificate
+     * signed by a Certification Authority, per EMV 4.4 Book 2 §6.
+     * <p>
+     * The certificate, remainder, and exponent inputs correspond to EMV
+     * tags {@code 0x90} (Issuer Public Key Certificate), {@code 0x92}
+     * (Issuer Public Key Remainder, optional) and {@code 0x9F32} (Issuer
+     * Public Key Exponent) respectively, as read from the card.
+     * <p>
+     * The implementation performs RSA recovery {@code cert^e mod n} under
+     * the supplied CA public key and validates every field EMV mandates:
+     * recovered data header {@code 0x6A}, certificate format {@code 0x02},
+     * trailer {@code 0xBC}, hash algorithm indicator, public key algorithm
+     * indicator, length consistency, SHA-1 hash over the cert payload +
+     * remainder + exponent, certificate expiration date against the
+     * current system clock, and (when {@code pan} is non-null) issuer
+     * identifier match with the leftmost PAN digits.
+     * <p>
+     * <b>Every validation is a hard failure</b>: any inconsistency throws
+     * {@link SMException} with a message naming the failed step, and no
+     * partial result is returned. Callers who need lenient behavior
+     * (e.g. recovering keys from expired certs for forensics) should
+     * pre-process inputs rather than catching exceptions.
+     * <p>
+     * <b>Algorithm support</b>: the JCE adapter currently implements only
+     * hash algorithm indicator {@code 0x01} (SHA-1) and public key
+     * algorithm indicator {@code 0x01} (RSA). Other indicators raise
+     * {@link SMException}; support can be extended when EMV consumers
+     * need SHA-256 variants.
+     *
+     * @param caPublicKey the CA public key, identified per scheme by its
+     *        RID + index
+     * @param issuerPublicKeyCertificate EMV tag {@code 0x90} contents;
+     *        length must equal the CA modulus length in bytes
+     * @param issuerPublicKeyRemainder EMV tag {@code 0x92} contents, or
+     *        {@code null} / empty when the issuer modulus fits entirely
+     *        inside the certificate
+     * @param issuerPublicKeyExponent EMV tag {@code 0x9F32} contents
+     * @param pan the cardholder PAN, used to verify the issuer identifier
+     *        embedded in the certificate; if {@code null} or empty, the
+     *        issuer-identifier check is skipped (useful for diagnostic
+     *        recovery without a card context)
+     * @return the recovered Issuer Public Key
+     * @throws SMException on RSA recovery failure or any EMV validation
+     *         failure (header, format, trailer, lengths, hash, expiration,
+     *         issuer identifier, unsupported algorithm indicator)
+     */
+    EMVIssuerPublicKey recoverIssuerPublicKey(
+            EMVCAPublicKey caPublicKey,
+            byte[] issuerPublicKeyCertificate,
+            byte[] issuerPublicKeyRemainder,
+            byte[] issuerPublicKeyExponent,
+            String pan) throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -1,0 +1,89 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+/**
+ * Extension of {@link SMAdapter} that adds public APIs for EMV cryptographic
+ * primitives whose computations already exist inside jPOS but are not yet
+ * exposed for direct generation use.
+ * <p>
+ * Methods declared here are <b>generation counterparts</b> of existing
+ * verification methods on {@link SMAdapter}. The values returned must satisfy
+ * the corresponding verifier; that is, for any valid set of inputs:
+ * <ul>
+ *   <li>{@link #generateCVC3} must produce a CVC3 accepted by
+ *       {@link SMAdapter#verifyCVC3};
+ *   <li>{@link #generatedCVV} must produce a dCVV accepted by
+ *       {@link SMAdapter#verifydCVV}.
+ * </ul>
+ * <p>
+ * Implementations that cannot perform a given operation should leave the
+ * default {@link BaseSMAdapter} implementation in place, which throws
+ * {@link SMException}.
+ *
+ * @param <T> the SecureKey implementation type
+ */
+public interface EMVSMAdapter<T> extends SMAdapter<T> {
+
+    /**
+     * Generate a Dynamic Card Verification Code 3 (CVC3).
+     * <p>
+     * This is the generation counterpart of
+     * {@link #verifyCVC3(Object, String, String, byte[], byte[], byte[], MKDMethod, String)}.
+     * Inputs have the same semantics; the result is the full 5-digit CVC3
+     * string that the verifier would compute internally.
+     *
+     * @param imkcvc3 issuer master key for CVC3, encrypted under the LMK
+     * @param accountNo account number including BIN and check digit
+     * @param acctSeqNo account sequence number, 2 decimal digits, or {@code null}
+     * @param atc application transaction counter (2 bytes)
+     * @param upn unpredictable number (4 bytes)
+     * @param data static track data, or a pre-computed 2-byte IVCVC3
+     * @param mkdm ICC master-key derivation method; if {@code null},
+     *        {@link MKDMethod#OPTION_A} is used
+     * @return the 5-digit CVC3 (zero-padded on the left if numerically short)
+     * @throws SMException on security module error
+     */
+    String generateCVC3(T imkcvc3, String accountNo, String acctSeqNo,
+                        byte[] atc, byte[] upn, byte[] data, MKDMethod mkdm)
+            throws SMException;
+
+    /**
+     * Generate a Dynamic Card Verification Value (dCVV).
+     * <p>
+     * This is the generation counterpart of
+     * {@link #verifydCVV(String, Object, String, String, String, byte[], MKDMethod)}.
+     * Inputs have the same semantics; the result is the dCVV string that the
+     * verifier would compute internally.
+     *
+     * @param accountNo account number including BIN and check digit
+     * @param imkac issuer master key for application cryptograms, encrypted
+     *        under the LMK
+     * @param expDate card expiration date as {@code yyMM}
+     * @param serviceCode 3-digit service code
+     * @param atc application transaction counter (2 bytes)
+     * @param mkdm ICC master-key derivation method; if {@code null},
+     *        {@link MKDMethod#OPTION_A} is used
+     * @return the dCVV string
+     * @throws SMException on security module error
+     */
+    String generatedCVV(String accountNo, T imkac, String expDate,
+                        String serviceCode, byte[] atc, MKDMethod mkdm)
+            throws SMException;
+}

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -335,4 +335,75 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
      * @throws SMException on security module error
      */
     byte[] generateSM_MAC(T sessionKey, byte[] data) throws SMException;
+
+    /**
+     * Encrypt a PIN block for Secure Messaging directly under a supplied
+     * SM session encryption key.
+     * <p>
+     * This is the SM-PIN-encrypt half of the integrated
+     * {@link SMAdapter#translatePINGenerateSM_MAC translatePINGenerateSM_MAC},
+     * exposed as a stand-alone primitive. The caller supplies the SK-SMC
+     * directly — typically the output of
+     * {@link #deriveSecureMessagingSessionKey(MKDMethod, SKDMethod, Object, String, String, byte[], byte[])}
+     * with an IMK-SMC — and the new PIN already encrypted under an existing
+     * key {@code kd1}. The method translates the PIN into
+     * {@code destinationPINBlockFormat} and re-encrypts it under the
+     * SK-SMC for transmission to the card in an issuer script.
+     * <p>
+     * Composability:
+     * <pre>
+     *   EMVDerivedKey&lt;T&gt; udkAc  = deriveICCMasterKey(mkdm, imkAc,  pan, psn);  // FORMAT41/42 only
+     *   EMVDerivedKey&lt;T&gt; udkSmc = deriveICCMasterKey(mkdm, imkSmc, pan, psn);  // not strictly needed; PR 7 below does its own derivation
+     *   EMVDerivedKey&lt;T&gt; skSmc  = deriveSecureMessagingSessionKey(
+     *           mkdm, skdm, imkSmc, pan, psn, atc, arqc);
+     *   EncryptedPIN     enc    = encryptSecureMessagingPIN(
+     *           skSmc.key(), newPIN, kd1, destinationPINBlockFormat,
+     *           paddingMethod, currentPIN, udkAc.key());
+     * </pre>
+     * <p>
+     * Per-format input requirements:
+     * <ul>
+     *   <li>{@code FORMAT34}, {@code FORMAT35} (EMV / Mastercard): only
+     *       {@code sessionKey}, {@code newPIN}, {@code kd1},
+     *       {@code destinationPINBlockFormat}, {@code paddingMethod} are
+     *       used. {@code currentPIN} and {@code udkAc} may be {@code null}.
+     *   <li>{@code FORMAT41} (Visa, new PIN only): {@code udkAc} is
+     *       required (used as the PAN-like diversifier in the PIN block).
+     *       {@code currentPIN} may be {@code null}.
+     *   <li>{@code FORMAT42} (Visa, PIN change with current PIN): both
+     *       {@code currentPIN} and {@code udkAc} are required.
+     * </ul>
+     * <p>
+     * If {@code paddingMethod} is {@code null}, {@link PaddingMethod#MCHIP}
+     * is used (no SM-specific padding added). The integrated
+     * {@code translatePINGenerateSM_MAC} auto-derives padding from the
+     * SKDMethod; this direct method has no SKDMethod context, so the
+     * caller picks.
+     *
+     * @param sessionKey the SM session encryption key (SK-SMC), wrapped
+     *        per the adapter's convention
+     * @param newPIN the PIN currently wrapped under {@code kd1}
+     * @param kd1 the key currently wrapping {@code newPIN}
+     * @param destinationPINBlockFormat the target PIN block format
+     *        (e.g. {@link SMAdapter#FORMAT34}, {@link SMAdapter#FORMAT35},
+     *        {@link SMAdapter#FORMAT41}, {@link SMAdapter#FORMAT42})
+     * @param paddingMethod the SM padding method; {@code null} defaults to
+     *        {@link PaddingMethod#MCHIP}
+     * @param currentPIN the current PIN wrapped under {@code kd1};
+     *        required only for {@link SMAdapter#FORMAT42}, otherwise
+     *        may be {@code null}
+     * @param udkAc the ICC AC Master Key (typically the output of
+     *        {@link #deriveICCMasterKey} with an IMK-AC), wrapped per the
+     *        adapter's convention; required only for
+     *        {@link SMAdapter#FORMAT41} and {@link SMAdapter#FORMAT42},
+     *        otherwise may be {@code null}
+     * @return the PIN re-encrypted under the SK-SMC in
+     *         {@code destinationPINBlockFormat}
+     * @throws SMException on security module error
+     * @see SMAdapter#translatePINGenerateSM_MAC
+     * @see SMAdapter#translatePIN
+     */
+    EncryptedPIN encryptSecureMessagingPIN(T sessionKey, EncryptedPIN newPIN,
+            T kd1, byte destinationPINBlockFormat, PaddingMethod paddingMethod,
+            EncryptedPIN currentPIN, T udkAc) throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -577,4 +577,53 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
             EMVIssuerPublicKey issuerPublicKey,
             byte[] signedStaticApplicationData,
             byte[] staticApplicationData) throws SMException;
+
+    /**
+     * Verify EMV Signed Dynamic Application Data (SDAD, tag {@code 0x9F4B})
+     * returned by the card from INTERNAL AUTHENTICATE, per EMV 4.4 Book 2
+     * §6.5, and return the ICC Dynamic Number the card signed inside it.
+     * <p>
+     * DDA proves the card holds the ICC private key — a stronger signal
+     * than SDA (which only proves the issuer signed static records). The
+     * natural caller flow chains all three offline-auth recovery steps:
+     * <pre>
+     *   EMVIssuerPublicKey issuer = recoverIssuerPublicKey(ca, issuerCert,
+     *           issuerRemainder, issuerExp, pan);
+     *   EMVICCPublicKey    icc    = recoverICCPublicKey(issuer, iccCert,
+     *           iccRemainder, iccExp, staticApplicationData, pan);
+     *   byte[]             dyn    = verifyDDA(icc, sdad, ddolData);
+     * </pre>
+     * <p>
+     * The implementation performs RSA recovery {@code sdad^e mod n} under
+     * the ICC public key and validates the recovered structure:
+     * header {@code 0x6A}, signed-data-format {@code 0x05} (distinct from
+     * {@code 0x03} for SSAD), trailer {@code 0xBC}, hash algorithm
+     * indicator, LDD and LDN sanity (the latter must fall in
+     * {@code [2, 8]} per EMV §6.5.2), mandatory {@code 0xBB} pad pattern,
+     * and a SHA-1 hash over the recovered payload (minus header / hash /
+     * trailer) concatenated with the supplied DDOL bytes.
+     * <p>
+     * <b>Pad pattern check is mandatory</b> — same rationale as
+     * {@link #verifySDA}.
+     * <p>
+     * <b>Caller is responsible for DDOL assembly.</b> Per EMV §10.4, the
+     * terminal builds DDOL by substituting its data elements into the
+     * card-supplied DDOL template (tag {@code 0x9F49}). That assembly is
+     * application policy, outside this method's scope — the verify
+     * method consumes whatever bytes the caller passes.
+     *
+     * @param iccPublicKey the recovered ICC Public Key (typically the
+     *        output of {@link #recoverICCPublicKey})
+     * @param signedDynamicApplicationData EMV tag {@code 0x9F4B} contents;
+     *        length must equal the ICC modulus length
+     * @param ddolData the DDOL bytes the terminal sent to INTERNAL
+     *        AUTHENTICATE — same bytes the card hashed when signing
+     * @return the ICC Dynamic Number (variable length, 2 to 8 bytes)
+     * @throws SMException on RSA recovery failure or any EMV validation
+     *         failure
+     */
+    byte[] verifyDDA(
+            EMVICCPublicKey iccPublicKey,
+            byte[] signedDynamicApplicationData,
+            byte[] ddolData) throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -526,4 +526,55 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
             byte[] iccPublicKeyExponent,
             byte[] staticApplicationData,
             String pan) throws SMException;
+
+    /**
+     * Verify EMV Signed Static Application Data (SSAD, tag {@code 0x93})
+     * per EMV 4.4 Book 2 §5.4 and return the Data Authentication Code
+     * (DAC) the issuer embedded in the signed payload.
+     * <p>
+     * The natural caller flow chains this with PR 9's
+     * {@link #recoverIssuerPublicKey(EMVCAPublicKey, byte[], byte[], byte[], String)}:
+     * <pre>
+     *   EMVIssuerPublicKey issuer = recoverIssuerPublicKey(ca, issuerCert,
+     *           issuerRemainder, issuerExp, pan);
+     *   byte[]             dac    = verifySDA(issuer, ssad, staticApplicationData);
+     *   // store dac in EMV tag 0x9F45 for subsequent transaction data
+     * </pre>
+     * <p>
+     * The implementation performs RSA recovery {@code ssad^e mod n}
+     * under the supplied issuer public key and validates the recovered
+     * structure: header {@code 0x6A}, signed-data-format {@code 0x03}
+     * (distinct from {@code 0x02} for issuer certificates and
+     * {@code 0x04} for ICC certificates), trailer {@code 0xBC}, hash
+     * algorithm indicator, mandatory {@code 0xBB} pad pattern, and a
+     * SHA-1 hash over (signed-data-format + hash-alg + DAC + pad-pattern)
+     * concatenated with the supplied Static Application Data.
+     * <p>
+     * <b>Pad pattern check is mandatory.</b> EMV §5.4 lists this under
+     * structural verification guidance; this adapter treats any
+     * deviation from {@code 0xBB} as a hard failure rather than hiding a
+     * card conformance defect. Callers needing lenient behavior should
+     * pre-process the SSAD.
+     * <p>
+     * <b>Caller assembles SAD.</b> Per EMV Book 3 §10.3, terminals
+     * concatenate the records identified by the AFL plus (optionally)
+     * the Static Data Authentication Tag List. That assembly is
+     * application policy, outside this method's scope — the verify
+     * method consumes whatever bytes the caller passes.
+     *
+     * @param issuerPublicKey the recovered Issuer Public Key (typically
+     *        the output of {@link #recoverIssuerPublicKey})
+     * @param signedStaticApplicationData EMV tag {@code 0x93} contents;
+     *        length must equal the issuer modulus length
+     * @param staticApplicationData the SAD bytes assembled per EMV
+     *        Book 3 §10.3 — same bytes the issuer hashed when signing
+     * @return the 2-byte Data Authentication Code (to be stored in EMV
+     *         tag {@code 0x9F45})
+     * @throws SMException on RSA recovery failure or any EMV
+     *         validation failure
+     */
+    byte[] verifySDA(
+            EMVIssuerPublicKey issuerPublicKey,
+            byte[] signedStaticApplicationData,
+            byte[] staticApplicationData) throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -249,4 +249,56 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
     byte[] generateARPC(T key, byte[] arqc, ARPCMethod arpcMethod,
                         byte[] arc, byte[] propAuthData)
             throws SMException;
+
+    /**
+     * Derive an EMV Secure Messaging session key from a Secure Messaging
+     * Issuer Master Key (IMK-SMI or IMK-SMC), the cardholder PAN/PSN, and
+     * the per-session diversifier.
+     * <p>
+     * The same algorithm computes both the integrity key (SK-SMI) and the
+     * confidentiality key (SK-SMC); only the input IMK differs. Pass
+     * {@code imk-smi} to get SK-SMI for MACing issuer scripts, or
+     * {@code imk-smc} to get SK-SMC for PIN-block encryption. The derived
+     * key inherits the IMK's {@code keyType} and {@code keyLength}, so the
+     * usage family carries through to the returned {@link SecureKey}.
+     * <p>
+     * Per-{@code skdm} input usage:
+     * <ul>
+     *   <li>{@link SKDMethod#VSDC} — uses {@code atc} as a 2-byte
+     *       diversifier; {@code arqc} is ignored and may be {@code null}.
+     *   <li>{@link SKDMethod#MCHIP} and {@link SKDMethod#EMV_CSKD} — use
+     *       {@code arqc} as an 8-byte diversifier (typically the ARQC
+     *       itself for the first script, then {@code ARQC + n} for
+     *       subsequent scripts); {@code atc} is ignored and may be
+     *       {@code null}.
+     * </ul>
+     * <p>
+     * <b>Note on dispatch:</b> SM session-key derivation is <i>not</i> the
+     * same algorithm as AC session-key derivation. In particular, MCHIP
+     * uses {@code deriveSK_MK(atc, upn)} for AC (see
+     * {@link #deriveEMVSessionKey}) but {@code deriveCommonSK_SM(arqc)}
+     * for SM. Use the right method for the right purpose.
+     *
+     * @param mkdm ICC Master Key Derivation Method. If {@code null},
+     *        {@link MKDMethod#OPTION_A} is used.
+     * @param skdm Session Key Derivation Method
+     * @param imk the SM Issuer Master Key — pass IMK-SMI for SK-SMI or
+     *        IMK-SMC for SK-SMC
+     * @param pan account number including BIN and check digit
+     * @param psn PAN Sequence Number, 2 decimal digits; if {@code null} or
+     *        empty, treated as {@code "00"}
+     * @param atc Application Transaction Counter (2 bytes). Used only for
+     *        {@link SKDMethod#VSDC}.
+     * @param arqc the per-session diversifier (8 bytes). Used only for
+     *        {@link SKDMethod#MCHIP} and {@link SKDMethod#EMV_CSKD}.
+     * @return the derived SM session key paired with its 3-byte KCV
+     * @throws SMException on security module error or if {@code skdm} is
+     *         not supported
+     * @see SMAdapter#generateSM_MAC
+     * @see SMAdapter#translatePINGenerateSM_MAC
+     */
+    EMVDerivedKey<T> deriveSecureMessagingSessionKey(MKDMethod mkdm, SKDMethod skdm,
+                                                    T imk, String pan, String psn,
+                                                    byte[] atc, byte[] arqc)
+            throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
+++ b/jpos/src/main/java/org/jpos/security/EMVSMAdapter.java
@@ -460,4 +460,70 @@ public interface EMVSMAdapter<T> extends SMAdapter<T> {
             byte[] issuerPublicKeyRemainder,
             byte[] issuerPublicKeyExponent,
             String pan) throws SMException;
+
+    /**
+     * Recover an ICC Public Key from an EMV ICC Public Key Certificate
+     * signed by the issuer, per EMV 4.4 Book 2 §6.4.
+     * <p>
+     * The certificate, remainder, exponent, and static application data
+     * inputs correspond to EMV tags {@code 0x9F46} (ICC Public Key
+     * Certificate), {@code 0x9F48} (ICC Public Key Remainder, optional),
+     * {@code 0x9F47} (ICC Public Key Exponent), and the Static Application
+     * Data assembled by the terminal per EMV Book 3 §10.3.
+     * <p>
+     * The natural caller flow is to chain this with
+     * {@link #recoverIssuerPublicKey(EMVCAPublicKey, byte[], byte[], byte[], String)}:
+     * <pre>
+     *   EMVIssuerPublicKey issuer = recoverIssuerPublicKey(ca, issuerCert,
+     *           issuerRemainder, issuerExp, pan);
+     *   EMVICCPublicKey    icc    = recoverICCPublicKey(issuer, iccCert,
+     *           iccRemainder, iccExp, staticApplicationData, pan);
+     * </pre>
+     * <p>
+     * The implementation performs RSA recovery {@code cert^e mod n} under
+     * the supplied <i>issuer</i> public key and validates every field EMV
+     * mandates: recovered data header {@code 0x6A}, certificate format
+     * {@code 0x04} (note: differs from the issuer cert format {@code 0x02}),
+     * trailer {@code 0xBC}, hash algorithm indicator, public key algorithm
+     * indicator, length consistency, SHA-1 hash over the cert payload +
+     * remainder + exponent <b>+ Static Application Data</b>, certificate
+     * expiration date against the current system clock, and (when {@code pan}
+     * is non-null) Application PAN match.
+     * <p>
+     * The SAD inclusion in the hash input is the key semantic difference
+     * vs. issuer certificate recovery — it's how the issuer cryptographically
+     * commits the ICC public key to a specific set of card records. Passing
+     * a different SAD at recovery time than was used at certificate creation
+     * causes the hash validation step to fail.
+     * <p>
+     * Every validation is a hard failure (see
+     * {@link #recoverIssuerPublicKey} for the same model). The JCE adapter
+     * currently supports hash algorithm indicator {@code 0x01} (SHA-1) and
+     * public key algorithm indicator {@code 0x01} (RSA) only.
+     *
+     * @param issuerPublicKey the recovered Issuer Public Key, typically
+     *        the output of {@link #recoverIssuerPublicKey}
+     * @param iccPublicKeyCertificate EMV tag {@code 0x9F46} contents;
+     *        length must equal the issuer modulus length in bytes
+     * @param iccPublicKeyRemainder EMV tag {@code 0x9F48} contents, or
+     *        {@code null} / empty when the ICC modulus fits entirely
+     *        inside the certificate
+     * @param iccPublicKeyExponent EMV tag {@code 0x9F47} contents
+     * @param staticApplicationData the data assembled per EMV Book 3
+     *        §10.3 (records read from the AFL, optionally followed by the
+     *        Static Data Authentication Tag List); included in the SHA-1
+     *        hash validation
+     * @param pan the cardholder PAN; if {@code null} or empty, the
+     *        Application PAN check is skipped
+     * @return the recovered ICC Public Key
+     * @throws SMException on RSA recovery failure or any EMV validation
+     *         failure
+     */
+    EMVICCPublicKey recoverICCPublicKey(
+            EMVIssuerPublicKey issuerPublicKey,
+            byte[] iccPublicKeyCertificate,
+            byte[] iccPublicKeyRemainder,
+            byte[] iccPublicKeyExponent,
+            byte[] staticApplicationData,
+            String pan) throws SMException;
 }

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1385,6 +1385,8 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
         require(issuerPublicKeyExponent.length == ipkExpLen,
                 "Issuer Public Key exponent length mismatch: declared " + ipkExpLen
                 + " but supplied " + issuerPublicKeyExponent.length);
+        requirePadPattern(recovered, 15 + ipkInCert, nca - 21,
+                "Issuer Public Key Certificate");
 
         // 8. Hash validation: SHA-1(recovered[1..nca-22] || remainder || exponent)
         byte[] hashInCert = Arrays.copyOfRange(recovered, nca - 21, nca - 1);
@@ -1438,6 +1440,16 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
 
     private static void require(boolean condition, String msg) throws SMException {
         if (!condition) throw new SMException(msg);
+    }
+
+    private static void requirePadPattern(byte[] data, int from, int to, String label)
+            throws SMException {
+        for (int i = from; i < to; i++) {
+            if (data[i] != (byte) 0xBB)
+                throw new SMException("Invalid " + label + " pad pattern at offset " + i
+                        + ": expected 0xBB but got 0x"
+                        + String.format("%02X", data[i] & 0xff));
+        }
     }
 
     private static void requireExpirationFuture(byte[] mmyy) throws SMException {
@@ -1538,6 +1550,8 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
         require(iccPublicKeyExponent.length == iccExpLen,
                 "ICC Public Key exponent length mismatch: declared " + iccExpLen
                 + " but supplied " + iccPublicKeyExponent.length);
+        requirePadPattern(recovered, 21 + iccInCert, ni - 21,
+                "ICC Public Key Certificate");
 
         // 8. Hash validation — input includes Static Application Data
         byte[] hashInCert = Arrays.copyOfRange(recovered, ni - 21, ni - 1);
@@ -1717,6 +1731,9 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
         int ldn = recovered[4] & 0xff;
         require(ldn >= 2 && ldn <= 8,
                 "Invalid ICC Dynamic Number Length: " + ldn + " (must be 2..8 per EMV 4.4 Book 2 §6.5.2)");
+        require(ldd == ldn + 1,
+                "Invalid DDA ICC Dynamic Data Length: " + ldd
+                + " (must be LDN + 1 = " + (ldn + 1) + " per EMV 4.4 Book 2 §6.5.2)");
 
         // 8. Pad pattern: bytes (4 + ldd) .. (nic - 21) must all be 0xBB
         for (int i = 4 + ldd; i < nic - 21; i++) {

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1588,6 +1588,91 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     @Override
+    protected EMVCDAResult verifyCDAImpl(EMVICCPublicKey icc,
+            byte[] sdad, byte[] un, byte[] ac, byte[] transactionData) throws SMException {
+
+        if (icc == null || icc.modulus() == null || icc.exponent() == null)
+            throw new SMException("ICC Public Key is missing modulus or exponent");
+        if (sdad == null)
+            throw new SMException("Signed Dynamic Application Data (EMV tag 0x9F4B) is required");
+        if (un == null || un.length != 4)
+            throw new SMException("Unpredictable Number must be 4 bytes");
+        if (ac == null || ac.length != 8)
+            throw new SMException("Application Cryptogram must be 8 bytes");
+
+        int nic = icc.modulus().length;
+        if (sdad.length != nic)
+            throw new SMException("SDAD length (" + sdad.length
+                    + ") must equal ICC modulus length (" + nic + ")");
+        if (nic < 26)
+            throw new SMException("ICC modulus too small for CDA SDAD (need at least 26 bytes, got " + nic + ")");
+
+        // 1. RSA recovery
+        BigInteger n = new BigInteger(1, icc.modulus());
+        BigInteger e = new BigInteger(1, icc.exponent());
+        byte[] recovered = bigIntegerToFixedLengthBytes(
+                new BigInteger(1, sdad).modPow(e, n), nic);
+
+        // 2-5. Header / format / trailer / hash algo
+        require(recovered[0] == (byte) 0x6A,
+                "Invalid recovered data header: expected 0x6A but got 0x"
+                + String.format("%02X", recovered[0] & 0xff));
+        require(recovered[1] == (byte) 0x05,
+                "Invalid signed data format: expected 0x05 (Signed Dynamic Application Data) but got 0x"
+                + String.format("%02X", recovered[1] & 0xff));
+        require(recovered[nic - 1] == (byte) 0xBC,
+                "Invalid recovered data trailer: expected 0xBC but got 0x"
+                + String.format("%02X", recovered[nic - 1] & 0xff));
+        require(recovered[2] == (byte) 0x01,
+                "Unsupported hash algorithm indicator: only SHA-1 (0x01) is currently supported (got 0x"
+                + String.format("%02X", recovered[2] & 0xff) + ")");
+
+        // 6-7. CDA structural sanity
+        int ldd = recovered[3] & 0xff;
+        int ldn = recovered[4] & 0xff;
+        require(ldn >= 2 && ldn <= 8,
+                "Invalid ICC Dynamic Number Length: " + ldn + " (must be 2..8 per EMV §6.5.2)");
+        require(ldd == ldn + 30,
+                "Invalid CDA ICC Dynamic Data Length: " + ldd
+                + " (must be LDN + 30 = " + (ldn + 30) + " per EMV §6.6.2)");
+
+        // 8. CDA dynamic data must fit before the 20-byte hash and trailer
+        require(4 + ldd <= nic - 21,
+                "CDA dynamic data does not fit in cert: 4 + " + ldd + " > " + (nic - 21));
+
+        // 9. Pad pattern: bytes (4 + ldd) .. (nic - 21) must all be 0xBB
+        for (int i = 4 + ldd; i < nic - 21; i++) {
+            if (recovered[i] != (byte) 0xBB)
+                throw new SMException("Invalid CDA pad pattern at offset " + i
+                        + ": expected 0xBB but got 0x" + String.format("%02X", recovered[i] & 0xff));
+        }
+
+        // 10. Hash validation: SHA-1(recovered[1..nic-21) || UN)
+        byte[] hashInCert = Arrays.copyOfRange(recovered, nic - 21, nic - 1);
+        byte[] hashInput  = Arrays.copyOfRange(recovered, 1, nic - 21);
+        hashInput = ISOUtil.concat(hashInput, un);
+        byte[] computedHash = SHA1_MESSAGE_DIGEST.digest(hashInput);
+        require(Arrays.equals(hashInCert, computedHash),
+                "CDA SDAD hash validation failed");
+
+        // 11. AC binding: SDAD-embedded AC must equal supplied AC
+        byte cid = recovered[5 + ldn];
+        byte[] acInSDAD = Arrays.copyOfRange(recovered, 5 + ldn + 1, 5 + ldn + 9);
+        require(Arrays.equals(acInSDAD, ac),
+                "CDA Application Cryptogram binding failed: SDAD-embedded AC does not match supplied AC");
+
+        // 12. Transaction Data Hash binding
+        byte[] txnHashInSDAD = Arrays.copyOfRange(recovered, 5 + ldn + 9, 5 + ldn + 29);
+        byte[] computedTxnHash = SHA1_MESSAGE_DIGEST.digest(
+                transactionData == null ? new byte[0] : transactionData);
+        require(Arrays.equals(txnHashInSDAD, computedTxnHash),
+                "CDA Transaction Data Hash binding failed");
+
+        byte[] iccDyn = Arrays.copyOfRange(recovered, 5, 5 + ldn);
+        return new EMVCDAResult(iccDyn, cid);
+    }
+
+    @Override
     protected byte[] verifyDDAImpl(EMVICCPublicKey icc,
             byte[] sdad, byte[] ddolData) throws SMException {
 

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1478,6 +1478,116 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     @Override
+    protected EMVICCPublicKey recoverICCPublicKeyImpl(
+            EMVIssuerPublicKey issuer,
+            byte[] iccPublicKeyCertificate,
+            byte[] iccPublicKeyRemainder,
+            byte[] iccPublicKeyExponent,
+            byte[] staticApplicationData,
+            String pan) throws SMException {
+
+        if (issuer == null || issuer.modulus() == null || issuer.exponent() == null)
+            throw new SMException("Issuer Public Key is missing modulus or exponent");
+        if (iccPublicKeyCertificate == null)
+            throw new SMException("ICC Public Key Certificate (EMV tag 0x9F46) is required");
+        if (iccPublicKeyExponent == null || iccPublicKeyExponent.length == 0)
+            throw new SMException("ICC Public Key Exponent (EMV tag 0x9F47) is required");
+
+        int ni = issuer.modulus().length;
+        if (iccPublicKeyCertificate.length != ni)
+            throw new SMException("ICC Public Key Certificate length (" + iccPublicKeyCertificate.length
+                    + ") must equal Issuer modulus length (" + ni + ")");
+        if (ni < 42)
+            throw new SMException("Issuer modulus too small for an EMV ICC certificate (need at least 42 bytes, got " + ni + ")");
+
+        // 1. RSA recovery under the issuer public key
+        BigInteger n = new BigInteger(1, issuer.modulus());
+        BigInteger e = new BigInteger(1, issuer.exponent());
+        BigInteger c = new BigInteger(1, iccPublicKeyCertificate);
+        byte[] recovered = bigIntegerToFixedLengthBytes(c.modPow(e, n), ni);
+
+        // 2-4. Header / format / trailer
+        require(recovered[0] == (byte) 0x6A,
+                "Invalid recovered data header: expected 0x6A but got 0x"
+                + String.format("%02X", recovered[0] & 0xff));
+        require(recovered[1] == (byte) 0x04,
+                "Invalid certificate format: expected 0x04 (ICC Public Key Certificate) but got 0x"
+                + String.format("%02X", recovered[1] & 0xff));
+        require(recovered[ni - 1] == (byte) 0xBC,
+                "Invalid recovered data trailer: expected 0xBC but got 0x"
+                + String.format("%02X", recovered[ni - 1] & 0xff));
+
+        // 5-6. Algorithm indicators (note offsets differ from PR 9: PAN is 10 bytes here)
+        byte hashInd = recovered[17];
+        byte pkInd   = recovered[18];
+        require(hashInd == (byte) 0x01,
+                "Unsupported hash algorithm indicator: only SHA-1 (0x01) is currently supported (got 0x"
+                + String.format("%02X", hashInd & 0xff) + ")");
+        require(pkInd == (byte) 0x01,
+                "Unsupported public key algorithm indicator: only RSA (0x01) is currently supported (got 0x"
+                + String.format("%02X", pkInd & 0xff) + ")");
+
+        // 7. Length consistency
+        int nic       = recovered[19] & 0xff;
+        int iccExpLen = recovered[20] & 0xff;
+        int iccInCert = Math.min(nic, ni - 42);
+        int remainderLen = iccPublicKeyRemainder == null ? 0 : iccPublicKeyRemainder.length;
+        require(iccInCert + remainderLen == nic,
+                "ICC Public Key length mismatch: in-cert " + iccInCert
+                + " + remainder " + remainderLen + " != declared NIC " + nic);
+        require(iccPublicKeyExponent.length == iccExpLen,
+                "ICC Public Key exponent length mismatch: declared " + iccExpLen
+                + " but supplied " + iccPublicKeyExponent.length);
+
+        // 8. Hash validation — input includes Static Application Data
+        byte[] hashInCert = Arrays.copyOfRange(recovered, ni - 21, ni - 1);
+        byte[] hashInput = Arrays.copyOfRange(recovered, 1, ni - 21);
+        if (remainderLen > 0)
+            hashInput = ISOUtil.concat(hashInput, iccPublicKeyRemainder);
+        hashInput = ISOUtil.concat(hashInput, iccPublicKeyExponent);
+        if (staticApplicationData != null && staticApplicationData.length > 0)
+            hashInput = ISOUtil.concat(hashInput, staticApplicationData);
+        byte[] computedHash = SHA1_MESSAGE_DIGEST.digest(hashInput);
+        require(Arrays.equals(hashInCert, computedHash),
+                "ICC Public Key Certificate hash validation failed");
+
+        // 9. Expiration date
+        byte[] expDate = Arrays.copyOfRange(recovered, 12, 14);
+        requireExpirationFuture(expDate);
+
+        // 10. Application PAN check (10 BCD bytes, F-padded)
+        byte[] certPan = Arrays.copyOfRange(recovered, 2, 12);
+        if (pan != null && !pan.isEmpty())
+            requirePanMatches(certPan, pan);
+
+        // Reconstruct full ICC public key modulus
+        byte[] modulus;
+        if (remainderLen == 0) {
+            modulus = Arrays.copyOfRange(recovered, 21, 21 + nic);
+        } else {
+            modulus = ISOUtil.concat(
+                    Arrays.copyOfRange(recovered, 21, 21 + iccInCert),
+                    iccPublicKeyRemainder);
+        }
+
+        return new EMVICCPublicKey(
+                certPan, expDate,
+                Arrays.copyOfRange(recovered, 14, 17),
+                modulus, iccPublicKeyExponent, hashInd, pkInd);
+    }
+
+    private static void requirePanMatches(byte[] certPan, String pan) throws SMException {
+        if (certPan == null || certPan.length != 10)
+            throw new SMException("Application PAN in ICC certificate must be 10 bytes");
+        // 10 bytes = 20 nibbles; strip trailing F-padding to recover the digit string.
+        String certHex = ISOUtil.hexString(certPan).toUpperCase();
+        String certDigits = certHex.replaceFirst("F+$", "");
+        if (!pan.equals(certDigits))
+            throw new SMException("Application PAN in ICC certificate ("
+                    + certDigits + ") does not match supplied PAN (" + pan + ")");
+    }
+
+    @Override
     protected Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MACImpl(
             MKDMethod mkdm, SKDMethod skdm, PaddingMethod padm, SecureDESKey imksmi
            ,String accountNo, String accntSeqNo, byte[] atc, byte[] arqc

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1105,6 +1105,13 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     @Override
+    protected byte[] generateApplicationCryptogramImpl(MKDMethod mkdm, SKDMethod skdm,
+            SecureDESKey imkac, String accountNo, String accntSeqNo, byte[] atc,
+            byte[] upn, byte[] txnData) throws SMException {
+        return calculateARQC(mkdm, skdm, imkac, accountNo, accntSeqNo, atc, upn, txnData);
+    }
+
+    @Override
     public byte[] generateARPCImpl(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
             ,String accountNo, String accntSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1112,6 +1112,17 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     @Override
+    protected EMVDerivedKey<SecureDESKey> deriveICCMasterKeyImpl(MKDMethod mkdm,
+            SecureDESKey imk, String pan, String psn) throws SMException {
+        if (mkdm == null)
+            mkdm = MKDMethod.OPTION_A;
+        byte[] panpsn = formatPANPSN(pan, psn, mkdm);
+        Key clearIcc = deriveICCMasterKey(decryptFromLMK(imk), panpsn);
+        SecureDESKey wrapped = encryptToLMK(imk.getKeyLength(), imk.getKeyType(), clearIcc);
+        return new EMVDerivedKey<>(wrapped, wrapped.getKeyCheckValue());
+    }
+
+    @Override
     public byte[] generateARPCImpl(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
             ,String accountNo, String accntSeqNo, byte[] arqc, byte[] atc, byte[] upn
             ,ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1011,7 +1011,7 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
      * @return derived 16-bytes Session Key with adjusted DES parity.
      * @throws JCEHandlerException
      */
-    private Key deriveCommonSK_AC(Key mkac, byte[] atc) throws JCEHandlerException {
+    protected Key deriveCommonSK_AC(Key mkac, byte[] atc) throws JCEHandlerException {
 
         byte[] r = new byte[8];
         System.arraycopy(atc, atc.length-2, r, 0, 2);
@@ -1031,7 +1031,7 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
      * @return derived 16-bytes Session Key with adjusted DES parity
      * @throws JCEHandlerException
      */
-    private Key deriveSK_MK(Key mkac, byte[] atc, byte[] upn) throws JCEHandlerException {
+    protected Key deriveSK_MK(Key mkac, byte[] atc, byte[] upn) throws JCEHandlerException {
 
         byte[] r = new byte[8];
         System.arraycopy(atc, atc.length-2, r, 0, 2);
@@ -1119,6 +1119,29 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
         byte[] panpsn = formatPANPSN(pan, psn, mkdm);
         Key clearIcc = deriveICCMasterKey(decryptFromLMK(imk), panpsn);
         SecureDESKey wrapped = encryptToLMK(imk.getKeyLength(), imk.getKeyType(), clearIcc);
+        return new EMVDerivedKey<>(wrapped, wrapped.getKeyCheckValue());
+    }
+
+    @Override
+    protected EMVDerivedKey<SecureDESKey> deriveEMVSessionKeyImpl(SKDMethod skdm,
+            SecureDESKey iccMk, byte[] atc, byte[] upn) throws SMException {
+        Key clearIcc = decryptFromLMK(iccMk);
+        Key clearSk;
+        switch (skdm) {
+            case VSDC:
+                clearSk = clearIcc;
+                break;
+            case MCHIP:
+                clearSk = deriveSK_MK(clearIcc, atc, upn);
+                break;
+            case EMV_CSKD:
+                clearSk = deriveCommonSK_AC(clearIcc, atc);
+                break;
+            default:
+                throw new SMException(
+                        "Session Key Derivation " + skdm + " not supported");
+        }
+        SecureDESKey wrapped = encryptToLMK(iccMk.getKeyLength(), iccMk.getKeyType(), clearSk);
         return new EMVDerivedKey<>(wrapped, wrapped.getKeyCheckValue());
     }
 

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1176,6 +1176,13 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     @Override
+    protected byte[] generateARPCImpl(SecureDESKey key, byte[] arqc,
+            ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
+            throws SMException {
+        return calculateARPC(decryptFromLMK(key), arqc, arpcMethod, arc, propAuthData);
+    }
+
+    @Override
     public byte[] verifyARQCGenerateARPCImpl(MKDMethod mkdm, SKDMethod skdm, SecureDESKey imkac
             ,String accountNo, String accntSeqNo, byte[] arqc, byte[] atc, byte[] upn 
             ,byte[] transData, ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -844,27 +844,6 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     /**
-     * Compute the 3-byte Key Check Value of a clear DES / Triple-DES key.
-     * <p>
-     * The KCV is the high-order three bytes of encrypting an 8-byte all-zero
-     * block with the supplied key — the standard "short" check value used
-     * across the payments industry to identify which clear key a wrapped key
-     * represents. No equivalent helper existed in {@code JCESecurityModule}
-     * before; this is introduced as foundation plumbing for the EMV
-     * key-derivation APIs (see {@link org.jpos.security.EMVDerivedKey}).
-     * <p>
-     * An AES variant (16-byte zero input) is intentionally not provided
-     * here; it can be added when AES Issuer Master Keys land in jPOS.
-     *
-     * @param key clear DES or Triple-DES key
-     * @return the 3-byte Key Check Value
-     * @throws JCEHandlerException on cryptographic failure
-     */
-    protected byte[] calculateKCV(Key key) throws JCEHandlerException {
-        return Arrays.copyOfRange(jceHandler.encryptData(new byte[8], key), 0, 3);
-    }
-
-    /**
      * Calculates a 4-digit PVV using the IBM 3624 algorithm.
      *
      * @param pinUnderLmk PIN block encrypted under the LMK

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -38,8 +38,10 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.*;
+import java.time.LocalDate;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1322,6 +1324,157 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
         Key clearUdk = (udkAc == null) ? null : decryptFromLMK(udkAc);
         return translatePINExt(currentPIN, newPIN, clearKd1, clearSk,
                 destinationPINBlockFormat, clearUdk, paddingMethod);
+    }
+
+    @Override
+    protected EMVIssuerPublicKey recoverIssuerPublicKeyImpl(
+            EMVCAPublicKey caPublicKey,
+            byte[] issuerPublicKeyCertificate,
+            byte[] issuerPublicKeyRemainder,
+            byte[] issuerPublicKeyExponent,
+            String pan) throws SMException {
+
+        if (caPublicKey == null || caPublicKey.modulus() == null || caPublicKey.exponent() == null)
+            throw new SMException("CA public key is missing modulus or exponent");
+        if (issuerPublicKeyCertificate == null)
+            throw new SMException("Issuer Public Key Certificate (EMV tag 0x90) is required");
+        if (issuerPublicKeyExponent == null || issuerPublicKeyExponent.length == 0)
+            throw new SMException("Issuer Public Key Exponent (EMV tag 0x9F32) is required");
+
+        int nca = caPublicKey.modulus().length;
+        if (issuerPublicKeyCertificate.length != nca)
+            throw new SMException("Issuer Public Key Certificate length (" + issuerPublicKeyCertificate.length
+                    + ") must equal CA modulus length (" + nca + ")");
+        if (nca < 36)
+            throw new SMException("CA modulus too small for an EMV issuer certificate (need at least 36 bytes, got " + nca + ")");
+
+        // 1. RSA recovery: cert^e mod n
+        BigInteger n = new BigInteger(1, caPublicKey.modulus());
+        BigInteger e = new BigInteger(1, caPublicKey.exponent());
+        BigInteger c = new BigInteger(1, issuerPublicKeyCertificate);
+        byte[] recovered = bigIntegerToFixedLengthBytes(c.modPow(e, n), nca);
+
+        // 2-4. Header / format / trailer
+        require(recovered[0] == (byte) 0x6A,
+                "Invalid recovered data header: expected 0x6A but got 0x" + String.format("%02X", recovered[0] & 0xff));
+        require(recovered[1] == (byte) 0x02,
+                "Invalid certificate format: expected 0x02 (Issuer Public Key Certificate) but got 0x"
+                + String.format("%02X", recovered[1] & 0xff));
+        require(recovered[nca - 1] == (byte) 0xBC,
+                "Invalid recovered data trailer: expected 0xBC but got 0x"
+                + String.format("%02X", recovered[nca - 1] & 0xff));
+
+        // 5-6. Algorithm indicators
+        byte hashInd = recovered[11];
+        byte pkInd   = recovered[12];
+        require(hashInd == (byte) 0x01,
+                "Unsupported hash algorithm indicator: only SHA-1 (0x01) is currently supported (got 0x"
+                + String.format("%02X", hashInd & 0xff) + ")");
+        require(pkInd == (byte) 0x01,
+                "Unsupported public key algorithm indicator: only RSA (0x01) is currently supported (got 0x"
+                + String.format("%02X", pkInd & 0xff) + ")");
+
+        // 7. Length consistency
+        int ni        = recovered[13] & 0xff;
+        int ipkExpLen = recovered[14] & 0xff;
+        int ipkInCert = Math.min(ni, nca - 36);
+        int remainderLen = issuerPublicKeyRemainder == null ? 0 : issuerPublicKeyRemainder.length;
+        require(ipkInCert + remainderLen == ni,
+                "Issuer Public Key length mismatch: in-cert " + ipkInCert
+                + " + remainder " + remainderLen + " != declared NI " + ni);
+        require(issuerPublicKeyExponent.length == ipkExpLen,
+                "Issuer Public Key exponent length mismatch: declared " + ipkExpLen
+                + " but supplied " + issuerPublicKeyExponent.length);
+
+        // 8. Hash validation: SHA-1(recovered[1..nca-22] || remainder || exponent)
+        byte[] hashInCert = Arrays.copyOfRange(recovered, nca - 21, nca - 1);
+        byte[] hashInput = Arrays.copyOfRange(recovered, 1, nca - 21);
+        if (remainderLen > 0)
+            hashInput = ISOUtil.concat(hashInput, issuerPublicKeyRemainder);
+        hashInput = ISOUtil.concat(hashInput, issuerPublicKeyExponent);
+        byte[] computedHash = SHA1_MESSAGE_DIGEST.digest(hashInput);
+        require(Arrays.equals(hashInCert, computedHash),
+                "Issuer Public Key Certificate hash validation failed");
+
+        // 9. Expiration date (MMYY BCD)
+        byte[] expDate = Arrays.copyOfRange(recovered, 6, 8);
+        requireExpirationFuture(expDate);
+
+        // 10. Issuer identifier check (skipped when pan is null/empty)
+        byte[] issuerId = Arrays.copyOfRange(recovered, 2, 6);
+        if (pan != null && !pan.isEmpty())
+            requireIssuerIdMatches(issuerId, pan);
+
+        // Reconstruct full issuer public key modulus (leftmost || remainder)
+        byte[] modulus;
+        if (remainderLen == 0) {
+            modulus = Arrays.copyOfRange(recovered, 15, 15 + ni);
+        } else {
+            modulus = ISOUtil.concat(
+                    Arrays.copyOfRange(recovered, 15, 15 + ipkInCert),
+                    issuerPublicKeyRemainder);
+        }
+
+        return new EMVIssuerPublicKey(
+                issuerId, expDate,
+                Arrays.copyOfRange(recovered, 8, 11),
+                modulus, issuerPublicKeyExponent, hashInd, pkInd);
+    }
+
+    private static byte[] bigIntegerToFixedLengthBytes(BigInteger value, int length) {
+        byte[] raw = value.toByteArray();
+        if (raw.length == length) return raw;
+        byte[] out = new byte[length];
+        if (raw.length > length) {
+            // BigInteger.toByteArray() prepends a 0x00 sign byte for positive
+            // numbers whose high bit is set; strip leading bytes.
+            System.arraycopy(raw, raw.length - length, out, 0, length);
+        } else {
+            // Left-pad with zeros to reach the declared length.
+            System.arraycopy(raw, 0, out, length - raw.length, raw.length);
+        }
+        return out;
+    }
+
+    private static void require(boolean condition, String msg) throws SMException {
+        if (!condition) throw new SMException(msg);
+    }
+
+    private static void requireExpirationFuture(byte[] mmyy) throws SMException {
+        if (mmyy == null || mmyy.length != 2)
+            throw new SMException("Expiration date must be 2 bytes (MMYY BCD)");
+        String hex = ISOUtil.hexString(mmyy);
+        int month, year;
+        try {
+            month = Integer.parseInt(hex.substring(0, 2));
+            year  = Integer.parseInt(hex.substring(2, 4));
+        } catch (NumberFormatException e) {
+            throw new SMException("Expiration date is not valid BCD: " + hex);
+        }
+        if (month < 1 || month > 12)
+            throw new SMException("Invalid expiration month in certificate: " + month + " (date " + hex + ")");
+        LocalDate now = LocalDate.now();
+        int nowYY = now.getYear() % 100;
+        int nowMM = now.getMonthValue();
+        // Compare YY then MM. Assumes 2-digit year is in the current century;
+        // EMV CA certs in practice are issued post-2010 so this holds for the
+        // foreseeable future.
+        int certKey = year * 100 + month;
+        int nowKey  = nowYY * 100 + nowMM;
+        if (certKey < nowKey)
+            throw new SMException("Issuer Public Key Certificate has expired (MM/YY: "
+                    + String.format("%02d", month) + "/" + String.format("%02d", year) + ")");
+    }
+
+    private static void requireIssuerIdMatches(byte[] issuerId, String pan) throws SMException {
+        if (issuerId == null || issuerId.length != 4)
+            throw new SMException("Issuer Identifier must be 4 bytes");
+        // 4 bytes = 8 hex nibbles; strip trailing F-padding to recover the BIN digits.
+        String idHex = ISOUtil.hexString(issuerId).toUpperCase();
+        String idDigits = idHex.replaceFirst("F+$", "");
+        if (!pan.startsWith(idDigits))
+            throw new SMException("Issuer Identifier in certificate ("
+                    + idHex + ") does not match PAN prefix");
     }
 
     @Override

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -844,6 +844,27 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     /**
+     * Compute the 3-byte Key Check Value of a clear DES / Triple-DES key.
+     * <p>
+     * The KCV is the high-order three bytes of encrypting an 8-byte all-zero
+     * block with the supplied key — the standard "short" check value used
+     * across the payments industry to identify which clear key a wrapped key
+     * represents. No equivalent helper existed in {@code JCESecurityModule}
+     * before; this is introduced as foundation plumbing for the EMV
+     * key-derivation APIs (see {@link org.jpos.security.EMVDerivedKey}).
+     * <p>
+     * An AES variant (16-byte zero input) is intentionally not provided
+     * here; it can be added when AES Issuer Master Keys land in jPOS.
+     *
+     * @param key clear DES or Triple-DES key
+     * @return the 3-byte Key Check Value
+     * @throws JCEHandlerException on cryptographic failure
+     */
+    protected byte[] calculateKCV(Key key) throws JCEHandlerException {
+        return Arrays.copyOfRange(jceHandler.encryptData(new byte[8], key), 0, 3);
+    }
+
+    /**
      * Calculates a 4-digit PVV using the IBM 3624 algorithm.
      *
      * @param pinUnderLmk PIN block encrypted under the LMK

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1311,6 +1311,20 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     @Override
+    protected EncryptedPIN encryptSecureMessagingPINImpl(SecureDESKey sessionKey,
+            EncryptedPIN newPIN, SecureDESKey kd1, byte destinationPINBlockFormat,
+            PaddingMethod paddingMethod, EncryptedPIN currentPIN, SecureDESKey udkAc)
+            throws SMException {
+        if (paddingMethod == null)
+            paddingMethod = PaddingMethod.MCHIP;
+        Key clearSk  = decryptFromLMK(sessionKey);
+        Key clearKd1 = decryptFromLMK(kd1);
+        Key clearUdk = (udkAc == null) ? null : decryptFromLMK(udkAc);
+        return translatePINExt(currentPIN, newPIN, clearKd1, clearSk,
+                destinationPINBlockFormat, clearUdk, paddingMethod);
+    }
+
+    @Override
     protected Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MACImpl(
             MKDMethod mkdm, SKDMethod skdm, PaddingMethod padm, SecureDESKey imksmi
            ,String accountNo, String accntSeqNo, byte[] atc, byte[] arqc

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -658,7 +658,7 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
      * @param d da to be padded
      * @return padded data
      */
-    private byte[] paddingISO9797Method2(byte[] d) {
+    protected byte[] paddingISO9797Method2(byte[] d) {
         //Padding - first byte 0x80 rest 0x00
         byte[] t = new byte[d.length - d.length%8 + 8];
         System.arraycopy(d, 0, t, 0, d.length);
@@ -675,7 +675,7 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
      * @return 8 byte of mac value
      * @throws JCEHandlerException
      */
-    private byte[] calculateMACISO9797Alg3(Key key, byte[] d) throws JCEHandlerException {
+    protected byte[] calculateMACISO9797Alg3(Key key, byte[] d) throws JCEHandlerException {
         Key kl = jceHandler.formDESKey(SMAdapter.LENGTH_DES
                             ,Arrays.copyOfRange(key.getEncoded(), 0, 8));
         Key kr = jceHandler.formDESKey(SMAdapter.LENGTH_DES
@@ -1301,6 +1301,13 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
             throw new SMException("Session Key Derivation "+skdm+" not supported");
         }
         return calculateMACISO9797Alg3(smi, data);
+    }
+
+    @Override
+    protected byte[] generateSM_MACImpl(SecureDESKey sessionKey, byte[] data) throws SMException {
+        Key clearSk = decryptFromLMK(sessionKey);
+        byte[] padded = paddingISO9797Method2(data);
+        return calculateMACISO9797Alg3(clearSk, padded);
     }
 
     @Override

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -959,7 +959,7 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
      * @return derived 16-bytes Session Key with adjusted DES parity
      * @throws JCEHandlerException
      */
-    private Key deriveSK_VISA(Key mkac, byte[] atc) throws JCEHandlerException {
+    protected Key deriveSK_VISA(Key mkac, byte[] atc) throws JCEHandlerException {
 
         byte[] skl = new byte[8];
         System.arraycopy(atc, atc.length-2, skl, 6, 2);
@@ -988,7 +988,7 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
      * @return derived 16-bytes Session Key with adjusted DES parity
      * @throws JCEHandlerException
      */
-    private Key deriveCommonSK_SM(Key mksm, byte[] rand) throws JCEHandlerException {
+    protected Key deriveCommonSK_SM(Key mksm, byte[] rand) throws JCEHandlerException {
       byte[] rl = Arrays.copyOf(rand,8);
       rl[2] = (byte)0xf0;
       byte[] skl = jceHandler.encryptData(rl, mksm);
@@ -1180,6 +1180,31 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
             ARPCMethod arpcMethod, byte[] arc, byte[] propAuthData)
             throws SMException {
         return calculateARPC(decryptFromLMK(key), arqc, arpcMethod, arc, propAuthData);
+    }
+
+    @Override
+    protected EMVDerivedKey<SecureDESKey> deriveSecureMessagingSessionKeyImpl(
+            MKDMethod mkdm, SKDMethod skdm, SecureDESKey imk,
+            String pan, String psn, byte[] atc, byte[] arqc) throws SMException {
+        if (mkdm == null)
+            mkdm = MKDMethod.OPTION_A;
+        byte[] panpsn = formatPANPSN(pan, psn, mkdm);
+        Key clearMk = deriveICCMasterKey(decryptFromLMK(imk), panpsn);
+        Key clearSk;
+        switch (skdm) {
+            case VSDC:
+                clearSk = deriveSK_VISA(clearMk, atc);
+                break;
+            case MCHIP:
+            case EMV_CSKD:
+                clearSk = deriveCommonSK_SM(clearMk, arqc);
+                break;
+            default:
+                throw new SMException(
+                        "Session Key Derivation " + skdm + " not supported");
+        }
+        SecureDESKey wrapped = encryptToLMK(imk.getKeyLength(), imk.getKeyType(), clearSk);
+        return new EMVDerivedKey<>(wrapped, wrapped.getKeyCheckValue());
     }
 
     @Override

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1588,6 +1588,72 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     @Override
+    protected byte[] verifyDDAImpl(EMVICCPublicKey icc,
+            byte[] sdad, byte[] ddolData) throws SMException {
+
+        if (icc == null || icc.modulus() == null || icc.exponent() == null)
+            throw new SMException("ICC Public Key is missing modulus or exponent");
+        if (sdad == null)
+            throw new SMException("Signed Dynamic Application Data (EMV tag 0x9F4B) is required");
+
+        int nic = icc.modulus().length;
+        if (sdad.length != nic)
+            throw new SMException("SDAD length (" + sdad.length
+                    + ") must equal ICC modulus length (" + nic + ")");
+        if (nic < 26)
+            throw new SMException("ICC modulus too small for SDAD (need at least 26 bytes, got " + nic + ")");
+
+        // 1. RSA recovery
+        BigInteger n = new BigInteger(1, icc.modulus());
+        BigInteger e = new BigInteger(1, icc.exponent());
+        byte[] recovered = bigIntegerToFixedLengthBytes(
+                new BigInteger(1, sdad).modPow(e, n), nic);
+
+        // 2-5. Header / format / trailer / hash algo
+        require(recovered[0] == (byte) 0x6A,
+                "Invalid recovered data header: expected 0x6A but got 0x"
+                + String.format("%02X", recovered[0] & 0xff));
+        require(recovered[1] == (byte) 0x05,
+                "Invalid signed data format: expected 0x05 (Signed Dynamic Application Data) but got 0x"
+                + String.format("%02X", recovered[1] & 0xff));
+        require(recovered[nic - 1] == (byte) 0xBC,
+                "Invalid recovered data trailer: expected 0xBC but got 0x"
+                + String.format("%02X", recovered[nic - 1] & 0xff));
+        require(recovered[2] == (byte) 0x01,
+                "Unsupported hash algorithm indicator: only SHA-1 (0x01) is currently supported (got 0x"
+                + String.format("%02X", recovered[2] & 0xff) + ")");
+
+        // 6. ICC Dynamic Data Length sanity
+        int ldd = recovered[3] & 0xff;
+        require(ldd >= 1 && ldd <= nic - 26,
+                "Invalid ICC Dynamic Data Length: " + ldd + " (must fit inside " + (nic - 25) + " bytes)");
+
+        // 7. ICC Dynamic Number Length sanity (EMV §6.5.2: 2..8)
+        int ldn = recovered[4] & 0xff;
+        require(ldn >= 2 && ldn <= 8,
+                "Invalid ICC Dynamic Number Length: " + ldn + " (must be 2..8 per EMV 4.4 Book 2 §6.5.2)");
+
+        // 8. Pad pattern: bytes (4 + ldd) .. (nic - 21) must all be 0xBB
+        for (int i = 4 + ldd; i < nic - 21; i++) {
+            if (recovered[i] != (byte) 0xBB)
+                throw new SMException("Invalid SDAD pad pattern at offset " + i
+                        + ": expected 0xBB but got 0x" + String.format("%02X", recovered[i] & 0xff));
+        }
+
+        // 9. Hash validation: SHA-1(recovered[1..nic-21) || DDOL)
+        byte[] hashInCert = Arrays.copyOfRange(recovered, nic - 21, nic - 1);
+        byte[] hashInput  = Arrays.copyOfRange(recovered, 1, nic - 21);
+        if (ddolData != null && ddolData.length > 0)
+            hashInput = ISOUtil.concat(hashInput, ddolData);
+        byte[] computedHash = SHA1_MESSAGE_DIGEST.digest(hashInput);
+        require(Arrays.equals(hashInCert, computedHash),
+                "SDAD hash validation failed");
+
+        // Return ICC Dynamic Number = recovered[5 .. 5+ldn)
+        return Arrays.copyOfRange(recovered, 5, 5 + ldn);
+    }
+
+    @Override
     protected byte[] verifySDAImpl(EMVIssuerPublicKey issuer,
             byte[] ssad, byte[] sad) throws SMException {
 

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -1588,6 +1588,62 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
     }
 
     @Override
+    protected byte[] verifySDAImpl(EMVIssuerPublicKey issuer,
+            byte[] ssad, byte[] sad) throws SMException {
+
+        if (issuer == null || issuer.modulus() == null || issuer.exponent() == null)
+            throw new SMException("Issuer Public Key is missing modulus or exponent");
+        if (ssad == null)
+            throw new SMException("Signed Static Application Data (EMV tag 0x93) is required");
+
+        int ni = issuer.modulus().length;
+        if (ssad.length != ni)
+            throw new SMException("SSAD length (" + ssad.length
+                    + ") must equal Issuer modulus length (" + ni + ")");
+        if (ni < 26)
+            throw new SMException("Issuer modulus too small for SSAD (need at least 26 bytes, got " + ni + ")");
+
+        // 1. RSA recovery
+        BigInteger n = new BigInteger(1, issuer.modulus());
+        BigInteger e = new BigInteger(1, issuer.exponent());
+        byte[] recovered = bigIntegerToFixedLengthBytes(
+                new BigInteger(1, ssad).modPow(e, n), ni);
+
+        // 2-5. Header / format / trailer / hash algo
+        require(recovered[0] == (byte) 0x6A,
+                "Invalid recovered data header: expected 0x6A but got 0x"
+                + String.format("%02X", recovered[0] & 0xff));
+        require(recovered[1] == (byte) 0x03,
+                "Invalid signed data format: expected 0x03 (Signed Static Application Data) but got 0x"
+                + String.format("%02X", recovered[1] & 0xff));
+        require(recovered[ni - 1] == (byte) 0xBC,
+                "Invalid recovered data trailer: expected 0xBC but got 0x"
+                + String.format("%02X", recovered[ni - 1] & 0xff));
+        require(recovered[2] == (byte) 0x01,
+                "Unsupported hash algorithm indicator: only SHA-1 (0x01) is currently supported (got 0x"
+                + String.format("%02X", recovered[2] & 0xff) + ")");
+
+        // 6. Pad pattern check: bytes 5..ni-21 must all be 0xBB
+        for (int i = 5; i < ni - 21; i++) {
+            if (recovered[i] != (byte) 0xBB)
+                throw new SMException("Invalid SSAD pad pattern at offset " + i
+                        + ": expected 0xBB but got 0x" + String.format("%02X", recovered[i] & 0xff));
+        }
+
+        // 7. Hash validation
+        byte[] hashInCert = Arrays.copyOfRange(recovered, ni - 21, ni - 1);
+        byte[] hashInput  = Arrays.copyOfRange(recovered, 1, ni - 21);
+        if (sad != null && sad.length > 0)
+            hashInput = ISOUtil.concat(hashInput, sad);
+        byte[] computedHash = SHA1_MESSAGE_DIGEST.digest(hashInput);
+        require(Arrays.equals(hashInCert, computedHash),
+                "SSAD hash validation failed");
+
+        // Return the 2-byte Data Authentication Code
+        return Arrays.copyOfRange(recovered, 3, 5);
+    }
+
+    @Override
     protected Pair<EncryptedPIN,byte[]> translatePINGenerateSM_MACImpl(
             MKDMethod mkdm, SKDMethod skdm, PaddingMethod padm, SecureDESKey imksmi
            ,String accountNo, String accntSeqNo, byte[] atc, byte[] arqc

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -582,6 +582,13 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
         return res.equals(dcvv);
     }
 
+    @Override
+    protected String generatedCVVImpl(String accountNo, SecureDESKey imkac,
+                     String expDate, String serviceCode, byte[] atc, MKDMethod mkdm)
+                     throws SMException {
+        return calculatedCVV(accountNo, imkac, expDate, serviceCode, atc, mkdm);
+    }
+
     /**
      * Computes the contactless CVC3 from the issuer master key, ATC, UPN, and track data.
      *
@@ -630,6 +637,13 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
         //get some last digits
         calcCVC3 = calcCVC3.substring(5-cvc3.length());
         return calcCVC3.equals(cvc3);
+    }
+
+    @Override
+    protected String generateCVC3Impl(SecureDESKey imkcvc3, String accountNo, String acctSeqNo,
+                     byte[] atc, byte[] upn, byte[] data, MKDMethod mkdm)
+                     throws SMException {
+        return calculateCVC3(imkcvc3, accountNo, acctSeqNo, atc, upn, data, mkdm);
     }
 
     private byte[] calculateIVCVC3(Key mkcvc3, byte[] data)

--- a/jpos/src/test/java/org/jpos/security/EMVCAPublicKeyTest.java
+++ b/jpos/src/test/java/org/jpos/security/EMVCAPublicKeyTest.java
@@ -1,0 +1,116 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jpos.iso.ISOUtil;
+import org.junit.jupiter.api.Test;
+
+public class EMVCAPublicKeyTest {
+
+    private static EMVCAPublicKey newKey() {
+        return new EMVCAPublicKey(
+                ISOUtil.hex2byte("A000000003"),                      // rid (Visa)
+                (byte) 0x07,                                          // index
+                ISOUtil.hex2byte("BCDEF012345678901122334455667788"), // modulus (16 bytes for test)
+                ISOUtil.hex2byte("03"),                               // exponent
+                (byte) 0x01,                                          // SHA-1
+                (byte) 0x01);                                         // RSA
+    }
+
+    @Test
+    public void testAccessorsReturnComponents() {
+        byte[] rid = ISOUtil.hex2byte("A000000003");
+        byte[] modulus = ISOUtil.hex2byte("BCDEF012345678901122334455667788");
+        byte[] exponent = ISOUtil.hex2byte("03");
+        EMVCAPublicKey k = new EMVCAPublicKey(rid, (byte) 0x07, modulus, exponent,
+                (byte) 0x01, (byte) 0x01);
+        assertSame(rid, k.rid());
+        assertEquals((byte) 0x07, k.index());
+        assertSame(modulus, k.modulus());
+        assertSame(exponent, k.exponent());
+        assertEquals((byte) 0x01, k.hashAlgorithmIndicator());
+        assertEquals((byte) 0x01, k.publicKeyAlgorithmIndicator());
+    }
+
+    @Test
+    public void testEqualsContentBasedOnByteArrays() {
+        EMVCAPublicKey a = newKey();
+        EMVCAPublicKey b = newKey();
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testEqualsFalseWhenModulusDiffersByOneByte() {
+        EMVCAPublicKey a = newKey();
+        EMVCAPublicKey b = new EMVCAPublicKey(
+                ISOUtil.hex2byte("A000000003"),
+                (byte) 0x07,
+                ISOUtil.hex2byte("BCDEF012345678901122334455667789"), // last byte differs
+                ISOUtil.hex2byte("03"),
+                (byte) 0x01,
+                (byte) 0x01);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsFalseWhenIndexDiffers() {
+        EMVCAPublicKey a = newKey();
+        EMVCAPublicKey b = new EMVCAPublicKey(
+                ISOUtil.hex2byte("A000000003"),
+                (byte) 0x08, // index differs
+                ISOUtil.hex2byte("BCDEF012345678901122334455667788"),
+                ISOUtil.hex2byte("03"),
+                (byte) 0x01,
+                (byte) 0x01);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsFalseForUnrelatedType() {
+        EMVCAPublicKey a = newKey();
+        assertFalse(a.equals("not-a-ca-key"));
+        assertFalse(a.equals(null));
+    }
+
+    @Test
+    public void testToStringRendersByteFieldsAsHex() {
+        EMVCAPublicKey k = newKey();
+        String s = k.toString();
+        assertTrue(s.startsWith("EMVCAPublicKey["), "toString prefix: " + s);
+        assertTrue(s.contains("A000000003"), "toString should contain RID hex: " + s);
+        assertTrue(s.contains("BCDEF012345678901122334455667788"),
+                "toString should contain modulus hex: " + s);
+        assertTrue(s.contains("index=07"), "toString should render index as hex: " + s);
+    }
+
+    @Test
+    public void testToStringSurvivesNullByteFields() {
+        EMVCAPublicKey k = new EMVCAPublicKey(null, (byte) 0x07, null, null,
+                (byte) 0x01, (byte) 0x01);
+        // Should not throw NPE
+        assertTrue(k.toString().startsWith("EMVCAPublicKey["));
+    }
+}

--- a/jpos/src/test/java/org/jpos/security/EMVCAPublicKeyTest.java
+++ b/jpos/src/test/java/org/jpos/security/EMVCAPublicKeyTest.java
@@ -18,10 +18,10 @@
 
 package org.jpos.security;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jpos.iso.ISOUtil;
@@ -46,12 +46,31 @@ public class EMVCAPublicKeyTest {
         byte[] exponent = ISOUtil.hex2byte("03");
         EMVCAPublicKey k = new EMVCAPublicKey(rid, (byte) 0x07, modulus, exponent,
                 (byte) 0x01, (byte) 0x01);
-        assertSame(rid, k.rid());
+        assertArrayEquals(rid, k.rid());
         assertEquals((byte) 0x07, k.index());
-        assertSame(modulus, k.modulus());
-        assertSame(exponent, k.exponent());
+        assertArrayEquals(modulus, k.modulus());
+        assertArrayEquals(exponent, k.exponent());
         assertEquals((byte) 0x01, k.hashAlgorithmIndicator());
         assertEquals((byte) 0x01, k.publicKeyAlgorithmIndicator());
+    }
+
+    @Test
+    public void testDefensiveCopiesArrayComponents() {
+        byte[] rid = ISOUtil.hex2byte("A000000003");
+        byte[] modulus = ISOUtil.hex2byte("BCDEF012345678901122334455667788");
+        byte[] exponent = ISOUtil.hex2byte("03");
+        EMVCAPublicKey k = new EMVCAPublicKey(rid, (byte) 0x07, modulus, exponent,
+                (byte) 0x01, (byte) 0x01);
+        rid[0] = 0x00;
+        modulus[0] = 0x00;
+        exponent[0] = 0x00;
+        k.rid()[1] = 0x00;
+        k.modulus()[1] = 0x00;
+        k.exponent()[0] = 0x00;
+
+        assertArrayEquals(ISOUtil.hex2byte("A000000003"), k.rid());
+        assertArrayEquals(ISOUtil.hex2byte("BCDEF012345678901122334455667788"), k.modulus());
+        assertArrayEquals(ISOUtil.hex2byte("03"), k.exponent());
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/security/EMVCDAResultTest.java
+++ b/jpos/src/test/java/org/jpos/security/EMVCDAResultTest.java
@@ -1,0 +1,81 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jpos.iso.ISOUtil;
+import org.junit.jupiter.api.Test;
+
+public class EMVCDAResultTest {
+
+    private static EMVCDAResult newResult() {
+        return new EMVCDAResult(ISOUtil.hex2byte("12345678"), (byte) 0x40);
+    }
+
+    @Test
+    public void testAccessorsReturnComponents() {
+        byte[] dyn = ISOUtil.hex2byte("12345678");
+        EMVCDAResult r = new EMVCDAResult(dyn, (byte) 0x40);
+        assertSame(dyn, r.iccDynamicNumber());
+        assertEquals((byte) 0x40, r.cid());
+    }
+
+    @Test
+    public void testEqualsContentBased() {
+        EMVCDAResult a = newResult();
+        EMVCDAResult b = newResult();
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testEqualsFalseWhenDynamicNumberDiffers() {
+        EMVCDAResult a = newResult();
+        EMVCDAResult b = new EMVCDAResult(ISOUtil.hex2byte("12345679"), (byte) 0x40);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsFalseWhenCidDiffers() {
+        EMVCDAResult a = newResult();
+        EMVCDAResult b = new EMVCDAResult(ISOUtil.hex2byte("12345678"), (byte) 0x80);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsFalseForUnrelatedType() {
+        EMVCDAResult a = newResult();
+        assertFalse(a.equals("not-a-cda-result"));
+        assertFalse(a.equals(null));
+    }
+
+    @Test
+    public void testToStringRendersFieldsAsHex() {
+        EMVCDAResult r = newResult();
+        String s = r.toString();
+        assertTrue(s.startsWith("EMVCDAResult["), "toString prefix: " + s);
+        assertTrue(s.contains("12345678"), "toString should contain dynamic number hex: " + s);
+        assertTrue(s.contains("cid=40"), "toString should render CID as hex: " + s);
+    }
+}

--- a/jpos/src/test/java/org/jpos/security/EMVCDAResultTest.java
+++ b/jpos/src/test/java/org/jpos/security/EMVCDAResultTest.java
@@ -18,10 +18,10 @@
 
 package org.jpos.security;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jpos.iso.ISOUtil;
@@ -37,8 +37,18 @@ public class EMVCDAResultTest {
     public void testAccessorsReturnComponents() {
         byte[] dyn = ISOUtil.hex2byte("12345678");
         EMVCDAResult r = new EMVCDAResult(dyn, (byte) 0x40);
-        assertSame(dyn, r.iccDynamicNumber());
+        assertArrayEquals(dyn, r.iccDynamicNumber());
         assertEquals((byte) 0x40, r.cid());
+    }
+
+    @Test
+    public void testDefensiveCopiesDynamicNumber() {
+        byte[] dyn = ISOUtil.hex2byte("12345678");
+        EMVCDAResult r = new EMVCDAResult(dyn, (byte) 0x40);
+        dyn[0] = 0x00;
+        r.iccDynamicNumber()[1] = 0x00;
+
+        assertArrayEquals(ISOUtil.hex2byte("12345678"), r.iccDynamicNumber());
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/security/EMVDerivedKeyTest.java
+++ b/jpos/src/test/java/org/jpos/security/EMVDerivedKeyTest.java
@@ -18,6 +18,7 @@
 
 package org.jpos.security;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -41,7 +42,17 @@ public class EMVDerivedKeyTest {
         byte[] kcv = ISOUtil.hex2byte("ABCDEF");
         EMVDerivedKey<SecureDESKey> d = new EMVDerivedKey<>(key, kcv);
         assertSame(key, d.key());
-        assertSame(kcv, d.kcv());
+        assertArrayEquals(kcv, d.kcv());
+    }
+
+    @Test
+    public void testDefensiveCopiesKcv() {
+        byte[] kcv = ISOUtil.hex2byte("ABCDEF");
+        EMVDerivedKey<SecureDESKey> d = new EMVDerivedKey<>(newKey(), kcv);
+        kcv[0] = 0x00;
+        d.kcv()[1] = 0x00;
+
+        assertArrayEquals(ISOUtil.hex2byte("ABCDEF"), d.kcv());
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/security/EMVDerivedKeyTest.java
+++ b/jpos/src/test/java/org/jpos/security/EMVDerivedKeyTest.java
@@ -1,0 +1,105 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jpos.iso.ISOUtil;
+import org.junit.jupiter.api.Test;
+
+public class EMVDerivedKeyTest {
+
+    private static SecureDESKey newKey() {
+        return new SecureDESKey(SMAdapter.LENGTH_DES3_2KEY
+                ,SMAdapter.TYPE_MK_AC+":1U"
+                ,"0D39A43C864D1B40F33998B80BB02C95", "6FB1C8");
+    }
+
+    @Test
+    public void testAccessorsReturnComponents() {
+        SecureDESKey key = newKey();
+        byte[] kcv = ISOUtil.hex2byte("ABCDEF");
+        EMVDerivedKey<SecureDESKey> d = new EMVDerivedKey<>(key, kcv);
+        assertSame(key, d.key());
+        assertSame(kcv, d.kcv());
+    }
+
+    @Test
+    public void testEqualsContentBasedOnKcv() {
+        SecureDESKey key = newKey();
+        EMVDerivedKey<SecureDESKey> a = new EMVDerivedKey<>(key, ISOUtil.hex2byte("ABCDEF"));
+        EMVDerivedKey<SecureDESKey> b = new EMVDerivedKey<>(key, ISOUtil.hex2byte("ABCDEF"));
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testEqualsReflexive() {
+        EMVDerivedKey<SecureDESKey> d = new EMVDerivedKey<>(newKey(), ISOUtil.hex2byte("ABCDEF"));
+        assertEquals(d, d);
+    }
+
+    @Test
+    public void testEqualsFalseWhenKcvDiffersByOneByte() {
+        SecureDESKey key = newKey();
+        EMVDerivedKey<SecureDESKey> a = new EMVDerivedKey<>(key, ISOUtil.hex2byte("ABCDEF"));
+        EMVDerivedKey<SecureDESKey> b = new EMVDerivedKey<>(key, ISOUtil.hex2byte("ABCDEE"));
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsFalseWhenKeyDiffers() {
+        SecureDESKey k1 = new SecureDESKey(SMAdapter.LENGTH_DES3_2KEY
+                ,SMAdapter.TYPE_MK_AC+":1U"
+                ,"0D39A43C864D1B40F33998B80BB02C95", "6FB1C8");
+        SecureDESKey k2 = new SecureDESKey(SMAdapter.LENGTH_DES3_2KEY
+                ,SMAdapter.TYPE_MK_SMI+":2U"
+                ,"E86D8A2FC81DEC4E91F9FE76EDAF3C3B", "6FB1C8");
+        byte[] kcv = ISOUtil.hex2byte("ABCDEF");
+        EMVDerivedKey<SecureDESKey> a = new EMVDerivedKey<>(k1, kcv);
+        EMVDerivedKey<SecureDESKey> b = new EMVDerivedKey<>(k2, kcv);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsFalseForUnrelatedType() {
+        EMVDerivedKey<SecureDESKey> d = new EMVDerivedKey<>(newKey(), ISOUtil.hex2byte("ABCDEF"));
+        assertFalse(d.equals("not-a-derived-key"));
+        assertFalse(d.equals(null));
+    }
+
+    @Test
+    public void testToStringRendersKcvAsHex() {
+        EMVDerivedKey<SecureDESKey> d = new EMVDerivedKey<>(newKey(), ISOUtil.hex2byte("ABCDEF"));
+        String s = d.toString();
+        assertTrue(s.contains("ABCDEF"), "toString should contain hex KCV, got: " + s);
+        assertTrue(s.startsWith("EMVDerivedKey["), "toString prefix mismatch: " + s);
+    }
+
+    @Test
+    public void testToStringSurvivesNullKcv() {
+        EMVDerivedKey<SecureDESKey> d = new EMVDerivedKey<>(newKey(), null);
+        // Should not throw NPE
+        assertTrue(d.toString().startsWith("EMVDerivedKey["));
+    }
+}

--- a/jpos/src/test/java/org/jpos/security/EMVICCPublicKeyTest.java
+++ b/jpos/src/test/java/org/jpos/security/EMVICCPublicKeyTest.java
@@ -18,10 +18,10 @@
 
 package org.jpos.security;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jpos.iso.ISOUtil;
@@ -49,13 +49,40 @@ public class EMVICCPublicKeyTest {
         byte[] exponent = ISOUtil.hex2byte("03");
         EMVICCPublicKey k = new EMVICCPublicKey(
                 pan, expDate, serial, modulus, exponent, (byte) 0x01, (byte) 0x01);
-        assertSame(pan,      k.applicationPan());
-        assertSame(expDate,  k.expirationDate());
-        assertSame(serial,   k.serialNumber());
-        assertSame(modulus,  k.modulus());
-        assertSame(exponent, k.exponent());
+        assertArrayEquals(pan,      k.applicationPan());
+        assertArrayEquals(expDate,  k.expirationDate());
+        assertArrayEquals(serial,   k.serialNumber());
+        assertArrayEquals(modulus,  k.modulus());
+        assertArrayEquals(exponent, k.exponent());
         assertEquals((byte) 0x01, k.hashAlgorithmIndicator());
         assertEquals((byte) 0x01, k.publicKeyAlgorithmIndicator());
+    }
+
+    @Test
+    public void testDefensiveCopiesArrayComponents() {
+        byte[] pan      = ISOUtil.hex2byte("12345678901234FFFFFF");
+        byte[] expDate  = ISOUtil.hex2byte("1231");
+        byte[] serial   = ISOUtil.hex2byte("ABCDEF");
+        byte[] modulus  = ISOUtil.hex2byte("BCDEF012345678901122334455667788");
+        byte[] exponent = ISOUtil.hex2byte("03");
+        EMVICCPublicKey k = new EMVICCPublicKey(
+                pan, expDate, serial, modulus, exponent, (byte) 0x01, (byte) 0x01);
+        pan[0] = 0x00;
+        expDate[0] = 0x00;
+        serial[0] = 0x00;
+        modulus[0] = 0x00;
+        exponent[0] = 0x00;
+        k.applicationPan()[1] = 0x00;
+        k.expirationDate()[1] = 0x00;
+        k.serialNumber()[1] = 0x00;
+        k.modulus()[1] = 0x00;
+        k.exponent()[0] = 0x00;
+
+        assertArrayEquals(ISOUtil.hex2byte("12345678901234FFFFFF"), k.applicationPan());
+        assertArrayEquals(ISOUtil.hex2byte("1231"), k.expirationDate());
+        assertArrayEquals(ISOUtil.hex2byte("ABCDEF"), k.serialNumber());
+        assertArrayEquals(ISOUtil.hex2byte("BCDEF012345678901122334455667788"), k.modulus());
+        assertArrayEquals(ISOUtil.hex2byte("03"), k.exponent());
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/security/EMVICCPublicKeyTest.java
+++ b/jpos/src/test/java/org/jpos/security/EMVICCPublicKeyTest.java
@@ -1,0 +1,121 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jpos.iso.ISOUtil;
+import org.junit.jupiter.api.Test;
+
+public class EMVICCPublicKeyTest {
+
+    private static EMVICCPublicKey newKey() {
+        return new EMVICCPublicKey(
+                ISOUtil.hex2byte("12345678901234FFFFFF"),              // 10-byte PAN BCD
+                ISOUtil.hex2byte("1231"),                              // expirationDate
+                ISOUtil.hex2byte("ABCDEF"),                            // serialNumber
+                ISOUtil.hex2byte("BCDEF012345678901122334455667788"), // modulus (16 bytes for test)
+                ISOUtil.hex2byte("03"),                                // exponent
+                (byte) 0x01,                                           // SHA-1
+                (byte) 0x01);                                          // RSA
+    }
+
+    @Test
+    public void testAccessorsReturnComponents() {
+        byte[] pan      = ISOUtil.hex2byte("12345678901234FFFFFF");
+        byte[] expDate  = ISOUtil.hex2byte("1231");
+        byte[] serial   = ISOUtil.hex2byte("ABCDEF");
+        byte[] modulus  = ISOUtil.hex2byte("BCDEF012345678901122334455667788");
+        byte[] exponent = ISOUtil.hex2byte("03");
+        EMVICCPublicKey k = new EMVICCPublicKey(
+                pan, expDate, serial, modulus, exponent, (byte) 0x01, (byte) 0x01);
+        assertSame(pan,      k.applicationPan());
+        assertSame(expDate,  k.expirationDate());
+        assertSame(serial,   k.serialNumber());
+        assertSame(modulus,  k.modulus());
+        assertSame(exponent, k.exponent());
+        assertEquals((byte) 0x01, k.hashAlgorithmIndicator());
+        assertEquals((byte) 0x01, k.publicKeyAlgorithmIndicator());
+    }
+
+    @Test
+    public void testEqualsContentBasedOnByteArrays() {
+        EMVICCPublicKey a = newKey();
+        EMVICCPublicKey b = newKey();
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testEqualsFalseWhenModulusDiffersByOneByte() {
+        EMVICCPublicKey a = newKey();
+        EMVICCPublicKey b = new EMVICCPublicKey(
+                ISOUtil.hex2byte("12345678901234FFFFFF"),
+                ISOUtil.hex2byte("1231"),
+                ISOUtil.hex2byte("ABCDEF"),
+                ISOUtil.hex2byte("BCDEF012345678901122334455667789"), // last byte differs
+                ISOUtil.hex2byte("03"),
+                (byte) 0x01,
+                (byte) 0x01);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsFalseWhenPanDiffers() {
+        EMVICCPublicKey a = newKey();
+        EMVICCPublicKey b = new EMVICCPublicKey(
+                ISOUtil.hex2byte("99999999999999FFFFFF"), // differs
+                ISOUtil.hex2byte("1231"),
+                ISOUtil.hex2byte("ABCDEF"),
+                ISOUtil.hex2byte("BCDEF012345678901122334455667788"),
+                ISOUtil.hex2byte("03"),
+                (byte) 0x01,
+                (byte) 0x01);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsFalseForUnrelatedType() {
+        EMVICCPublicKey a = newKey();
+        assertFalse(a.equals("not-an-icc-key"));
+        assertFalse(a.equals(null));
+    }
+
+    @Test
+    public void testToStringRendersByteFieldsAsHex() {
+        EMVICCPublicKey k = newKey();
+        String s = k.toString();
+        assertTrue(s.startsWith("EMVICCPublicKey["), "toString prefix: " + s);
+        assertTrue(s.contains("12345678901234FFFFFF"), "toString should contain PAN hex: " + s);
+        assertTrue(s.contains("1231"), "toString should contain expirationDate hex: " + s);
+        assertTrue(s.contains("BCDEF012345678901122334455667788"),
+                "toString should contain modulus hex: " + s);
+    }
+
+    @Test
+    public void testToStringSurvivesNullByteFields() {
+        EMVICCPublicKey k = new EMVICCPublicKey(null, null, null, null, null,
+                (byte) 0x01, (byte) 0x01);
+        assertTrue(k.toString().startsWith("EMVICCPublicKey["));
+    }
+}

--- a/jpos/src/test/java/org/jpos/security/EMVIssuerPublicKeyTest.java
+++ b/jpos/src/test/java/org/jpos/security/EMVIssuerPublicKeyTest.java
@@ -1,0 +1,122 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jpos.iso.ISOUtil;
+import org.junit.jupiter.api.Test;
+
+public class EMVIssuerPublicKeyTest {
+
+    private static EMVIssuerPublicKey newKey() {
+        return new EMVIssuerPublicKey(
+                ISOUtil.hex2byte("1234FFFF"),                          // issuerIdentifier
+                ISOUtil.hex2byte("1231"),                              // expirationDate (Dec 2031)
+                ISOUtil.hex2byte("ABCDEF"),                            // serialNumber
+                ISOUtil.hex2byte("BCDEF012345678901122334455667788"), // modulus (16 bytes for test)
+                ISOUtil.hex2byte("03"),                                // exponent
+                (byte) 0x01,                                           // SHA-1
+                (byte) 0x01);                                          // RSA
+    }
+
+    @Test
+    public void testAccessorsReturnComponents() {
+        byte[] issuerId = ISOUtil.hex2byte("1234FFFF");
+        byte[] expDate  = ISOUtil.hex2byte("1231");
+        byte[] serial   = ISOUtil.hex2byte("ABCDEF");
+        byte[] modulus  = ISOUtil.hex2byte("BCDEF012345678901122334455667788");
+        byte[] exponent = ISOUtil.hex2byte("03");
+        EMVIssuerPublicKey k = new EMVIssuerPublicKey(
+                issuerId, expDate, serial, modulus, exponent, (byte) 0x01, (byte) 0x01);
+        assertSame(issuerId, k.issuerIdentifier());
+        assertSame(expDate,  k.expirationDate());
+        assertSame(serial,   k.serialNumber());
+        assertSame(modulus,  k.modulus());
+        assertSame(exponent, k.exponent());
+        assertEquals((byte) 0x01, k.hashAlgorithmIndicator());
+        assertEquals((byte) 0x01, k.publicKeyAlgorithmIndicator());
+    }
+
+    @Test
+    public void testEqualsContentBasedOnByteArrays() {
+        EMVIssuerPublicKey a = newKey();
+        EMVIssuerPublicKey b = newKey();
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testEqualsFalseWhenModulusDiffersByOneByte() {
+        EMVIssuerPublicKey a = newKey();
+        EMVIssuerPublicKey b = new EMVIssuerPublicKey(
+                ISOUtil.hex2byte("1234FFFF"),
+                ISOUtil.hex2byte("1231"),
+                ISOUtil.hex2byte("ABCDEF"),
+                ISOUtil.hex2byte("BCDEF012345678901122334455667789"), // last byte differs
+                ISOUtil.hex2byte("03"),
+                (byte) 0x01,
+                (byte) 0x01);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsFalseWhenExpirationDateDiffers() {
+        EMVIssuerPublicKey a = newKey();
+        EMVIssuerPublicKey b = new EMVIssuerPublicKey(
+                ISOUtil.hex2byte("1234FFFF"),
+                ISOUtil.hex2byte("0125"), // differs
+                ISOUtil.hex2byte("ABCDEF"),
+                ISOUtil.hex2byte("BCDEF012345678901122334455667788"),
+                ISOUtil.hex2byte("03"),
+                (byte) 0x01,
+                (byte) 0x01);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testEqualsFalseForUnrelatedType() {
+        EMVIssuerPublicKey a = newKey();
+        assertFalse(a.equals("not-an-issuer-key"));
+        assertFalse(a.equals(null));
+    }
+
+    @Test
+    public void testToStringRendersByteFieldsAsHex() {
+        EMVIssuerPublicKey k = newKey();
+        String s = k.toString();
+        assertTrue(s.startsWith("EMVIssuerPublicKey["), "toString prefix: " + s);
+        assertTrue(s.contains("1234FFFF"), "toString should contain issuerIdentifier hex: " + s);
+        assertTrue(s.contains("1231"), "toString should contain expirationDate hex: " + s);
+        assertTrue(s.contains("ABCDEF"), "toString should contain serial hex: " + s);
+        assertTrue(s.contains("BCDEF012345678901122334455667788"),
+                "toString should contain modulus hex: " + s);
+    }
+
+    @Test
+    public void testToStringSurvivesNullByteFields() {
+        EMVIssuerPublicKey k = new EMVIssuerPublicKey(null, null, null, null, null,
+                (byte) 0x01, (byte) 0x01);
+        assertTrue(k.toString().startsWith("EMVIssuerPublicKey["));
+    }
+}

--- a/jpos/src/test/java/org/jpos/security/EMVIssuerPublicKeyTest.java
+++ b/jpos/src/test/java/org/jpos/security/EMVIssuerPublicKeyTest.java
@@ -18,10 +18,10 @@
 
 package org.jpos.security;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jpos.iso.ISOUtil;
@@ -49,13 +49,40 @@ public class EMVIssuerPublicKeyTest {
         byte[] exponent = ISOUtil.hex2byte("03");
         EMVIssuerPublicKey k = new EMVIssuerPublicKey(
                 issuerId, expDate, serial, modulus, exponent, (byte) 0x01, (byte) 0x01);
-        assertSame(issuerId, k.issuerIdentifier());
-        assertSame(expDate,  k.expirationDate());
-        assertSame(serial,   k.serialNumber());
-        assertSame(modulus,  k.modulus());
-        assertSame(exponent, k.exponent());
+        assertArrayEquals(issuerId, k.issuerIdentifier());
+        assertArrayEquals(expDate,  k.expirationDate());
+        assertArrayEquals(serial,   k.serialNumber());
+        assertArrayEquals(modulus,  k.modulus());
+        assertArrayEquals(exponent, k.exponent());
         assertEquals((byte) 0x01, k.hashAlgorithmIndicator());
         assertEquals((byte) 0x01, k.publicKeyAlgorithmIndicator());
+    }
+
+    @Test
+    public void testDefensiveCopiesArrayComponents() {
+        byte[] issuerId = ISOUtil.hex2byte("1234FFFF");
+        byte[] expDate  = ISOUtil.hex2byte("1231");
+        byte[] serial   = ISOUtil.hex2byte("ABCDEF");
+        byte[] modulus  = ISOUtil.hex2byte("BCDEF012345678901122334455667788");
+        byte[] exponent = ISOUtil.hex2byte("03");
+        EMVIssuerPublicKey k = new EMVIssuerPublicKey(
+                issuerId, expDate, serial, modulus, exponent, (byte) 0x01, (byte) 0x01);
+        issuerId[0] = 0x00;
+        expDate[0] = 0x00;
+        serial[0] = 0x00;
+        modulus[0] = 0x00;
+        exponent[0] = 0x00;
+        k.issuerIdentifier()[1] = 0x00;
+        k.expirationDate()[1] = 0x00;
+        k.serialNumber()[1] = 0x00;
+        k.modulus()[1] = 0x00;
+        k.exponent()[0] = 0x00;
+
+        assertArrayEquals(ISOUtil.hex2byte("1234FFFF"), k.issuerIdentifier());
+        assertArrayEquals(ISOUtil.hex2byte("1231"), k.expirationDate());
+        assertArrayEquals(ISOUtil.hex2byte("ABCDEF"), k.serialNumber());
+        assertArrayEquals(ISOUtil.hex2byte("BCDEF012345678901122334455667788"), k.modulus());
+        assertArrayEquals(ISOUtil.hex2byte("03"), k.exponent());
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -2035,4 +2035,19 @@ public class JCESecurityModuleTest {
         verify(listener, times(1)).log(any(LogEvent.class));
     }
 
+    @Test
+    public void testCalculateKCV_3DES_StandardAlgorithm() throws Throwable {
+        byte[] clearKey = ISOUtil.hex2byte("0123456789ABCDEFFEDCBA9876543210");
+        java.security.Key key = jcesecmod.jceHandler
+                .formDESKey(SMAdapter.LENGTH_DES3_2KEY, clearKey);
+
+        byte[] kcv = jcesecmod.calculateKCV(key);
+
+        assertEquals(3, kcv.length);
+
+        byte[] expected = java.util.Arrays.copyOfRange(
+                jcesecmod.jceHandler.encryptData(new byte[8], key), 0, 3);
+        assertArrayEquals(expected, kcv);
+    }
+
 }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -2666,6 +2666,13 @@ public class JCESecurityModuleTest {
 
     private static byte[] buildPayload(byte[] issuerId, byte[] expDate, byte[] serial,
             byte hashAlg, byte pkAlg, byte[] issuerModulus, byte[] issuerExp) throws Exception {
+        return buildPayload(issuerId, expDate, serial, hashAlg, pkAlg,
+                issuerModulus, issuerExp, (byte) 0xBB);
+    }
+
+    private static byte[] buildPayload(byte[] issuerId, byte[] expDate, byte[] serial,
+            byte hashAlg, byte pkAlg, byte[] issuerModulus, byte[] issuerExp,
+            byte padByte) throws Exception {
         int nca = PR9_NCA;
         int ni  = issuerModulus.length;
         int ipkInCert = Math.min(ni, nca - 36);
@@ -2681,7 +2688,7 @@ public class JCESecurityModuleTest {
         payload[14] = (byte) issuerExp.length;
         System.arraycopy(issuerModulus, 0, payload, 15, ipkInCert);
         // 0xBB padding for ni < nca - 36 (not exercised in happy fixture, but support it)
-        for (int i = 15 + ipkInCert; i < nca - 21; i++) payload[i] = (byte) 0xBB;
+        for (int i = 15 + ipkInCert; i < nca - 21; i++) payload[i] = padByte;
         // SHA-1 over payload[1..nca-22] || remainder || exponent
         java.security.MessageDigest sha = java.security.MessageDigest.getInstance("SHA-1");
         sha.update(payload, 1, nca - 22);
@@ -2786,6 +2793,19 @@ public class JCESecurityModuleTest {
     }
 
     @Test
+    public void testRecoverIssuerPublicKey_BadPadding_Throws() throws Throwable {
+        byte[] shortIssuerModulus = java.util.Arrays.copyOf(pr9IssuerModulus, 80);
+        byte[] payload = buildPayload(PR9_ISSUER_ID, PR9_EXP_FUTURE, PR9_SERIAL,
+                (byte) 0x01, (byte) 0x01, shortIssuerModulus, pr9IssuerExp, (byte) 0xBC);
+        byte[] badPaddingCert = signWithCA(payload);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverIssuerPublicKey(pr9CaPublicKey, badPaddingCert, null,
+                        pr9IssuerExp, PR9_PAN));
+        assertTrue(ex.getMessage().toLowerCase().contains("pad pattern"),
+                "expected 'pad pattern' in error: " + ex.getMessage());
+    }
+
+    @Test
     public void testRecoverIssuerPublicKey_UnsupportedHashAlgo_Throws() throws Throwable {
         byte[] bad = mutateAndSign(pr9HappyCert, p -> p[11] = (byte) 0x02);
         SMException ex = assertThrows(SMException.class, () ->
@@ -2883,6 +2903,13 @@ public class JCESecurityModuleTest {
     private static byte[] buildICCPayload(byte[] appPan, byte[] expDate, byte[] serial,
             byte hashAlg, byte pkAlg, byte[] iccModulus, byte[] iccExp,
             byte[] sad) throws Exception {
+        return buildICCPayload(appPan, expDate, serial, hashAlg, pkAlg,
+                iccModulus, iccExp, sad, (byte) 0xBB);
+    }
+
+    private static byte[] buildICCPayload(byte[] appPan, byte[] expDate, byte[] serial,
+            byte hashAlg, byte pkAlg, byte[] iccModulus, byte[] iccExp,
+            byte[] sad, byte padByte) throws Exception {
         int ni  = PR9_NI;
         int nic = iccModulus.length;
         int iccInCert = Math.min(nic, ni - 42);
@@ -2897,7 +2924,7 @@ public class JCESecurityModuleTest {
         payload[19] = (byte) nic;
         payload[20] = (byte) iccExp.length;
         System.arraycopy(iccModulus, 0, payload, 21, iccInCert);
-        for (int i = 21 + iccInCert; i < ni - 21; i++) payload[i] = (byte) 0xBB;
+        for (int i = 21 + iccInCert; i < ni - 21; i++) payload[i] = padByte;
         // SHA-1 over payload[1..ni-22] || remainder || iccExp || sad
         java.security.MessageDigest sha = java.security.MessageDigest.getInstance("SHA-1");
         sha.update(payload, 1, ni - 22);
@@ -3003,6 +3030,22 @@ public class JCESecurityModuleTest {
                         PR10_SAD, PR10_APP_PAN_STR));
         assertTrue(ex.getMessage().toLowerCase().contains("hash"),
                 "expected 'hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverICCPublicKey_BadPadding_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] shortIccModulus = java.util.Arrays.copyOf(pr10IccModulus, 48);
+        byte[] payload = buildICCPayload(PR10_APP_PAN_BCD, PR9_EXP_FUTURE, PR9_SERIAL,
+                (byte) 0x01, (byte) 0x01, shortIccModulus, pr10IccExp,
+                PR10_SAD, (byte) 0xBC);
+        byte[] badPaddingCert = signWithIssuer(payload);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverICCPublicKey(issuer, badPaddingCert, null,
+                        pr10IccExp, PR10_SAD, PR10_APP_PAN_STR));
+        assertTrue(ex.getMessage().toLowerCase().contains("pad pattern"),
+                "expected 'pad pattern' in error: " + ex.getMessage());
     }
 
     @Test
@@ -3272,6 +3315,18 @@ public class JCESecurityModuleTest {
         return signWithICC(payload);
     }
 
+    private static byte[] mutateRehashAndSignSDAD(byte[] signedSDAD,
+            java.util.function.Consumer<byte[]> mutator, byte[] ddol) throws Exception {
+        java.math.BigInteger sig = new java.math.BigInteger(1, signedSDAD);
+        byte[] payload = bigIntToFixed(sig.modPow(pr12IccE, pr12IccN), signedSDAD.length);
+        mutator.accept(payload);
+        java.security.MessageDigest sha = java.security.MessageDigest.getInstance("SHA-1");
+        sha.update(payload, 1, payload.length - 22);
+        if (ddol != null && ddol.length > 0) sha.update(ddol);
+        System.arraycopy(sha.digest(), 0, payload, payload.length - 21, 20);
+        return signWithICC(payload);
+    }
+
     private static EMVICCPublicKey recoverICCForPR12() throws Exception {
         EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
                 pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
@@ -3340,6 +3395,17 @@ public class JCESecurityModuleTest {
                 jcesecmod.verifyDDA(icc, badPadding, PR12_DDOL));
         assertTrue(ex.getMessage().toLowerCase().contains("pad pattern"),
                 "expected 'pad pattern' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyDDA_BadDynamicDataLength_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] bad = mutateRehashAndSignSDAD(pr12HappySDAD,
+                p -> p[3] = (byte) ((p[4] & 0xff) + 2), PR12_DDOL);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyDDA(icc, bad, PR12_DDOL));
+        assertTrue(ex.getMessage().toLowerCase().contains("dynamic data length"),
+                "expected 'dynamic data length' in error: " + ex.getMessage());
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -2131,4 +2131,99 @@ public class JCESecurityModuleTest {
         });
     }
 
+    @Test
+    public void testDeriveEMVSessionKey_VSDC_ReturnsICCMasterKeyUnchanged() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveEMVSessionKey(
+                SKDMethod.VSDC, iccMk.key(), etd.getATC(), null);
+        // VSDC has no session-key derivation; session key == ICC MK
+        assertArrayEquals(iccMk.kcv(), session.kcv());
+        assertArrayEquals(iccMk.key().getKeyBytes(), session.key().getKeyBytes());
+    }
+
+    @Test
+    public void testDeriveEMVSessionKey_EMV_CSKD_MatchesInternalDerivation() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+
+        // Independent computation via the existing internal path
+        java.security.Key clearIcc = jcesecmod.decryptFromLMK(iccMk.key());
+        java.security.Key expectedClearSk = jcesecmod.deriveCommonSK_AC(clearIcc, etd.getATC());
+        byte[] expectedBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, expectedClearSk);
+
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveEMVSessionKey(
+                SKDMethod.EMV_CSKD, iccMk.key(), etd.getATC(), null);
+        java.security.Key actualClearSk = jcesecmod.decryptFromLMK(session.key());
+        byte[] actualBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, actualClearSk);
+
+        assertArrayEquals(expectedBytes, actualBytes);
+    }
+
+    @Test
+    public void testDeriveEMVSessionKey_MCHIP_MatchesInternalDerivation() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+
+        // Independent computation via the existing internal path
+        java.security.Key clearIcc = jcesecmod.decryptFromLMK(iccMk.key());
+        java.security.Key expectedClearSk = jcesecmod.deriveSK_MK(
+                clearIcc, etd.getATC(), etd.getUPN());
+        byte[] expectedBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, expectedClearSk);
+
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveEMVSessionKey(
+                SKDMethod.MCHIP, iccMk.key(), etd.getATC(), etd.getUPN());
+        java.security.Key actualClearSk = jcesecmod.decryptFromLMK(session.key());
+        byte[] actualBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, actualClearSk);
+
+        assertArrayEquals(expectedBytes, actualBytes);
+    }
+
+    @Test
+    public void testDeriveEMVSessionKey_Deterministic() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        EMVDerivedKey<SecureDESKey> a = jcesecmod.deriveEMVSessionKey(
+                SKDMethod.EMV_CSKD, iccMk.key(), etd.getATC(), null);
+        EMVDerivedKey<SecureDESKey> b = jcesecmod.deriveEMVSessionKey(
+                SKDMethod.EMV_CSKD, iccMk.key(), etd.getATC(), null);
+        assertArrayEquals(a.kcv(), b.kcv());
+        assertArrayEquals(a.key().getKeyBytes(), b.key().getKeyBytes());
+    }
+
+    @Test
+    public void testDeriveEMVSessionKey_PreservesICCKeyTypeAndLength() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveEMVSessionKey(
+                SKDMethod.EMV_CSKD, iccMk.key(), etd.getATC(), null);
+        assertEquals(iccMk.key().getKeyType(), session.key().getKeyType());
+        assertEquals(iccMk.key().getKeyLength(), session.key().getKeyLength());
+    }
+
+    @Test
+    public void testDeriveEMVSessionKey_KCVIsThreeBytes() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveEMVSessionKey(
+                SKDMethod.MCHIP, iccMk.key(), etd.getATC(), etd.getUPN());
+        assertNotNull(session.kcv());
+        assertEquals(3, session.kcv().length);
+        assertArrayEquals(session.kcv(), session.key().getKeyCheckValue());
+    }
+
+    @Test
+    public void testDeriveEMVSessionKey_RejectsUnsupportedSKD() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        assertThrows(SMException.class, () -> {
+            jcesecmod.deriveEMVSessionKey(
+                    SKDMethod.AEPIS_V40, iccMk.key(), etd.getATC(), null);
+        });
+    }
+
 }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -2317,4 +2317,116 @@ public class JCESecurityModuleTest {
         assertArrayEquals(expected, result);
     }
 
+    @Test
+    public void testDeriveSecureMessagingSessionKey_VSDC_SMI_MatchesInternalDerivation() throws Throwable {
+        // OPTION_A panpsn for accountNoA + "00" = last 8 bytes of hex("123456789012345600")
+        byte[] panpsn = ISOUtil.hex2byte("3456789012345600");
+        java.security.Key clearImk  = jcesecmod.decryptFromLMK(imksmi);
+        java.security.Key clearMksmi = jcesecmod.deriveICCMasterKey(clearImk, panpsn);
+        java.security.Key expectedClearSk = jcesecmod.deriveSK_VISA(clearMksmi, atc01);
+        byte[] expectedBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, expectedClearSk);
+
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.VSDC, imksmi,
+                accountNoA, accountNoA_CSN, atc01, null);
+        java.security.Key actualClearSk = jcesecmod.decryptFromLMK(session.key());
+        byte[] actualBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, actualClearSk);
+
+        assertArrayEquals(expectedBytes, actualBytes);
+    }
+
+    @Test
+    public void testDeriveSecureMessagingSessionKey_MCHIP_SMI_MatchesInternalDerivation() throws Throwable {
+        byte[] panpsn = ISOUtil.hex2byte("3456789012345600");
+        java.security.Key clearImk  = jcesecmod.decryptFromLMK(imksmi);
+        java.security.Key clearMksmi = jcesecmod.deriveICCMasterKey(clearImk, panpsn);
+        java.security.Key expectedClearSk = jcesecmod.deriveCommonSK_SM(clearMksmi, arqc01);
+        byte[] expectedBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, expectedClearSk);
+
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.MCHIP, imksmi,
+                accountNoA, accountNoA_CSN, null, arqc01);
+        java.security.Key actualClearSk = jcesecmod.decryptFromLMK(session.key());
+        byte[] actualBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, actualClearSk);
+
+        assertArrayEquals(expectedBytes, actualBytes);
+    }
+
+    @Test
+    public void testDeriveSecureMessagingSessionKey_CSKD_SMI_MatchesInternalDerivation() throws Throwable {
+        // MCHIP and EMV_CSKD share the same SM derivation algorithm (deriveCommonSK_SM)
+        byte[] panpsn = ISOUtil.hex2byte("3456789012345600");
+        java.security.Key clearImk  = jcesecmod.decryptFromLMK(imksmi);
+        java.security.Key clearMksmi = jcesecmod.deriveICCMasterKey(clearImk, panpsn);
+        java.security.Key expectedClearSk = jcesecmod.deriveCommonSK_SM(clearMksmi, arqc01);
+        byte[] expectedBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, expectedClearSk);
+
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.EMV_CSKD, imksmi,
+                accountNoA, accountNoA_CSN, null, arqc01);
+        java.security.Key actualClearSk = jcesecmod.decryptFromLMK(session.key());
+        byte[] actualBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, actualClearSk);
+
+        assertArrayEquals(expectedBytes, actualBytes);
+    }
+
+    @Test
+    public void testDeriveSecureMessagingSessionKey_VSDC_SMC_MatchesInternalDerivation() throws Throwable {
+        // Same algorithm as SMI, but starting from IMK-SMC; result inherits SMC keyType.
+        byte[] panpsn = ISOUtil.hex2byte("3456789012345600");
+        java.security.Key clearImk  = jcesecmod.decryptFromLMK(imksmc);
+        java.security.Key clearMksmc = jcesecmod.deriveICCMasterKey(clearImk, panpsn);
+        java.security.Key expectedClearSk = jcesecmod.deriveSK_VISA(clearMksmc, atc01);
+        byte[] expectedBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, expectedClearSk);
+
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.VSDC, imksmc,
+                accountNoA, accountNoA_CSN, atc01, null);
+        java.security.Key actualClearSk = jcesecmod.decryptFromLMK(session.key());
+        byte[] actualBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, actualClearSk);
+
+        assertArrayEquals(expectedBytes, actualBytes);
+        // Family carries through: SMC IMK -> SMC session key
+        assertEquals(imksmc.getKeyType(), session.key().getKeyType());
+    }
+
+    @Test
+    public void testDeriveSecureMessagingSessionKey_Deterministic() throws Throwable {
+        EMVDerivedKey<SecureDESKey> a = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.MCHIP, imksmi,
+                accountNoA, accountNoA_CSN, null, arqc01);
+        EMVDerivedKey<SecureDESKey> b = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.MCHIP, imksmi,
+                accountNoA, accountNoA_CSN, null, arqc01);
+        assertArrayEquals(a.kcv(), b.kcv());
+        assertArrayEquals(a.key().getKeyBytes(), b.key().getKeyBytes());
+    }
+
+    @Test
+    public void testDeriveSecureMessagingSessionKey_PreservesIMKMetadata() throws Throwable {
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.MCHIP, imksmi,
+                accountNoA, accountNoA_CSN, null, arqc01);
+        assertEquals(imksmi.getKeyType(), session.key().getKeyType());
+        assertEquals(imksmi.getKeyLength(), session.key().getKeyLength());
+        assertEquals(3, session.kcv().length);
+    }
+
+    @Test
+    public void testDeriveSecureMessagingSessionKey_RejectsUnsupportedSKD() throws Throwable {
+        assertThrows(SMException.class, () -> {
+            jcesecmod.deriveSecureMessagingSessionKey(
+                    MKDMethod.OPTION_A, SKDMethod.AEPIS_V40, imksmi,
+                    accountNoA, accountNoA_CSN, atc01, arqc01);
+        });
+    }
+
 }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -3048,4 +3048,156 @@ public class JCESecurityModuleTest {
                 "expected 'application pan' in error: " + ex.getMessage());
     }
 
+    // ----------------------------------------------------------------------
+    // PR 11 — Verify Signed Static Application Data (EMV 4.4 Book 2 §5.4)
+    // ----------------------------------------------------------------------
+    //
+    // Reuses PR 9's CA + Issuer keypair fixture. Builds SSAD by signing
+    // (format-prefix || hash-alg || DAC || pad-pattern || SAD)'s hash with
+    // the issuer private exponent, then recovers via verifySDA.
+
+    private static final byte[] PR11_DAC = ISOUtil.hex2byte("1234");
+    private static byte[] pr11HappySSAD;
+
+    @BeforeAll
+    public static void setUpPR11Fixtures() throws Exception {
+        // Build the canonical "happy" SSAD signed by the issuer. The issuer
+        // keypair (pr10IssuerD, pr9IssuerN) was captured during the PR 9
+        // fixture setup; PR 11 just consumes it.
+        pr11HappySSAD = buildSSAD(PR11_DAC, (byte) 0x01, (byte) 0x03,
+                (byte) 0xBB, PR10_SAD);
+    }
+
+    private static byte[] buildSSAD(byte[] dac, byte hashAlg, byte format,
+            byte padByte, byte[] sad) throws Exception {
+        int ni = PR9_NI;
+        byte[] payload = new byte[ni];
+        payload[0] = (byte) 0x6A;
+        payload[1] = format;
+        payload[2] = hashAlg;
+        System.arraycopy(dac, 0, payload, 3, 2);
+        // Pad pattern: bytes 5..ni-21 = padByte
+        for (int i = 5; i < ni - 21; i++) payload[i] = padByte;
+        // Hash over payload[1..ni-21) || sad
+        java.security.MessageDigest sha = java.security.MessageDigest.getInstance("SHA-1");
+        sha.update(payload, 1, ni - 22);
+        if (sad != null && sad.length > 0) sha.update(sad);
+        System.arraycopy(sha.digest(), 0, payload, ni - 21, 20);
+        payload[ni - 1] = (byte) 0xBC;
+        return signWithIssuer(payload);
+    }
+
+    private static byte[] mutateAndSignSSAD(byte[] signedSSAD, java.util.function.Consumer<byte[]> mutator) {
+        java.math.BigInteger sig = new java.math.BigInteger(1, signedSSAD);
+        byte[] payload = bigIntToFixed(sig.modPow(pr10IssuerE, pr9IssuerN), signedSSAD.length);
+        mutator.accept(payload);
+        return signWithIssuer(payload);
+    }
+
+    @Test
+    public void testVerifySDA_HappyPath() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+
+        byte[] dac = jcesecmod.verifySDA(issuer, pr11HappySSAD, PR10_SAD);
+        assertArrayEquals(PR11_DAC, dac);
+        assertEquals(2, dac.length);
+    }
+
+    @Test
+    public void testVerifySDA_BadHeader_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] bad = mutateAndSignSSAD(pr11HappySSAD, p -> p[0] = (byte) 0x6B);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifySDA(issuer, bad, PR10_SAD));
+        assertTrue(ex.getMessage().toLowerCase().contains("header"),
+                "expected 'header' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifySDA_BadFormat_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        // 0x03 → 0x02 (issuer cert format used by mistake)
+        byte[] bad = mutateAndSignSSAD(pr11HappySSAD, p -> p[1] = (byte) 0x02);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifySDA(issuer, bad, PR10_SAD));
+        assertTrue(ex.getMessage().toLowerCase().contains("signed data format"),
+                "expected 'signed data format' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifySDA_BadTrailer_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] bad = mutateAndSignSSAD(pr11HappySSAD, p -> p[PR9_NI - 1] = (byte) 0xBD);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifySDA(issuer, bad, PR10_SAD));
+        assertTrue(ex.getMessage().toLowerCase().contains("trailer"),
+                "expected 'trailer' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifySDA_UnsupportedHashAlgo_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] bad = mutateAndSignSSAD(pr11HappySSAD, p -> p[2] = (byte) 0x02);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifySDA(issuer, bad, PR10_SAD));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash algorithm"),
+                "expected 'hash algorithm' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifySDA_BadPadding_Throws() throws Throwable {
+        // Build SSAD with pad byte 0xBC instead of 0xBB. Hash is consistent
+        // with the cert (signed correctly); only the structural pad-pattern
+        // check rejects.
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] badPadding = buildSSAD(PR11_DAC, (byte) 0x01, (byte) 0x03,
+                (byte) 0xBC, PR10_SAD);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifySDA(issuer, badPadding, PR10_SAD));
+        assertTrue(ex.getMessage().toLowerCase().contains("pad pattern"),
+                "expected 'pad pattern' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifySDA_BadHash_Throws() throws Throwable {
+        // Flip a bit in the embedded hash (bytes ni-21..ni-2).
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] bad = mutateAndSignSSAD(pr11HappySSAD, p -> p[PR9_NI - 10] ^= 0x01);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifySDA(issuer, bad, PR10_SAD));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash"),
+                "expected 'hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifySDA_SADCorruption_Throws() throws Throwable {
+        // Pass a different SAD at verify time than was used at signing.
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] wrongSad = ISOUtil.hex2byte("DEADBEEFCAFEBABE");
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifySDA(issuer, pr11HappySSAD, wrongSad));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash"),
+                "expected 'hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifySDA_WrongLength_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        // Truncate the SSAD by one byte; should fail the length check.
+        byte[] tooShort = java.util.Arrays.copyOfRange(pr11HappySSAD, 0, pr11HappySSAD.length - 1);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifySDA(issuer, tooShort, PR10_SAD));
+        assertTrue(ex.getMessage().toLowerCase().contains("length"),
+                "expected 'length' in error: " + ex.getMessage());
+    }
+
 }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -2429,4 +2429,77 @@ public class JCESecurityModuleTest {
         });
     }
 
+    @Test
+    public void testGenerateSM_MACDirect_MCHIP_LongData() throws Throwable {
+        // Derive SK-SMI via PR 7 with MCHIP + arqc01
+        EMVDerivedKey<SecureDESKey> skSmi = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.MCHIP, imksmi,
+                accountNoA, accountNoA_CSN, null, arqc01);
+
+        byte[] data = ISOUtil.hex2byte("1122334455667788");
+        byte[] apdu = ISOUtil.concat(apdu01, atc01);
+        apdu = ISOUtil.concat(apdu, arqc01);
+        apdu = ISOUtil.concat(apdu, data);
+
+        byte[] mac = jcesecmod.generateSM_MAC(skSmi.key(), apdu);
+        assertArrayEquals(ISOUtil.hex2byte("217CF53EA0E7C327"), mac);
+    }
+
+    @Test
+    public void testGenerateSM_MACDirect_MCHIP_ShortData() throws Throwable {
+        EMVDerivedKey<SecureDESKey> skSmi = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.MCHIP, imksmi,
+                accountNoA, accountNoA_CSN, null, arqc01);
+
+        byte[] data = ISOUtil.hex2byte("11");
+        byte[] apdu = ISOUtil.concat(apdu01, atc01);
+        apdu = ISOUtil.concat(apdu, arqc01);
+        apdu = ISOUtil.concat(apdu, data);
+
+        byte[] mac = jcesecmod.generateSM_MAC(skSmi.key(), apdu);
+        assertArrayEquals(ISOUtil.hex2byte("5E14A5A5C4B98C0C"), mac);
+    }
+
+    @Test
+    public void testGenerateSM_MACDirect_VSDC_LongData() throws Throwable {
+        EMVDerivedKey<SecureDESKey> skSmi = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.VSDC, imksmi,
+                accountNoA, accountNoA_CSN, atc01, null);
+
+        byte[] data = ISOUtil.hex2byte("1122334455667788");
+        byte[] apdu = ISOUtil.concat(apdu01, atc01);
+        apdu = ISOUtil.concat(apdu, arqc01);
+        apdu = ISOUtil.concat(apdu, data);
+
+        byte[] mac = jcesecmod.generateSM_MAC(skSmi.key(), apdu);
+        assertArrayEquals(ISOUtil.hex2byte("E218CC0B7FEC6876"), mac);
+    }
+
+    @Test
+    public void testGenerateSM_MACDirect_VSDC_ShortData() throws Throwable {
+        EMVDerivedKey<SecureDESKey> skSmi = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.VSDC, imksmi,
+                accountNoA, accountNoA_CSN, atc01, null);
+
+        byte[] data = ISOUtil.hex2byte("11");
+        byte[] apdu = ISOUtil.concat(apdu01, atc01);
+        apdu = ISOUtil.concat(apdu, arqc01);
+        apdu = ISOUtil.concat(apdu, data);
+
+        byte[] mac = jcesecmod.generateSM_MAC(skSmi.key(), apdu);
+        assertArrayEquals(ISOUtil.hex2byte("C1F2C04136BD48E6"), mac);
+    }
+
+    @Test
+    public void testGenerateSM_MACDirect_Deterministic() throws Throwable {
+        EMVDerivedKey<SecureDESKey> skSmi = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.MCHIP, imksmi,
+                accountNoA, accountNoA_CSN, null, arqc01);
+        byte[] data = ISOUtil.hex2byte("1122334455667788");
+        byte[] a = jcesecmod.generateSM_MAC(skSmi.key(), data);
+        byte[] b = jcesecmod.generateSM_MAC(skSmi.key(), data);
+        assertArrayEquals(a, b);
+        assertEquals(8, a.length);
+    }
+
 }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -2036,12 +2036,12 @@ public class JCESecurityModuleTest {
     }
 
     @Test
-    public void testCalculateKCV_3DES_StandardAlgorithm() throws Throwable {
+    public void testCalculateKeyCheckValue_3DES_StandardAlgorithm() throws Throwable {
         byte[] clearKey = ISOUtil.hex2byte("0123456789ABCDEFFEDCBA9876543210");
         java.security.Key key = jcesecmod.jceHandler
                 .formDESKey(SMAdapter.LENGTH_DES3_2KEY, clearKey);
 
-        byte[] kcv = jcesecmod.calculateKCV(key);
+        byte[] kcv = jcesecmod.calculateKeyCheckValue(key);
 
         assertEquals(3, kcv.length);
 

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -37,6 +37,7 @@ import org.jpos.security.ARPCMethod;
 import org.jpos.security.CipherMode;
 import org.jpos.security.EMVCAPublicKey;
 import org.jpos.security.EMVDerivedKey;
+import org.jpos.security.EMVICCPublicKey;
 import org.jpos.security.EMVIssuerPublicKey;
 import org.jpos.security.EncryptedPIN;
 import org.jpos.security.KeyScheme;
@@ -2636,6 +2637,9 @@ public class JCESecurityModuleTest {
         java.security.KeyPair issuerKp = kpg.generateKeyPair();
         pr9IssuerN = ((java.security.interfaces.RSAPublicKey) issuerKp.getPublic()).getModulus();
         java.math.BigInteger issuerE = ((java.security.interfaces.RSAPublicKey) issuerKp.getPublic()).getPublicExponent();
+        // Capture issuer's public + private exponents for PR 10's ICC cert signing
+        pr10IssuerE = issuerE;
+        pr10IssuerD = ((java.security.interfaces.RSAPrivateKey) issuerKp.getPrivate()).getPrivateExponent();
 
         pr9CaModulus  = bigIntToFixed(pr9CaN, PR9_NCA);
         pr9CaExponent = trimLeadingZeros(pr9CaE.toByteArray());
@@ -2652,6 +2656,11 @@ public class JCESecurityModuleTest {
                 (byte) 0x01, (byte) 0x01, pr9IssuerModulus, pr9IssuerExp);
         pr9HappyCert = signWithCA(payload);
         pr9HappyRemainder = java.util.Arrays.copyOfRange(pr9IssuerModulus, PR9_NCA - 36, PR9_NI);
+
+        // PR 10 fixtures continue here so JUnit 5's non-deterministic
+        // @BeforeAll ordering can't leave pr10IssuerD null when
+        // signWithIssuer runs.
+        setUpPR10Fixtures(kpg);
     }
 
     private static byte[] buildPayload(byte[] issuerId, byte[] expDate, byte[] serial,
@@ -2816,6 +2825,227 @@ public class JCESecurityModuleTest {
                         pr9IssuerExp, "99990000123456"));
         assertTrue(ex.getMessage().toLowerCase().contains("issuer identifier"),
                 "expected 'issuer identifier' in error: " + ex.getMessage());
+    }
+
+    // ----------------------------------------------------------------------
+    // PR 10 — Recover ICC Public Key (EMV 4.4 Book 2 §6.4)
+    // ----------------------------------------------------------------------
+    //
+    // Builds on the PR 9 CA + Issuer keypair fixture, adds a 512-bit ICC
+    // keypair, constructs an ICC PK certificate signed with the issuer
+    // private exponent, and recovers it via the full PR 9 → PR 10 chain.
+
+    private static final byte[] PR10_APP_PAN_BCD = ISOUtil.hex2byte("12345678901234FFFFFF");
+    private static final String PR10_APP_PAN_STR = "12345678901234";
+    private static final byte[] PR10_SAD = ISOUtil.hex2byte(
+            "70819F36020001821C90DEADBEEF1234ABCDEFFEDCBA0987654321");
+
+    private static java.math.BigInteger pr10IssuerD;
+    private static byte[] pr10IccModulus;
+    private static byte[] pr10IccExp;
+    private static byte[] pr10HappyCert;
+    private static byte[] pr10HappyRemainder;  // empty for 512-bit ICC inside 768-bit issuer
+
+    // Called from setUpPR9Fixtures (NOT a separate @BeforeAll method) to
+    // guarantee setUpPR9Fixtures runs first; JUnit 5 does not order
+    // multiple @BeforeAll methods deterministically.
+    private static void setUpPR10Fixtures(java.security.KeyPairGenerator kpg) throws Exception {
+        // ICC keypair: 512 bits → 64-byte modulus. NI = issuer modulus length
+        // = 96 bytes, NI - 42 = 54 bytes "leftmost slot". A 512-bit (64-byte)
+        // ICC modulus exceeds 54, so remainder = 64 - 54 = 10 bytes —
+        // exercising the remainder path of the recovery routine.
+        kpg.initialize(512);
+        java.security.KeyPair iccKp = kpg.generateKeyPair();
+        java.math.BigInteger iccN = ((java.security.interfaces.RSAPublicKey) iccKp.getPublic()).getModulus();
+        java.math.BigInteger iccE = ((java.security.interfaces.RSAPublicKey) iccKp.getPublic()).getPublicExponent();
+
+        pr10IccModulus = bigIntToFixed(iccN, 64);
+        pr10IccExp     = trimLeadingZeros(iccE.toByteArray());
+
+        byte[] payload = buildICCPayload(PR10_APP_PAN_BCD, PR9_EXP_FUTURE, PR9_SERIAL,
+                (byte) 0x01, (byte) 0x01, pr10IccModulus, pr10IccExp, PR10_SAD);
+        pr10HappyCert = signWithIssuer(payload);
+
+        int nic = pr10IccModulus.length;      // 64
+        int iccInCert = Math.min(nic, PR9_NI - 42);  // min(64, 54) = 54
+        pr10HappyRemainder = java.util.Arrays.copyOfRange(pr10IccModulus, iccInCert, nic);
+    }
+
+    private static byte[] buildICCPayload(byte[] appPan, byte[] expDate, byte[] serial,
+            byte hashAlg, byte pkAlg, byte[] iccModulus, byte[] iccExp,
+            byte[] sad) throws Exception {
+        int ni  = PR9_NI;
+        int nic = iccModulus.length;
+        int iccInCert = Math.min(nic, ni - 42);
+        byte[] payload = new byte[ni];
+        payload[0] = (byte) 0x6A;
+        payload[1] = (byte) 0x04;
+        System.arraycopy(appPan,  0, payload, 2,  10);
+        System.arraycopy(expDate, 0, payload, 12, 2);
+        System.arraycopy(serial,  0, payload, 14, 3);
+        payload[17] = hashAlg;
+        payload[18] = pkAlg;
+        payload[19] = (byte) nic;
+        payload[20] = (byte) iccExp.length;
+        System.arraycopy(iccModulus, 0, payload, 21, iccInCert);
+        for (int i = 21 + iccInCert; i < ni - 21; i++) payload[i] = (byte) 0xBB;
+        // SHA-1 over payload[1..ni-22] || remainder || iccExp || sad
+        java.security.MessageDigest sha = java.security.MessageDigest.getInstance("SHA-1");
+        sha.update(payload, 1, ni - 22);
+        if (nic > iccInCert)
+            sha.update(iccModulus, iccInCert, nic - iccInCert);
+        sha.update(iccExp);
+        if (sad != null && sad.length > 0) sha.update(sad);
+        System.arraycopy(sha.digest(), 0, payload, ni - 21, 20);
+        payload[ni - 1] = (byte) 0xBC;
+        return payload;
+    }
+
+    private static byte[] signWithIssuer(byte[] payload) {
+        java.math.BigInteger m = new java.math.BigInteger(1, payload);
+        java.math.BigInteger s = m.modPow(pr10IssuerD, pr9IssuerN);
+        return bigIntToFixed(s, payload.length);
+    }
+
+    private static byte[] mutateAndSignICC(byte[] signedCert, java.util.function.Consumer<byte[]> mutator) {
+        // Decrypt under issuer public exponent, mutate, re-sign with issuer private exponent.
+        java.math.BigInteger sig = new java.math.BigInteger(1, signedCert);
+        byte[] payload = bigIntToFixed(sig.modPow(pr10IssuerE, pr9IssuerN), signedCert.length);
+        mutator.accept(payload);
+        return signWithIssuer(payload);
+    }
+
+    // Captured at PR 10 init so mutateAndSignICC can decrypt + re-sign.
+    private static java.math.BigInteger pr10IssuerE;
+
+    @Test
+    public void testRecoverICCPublicKey_HappyPath() throws Throwable {
+        // Chain: recover issuer first via PR 9, then recover ICC via PR 10.
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+
+        EMVICCPublicKey result = jcesecmod.recoverICCPublicKey(
+                issuer, pr10HappyCert, pr10HappyRemainder, pr10IccExp,
+                PR10_SAD, PR10_APP_PAN_STR);
+
+        assertArrayEquals(PR10_APP_PAN_BCD, result.applicationPan());
+        assertArrayEquals(PR9_EXP_FUTURE,   result.expirationDate());
+        assertArrayEquals(PR9_SERIAL,       result.serialNumber());
+        assertArrayEquals(pr10IccModulus,   result.modulus());
+        assertArrayEquals(pr10IccExp,       result.exponent());
+        assertEquals((byte) 0x01, result.hashAlgorithmIndicator());
+        assertEquals((byte) 0x01, result.publicKeyAlgorithmIndicator());
+    }
+
+    @Test
+    public void testRecoverICCPublicKey_NullPAN_SkipsPanCheck() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        EMVICCPublicKey result = jcesecmod.recoverICCPublicKey(
+                issuer, pr10HappyCert, pr10HappyRemainder, pr10IccExp, PR10_SAD, null);
+        assertArrayEquals(PR10_APP_PAN_BCD, result.applicationPan());
+    }
+
+    @Test
+    public void testRecoverICCPublicKey_BadHeader_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] bad = mutateAndSignICC(pr10HappyCert, p -> p[0] = (byte) 0x6B);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverICCPublicKey(issuer, bad, pr10HappyRemainder, pr10IccExp,
+                        PR10_SAD, PR10_APP_PAN_STR));
+        assertTrue(ex.getMessage().toLowerCase().contains("header"),
+                "expected 'header' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverICCPublicKey_BadFormat_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        // 0x04 → 0x02 (issuer cert format used by mistake)
+        byte[] bad = mutateAndSignICC(pr10HappyCert, p -> p[1] = (byte) 0x02);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverICCPublicKey(issuer, bad, pr10HappyRemainder, pr10IccExp,
+                        PR10_SAD, PR10_APP_PAN_STR));
+        assertTrue(ex.getMessage().toLowerCase().contains("certificate format"),
+                "expected 'certificate format' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverICCPublicKey_BadTrailer_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] bad = mutateAndSignICC(pr10HappyCert, p -> p[PR9_NI - 1] = (byte) 0xBD);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverICCPublicKey(issuer, bad, pr10HappyRemainder, pr10IccExp,
+                        PR10_SAD, PR10_APP_PAN_STR));
+        assertTrue(ex.getMessage().toLowerCase().contains("trailer"),
+                "expected 'trailer' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverICCPublicKey_BadHash_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        // Flip a bit in the embedded hash (bytes ni-21..ni-2).
+        byte[] bad = mutateAndSignICC(pr10HappyCert, p -> p[PR9_NI - 10] ^= 0x01);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverICCPublicKey(issuer, bad, pr10HappyRemainder, pr10IccExp,
+                        PR10_SAD, PR10_APP_PAN_STR));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash"),
+                "expected 'hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverICCPublicKey_SADCorruption_Throws() throws Throwable {
+        // Pass a different SAD at recovery time than was used at cert build
+        // time. The cert is otherwise valid; only the SAD-in-hash-input
+        // changes. This is unique to ICC PK recovery (vs Issuer PK).
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] wrongSad = ISOUtil.hex2byte("DEADBEEFCAFEBABE");
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverICCPublicKey(issuer, pr10HappyCert, pr10HappyRemainder,
+                        pr10IccExp, wrongSad, PR10_APP_PAN_STR));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash"),
+                "expected 'hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverICCPublicKey_UnsupportedHashAlgo_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] bad = mutateAndSignICC(pr10HappyCert, p -> p[17] = (byte) 0x02);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverICCPublicKey(issuer, bad, pr10HappyRemainder, pr10IccExp,
+                        PR10_SAD, PR10_APP_PAN_STR));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash algorithm"),
+                "expected 'hash algorithm' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverICCPublicKey_ExpiredDate_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        byte[] payload = buildICCPayload(PR10_APP_PAN_BCD, PR9_EXP_PAST, PR9_SERIAL,
+                (byte) 0x01, (byte) 0x01, pr10IccModulus, pr10IccExp, PR10_SAD);
+        byte[] expiredCert = signWithIssuer(payload);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverICCPublicKey(issuer, expiredCert, pr10HappyRemainder,
+                        pr10IccExp, PR10_SAD, PR10_APP_PAN_STR));
+        assertTrue(ex.getMessage().toLowerCase().contains("expired"),
+                "expected 'expired' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverICCPublicKey_PanMismatch_Throws() throws Throwable {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverICCPublicKey(issuer, pr10HappyCert, pr10HappyRemainder,
+                        pr10IccExp, PR10_SAD, "99999999999999"));
+        assertTrue(ex.getMessage().toLowerCase().contains("application pan"),
+                "expected 'application pan' in error: " + ex.getMessage());
     }
 
 }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -36,6 +36,7 @@ import org.jpos.iso.ISOUtil;
 import org.jpos.security.ARPCMethod;
 import org.jpos.security.CipherMode;
 import org.jpos.security.EMVCAPublicKey;
+import org.jpos.security.EMVCDAResult;
 import org.jpos.security.EMVDerivedKey;
 import org.jpos.security.EMVICCPublicKey;
 import org.jpos.security.EMVIssuerPublicKey;
@@ -3231,6 +3232,9 @@ public class JCESecurityModuleTest {
         // (pr12IccD captured during setUpPR10Fixtures).
         pr12HappySDAD = buildSDAD(PR12_ICC_DYNAMIC_NUMBER, (byte) 0x01,
                 (byte) 0x05, (byte) 0xBB, PR12_DDOL);
+
+        // Continue into PR 13 setup while we hold all dependencies.
+        setUpPR13Fixtures();
     }
 
     private static byte[] buildSDAD(byte[] iccDynamicNumber, byte hashAlg, byte format,
@@ -3367,6 +3371,188 @@ public class JCESecurityModuleTest {
         byte[] tooShort = java.util.Arrays.copyOfRange(pr12HappySDAD, 0, pr12HappySDAD.length - 1);
         SMException ex = assertThrows(SMException.class, () ->
                 jcesecmod.verifyDDA(icc, tooShort, PR12_DDOL));
+        assertTrue(ex.getMessage().toLowerCase().contains("length"),
+                "expected 'length' in error: " + ex.getMessage());
+    }
+
+    // ----------------------------------------------------------------------
+    // PR 13 — Verify CDA (Combined DDA + AC, EMV 4.4 Book 2 §6.6)
+    // ----------------------------------------------------------------------
+    //
+    // CDA SDAD shares EMV tag 0x9F4B with DDA SDAD (PR 12) but the inner
+    // ICC Dynamic Data block carries LDN + ICC Dynamic Number + CID + AC +
+    // SHA-1(transactionData), giving LDD = LDN + 30. The signature input
+    // is recovered[1..nic-21) || UN (the terminal's Unpredictable Number).
+
+    private static final byte[] PR13_UN  = ISOUtil.hex2byte("9988AABB");
+    private static final byte[] PR13_AC  = ISOUtil.hex2byte("ABCDEF0123456789");
+    private static final byte   PR13_CID = (byte) 0x40;
+    private static final byte[] PR13_TRANSACTION_DATA = ISOUtil.hex2byte(
+            "9F02060000000010009F0306000000000000");
+    private static final byte[] PR13_ICC_DYNAMIC_NUMBER = ISOUtil.hex2byte("DEADBEEF");
+
+    private static byte[] pr13HappyCDASDAD;
+
+    // Called from setUpPR12Fixtures (NOT a separate @BeforeAll method) for
+    // the same reason as setUpPR10/12: deterministic ordering of fixtures
+    // with cross-dependencies.
+    private static void setUpPR13Fixtures() throws Exception {
+        pr13HappyCDASDAD = buildCDASDAD(PR13_ICC_DYNAMIC_NUMBER, PR13_CID,
+                PR13_AC, PR13_TRANSACTION_DATA, (byte) 0xBB, (byte) 0x01, (byte) 0x05);
+    }
+
+    private static byte[] buildCDASDAD(byte[] iccDynamicNumber, byte cid,
+            byte[] ac, byte[] transactionData, byte padByte,
+            byte hashAlg, byte format) throws Exception {
+        int nic = pr10IccModulus.length;          // 64
+        int ldn = iccDynamicNumber.length;        // 4
+        int ldd = ldn + 30;                       // 34 for LDN=4
+        byte[] payload = new byte[nic];
+        payload[0] = (byte) 0x6A;
+        payload[1] = format;
+        payload[2] = hashAlg;
+        payload[3] = (byte) ldd;
+        payload[4] = (byte) ldn;
+        System.arraycopy(iccDynamicNumber, 0, payload, 5, ldn);
+        payload[5 + ldn] = cid;
+        System.arraycopy(ac, 0, payload, 5 + ldn + 1, 8);
+        // Transaction Data Hash
+        java.security.MessageDigest sha = java.security.MessageDigest.getInstance("SHA-1");
+        byte[] txnHash = sha.digest(transactionData == null ? new byte[0] : transactionData);
+        System.arraycopy(txnHash, 0, payload, 5 + ldn + 9, 20);
+        for (int i = 4 + ldd; i < nic - 21; i++) payload[i] = padByte;
+        // Outer hash: payload[1..nic-21) || UN
+        sha.reset();
+        sha.update(payload, 1, nic - 22);
+        sha.update(PR13_UN);
+        System.arraycopy(sha.digest(), 0, payload, nic - 21, 20);
+        payload[nic - 1] = (byte) 0xBC;
+        return signWithICC(payload);
+    }
+
+    private static byte[] mutateAndSignCDASDAD(byte[] signed, java.util.function.Consumer<byte[]> mutator) {
+        java.math.BigInteger sig = new java.math.BigInteger(1, signed);
+        byte[] payload = bigIntToFixed(sig.modPow(pr12IccE, pr12IccN), signed.length);
+        mutator.accept(payload);
+        return signWithICC(payload);
+    }
+
+    @Test
+    public void testVerifyCDA_HappyPath() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        EMVCDAResult result = jcesecmod.verifyCDA(icc, pr13HappyCDASDAD,
+                PR13_UN, PR13_AC, PR13_TRANSACTION_DATA);
+        assertArrayEquals(PR13_ICC_DYNAMIC_NUMBER, result.iccDynamicNumber());
+        assertEquals(PR13_CID, result.cid());
+    }
+
+    @Test
+    public void testVerifyCDA_BadHeader_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] bad = mutateAndSignCDASDAD(pr13HappyCDASDAD, p -> p[0] = (byte) 0x6B);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyCDA(icc, bad, PR13_UN, PR13_AC, PR13_TRANSACTION_DATA));
+        assertTrue(ex.getMessage().toLowerCase().contains("header"),
+                "expected 'header' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyCDA_BadFormat_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] bad = mutateAndSignCDASDAD(pr13HappyCDASDAD, p -> p[1] = (byte) 0x03);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyCDA(icc, bad, PR13_UN, PR13_AC, PR13_TRANSACTION_DATA));
+        assertTrue(ex.getMessage().toLowerCase().contains("signed data format"),
+                "expected 'signed data format' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyCDA_BadTrailer_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] bad = mutateAndSignCDASDAD(pr13HappyCDASDAD,
+                p -> p[pr10IccModulus.length - 1] = (byte) 0xBD);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyCDA(icc, bad, PR13_UN, PR13_AC, PR13_TRANSACTION_DATA));
+        assertTrue(ex.getMessage().toLowerCase().contains("trailer"),
+                "expected 'trailer' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyCDA_UnsupportedHashAlgo_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] bad = mutateAndSignCDASDAD(pr13HappyCDASDAD, p -> p[2] = (byte) 0x02);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyCDA(icc, bad, PR13_UN, PR13_AC, PR13_TRANSACTION_DATA));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash algorithm"),
+                "expected 'hash algorithm' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyCDA_BadPadding_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] badPad = buildCDASDAD(PR13_ICC_DYNAMIC_NUMBER, PR13_CID,
+                PR13_AC, PR13_TRANSACTION_DATA, (byte) 0xBC, (byte) 0x01, (byte) 0x05);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyCDA(icc, badPad, PR13_UN, PR13_AC, PR13_TRANSACTION_DATA));
+        assertTrue(ex.getMessage().toLowerCase().contains("pad pattern"),
+                "expected 'pad pattern' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyCDA_BadHash_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] bad = mutateAndSignCDASDAD(pr13HappyCDASDAD,
+                p -> p[pr10IccModulus.length - 10] ^= 0x01);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyCDA(icc, bad, PR13_UN, PR13_AC, PR13_TRANSACTION_DATA));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash"),
+                "expected 'hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyCDA_ACMismatch_Throws() throws Throwable {
+        // Unique to CDA — the AC embedded in the SDAD does not match the
+        // supplied AC. This catches a malicious card that signs one AC
+        // and returns a different one out-of-band.
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] differentAC = ISOUtil.hex2byte("FFEEDDCCBBAA9988");
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyCDA(icc, pr13HappyCDASDAD, PR13_UN,
+                        differentAC, PR13_TRANSACTION_DATA));
+        assertTrue(ex.getMessage().toLowerCase().contains("application cryptogram"),
+                "expected 'application cryptogram' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyCDA_TransactionDataMismatch_Throws() throws Throwable {
+        // Unique to CDA — the transaction data hash embedded in the SDAD
+        // does not match SHA-1 of supplied transaction data.
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] differentTxn = ISOUtil.hex2byte("9F0206000000099999");
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyCDA(icc, pr13HappyCDASDAD, PR13_UN, PR13_AC, differentTxn));
+        assertTrue(ex.getMessage().toLowerCase().contains("transaction data hash"),
+                "expected 'transaction data hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyCDA_UNCorruption_Throws() throws Throwable {
+        // UN is in the outer hash input; mismatching it surfaces as a
+        // hash failure (analogous to PR 12's DDOLCorruption case).
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] wrongUN = ISOUtil.hex2byte("00000000");
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyCDA(icc, pr13HappyCDASDAD, wrongUN, PR13_AC, PR13_TRANSACTION_DATA));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash"),
+                "expected 'hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyCDA_WrongLength_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] tooShort = java.util.Arrays.copyOfRange(pr13HappyCDASDAD, 0, pr13HappyCDASDAD.length - 1);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyCDA(icc, tooShort, PR13_UN, PR13_AC, PR13_TRANSACTION_DATA));
         assertTrue(ex.getMessage().toLowerCase().contains("length"),
                 "expected 'length' in error: " + ex.getMessage());
     }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -1315,6 +1315,88 @@ public class JCESecurityModuleTest {
         assertTrue(result);
     }
 
+    @Test
+    public void testGenerateApplicationCryptogram_VSDC_P00() throws Throwable {
+        byte[] expected = ISOUtil.hex2byte("26C8A1042D1CAF3E");
+        byte[] result = jcesecmod.generateApplicationCryptogram(MKDMethod.OPTION_A, SKDMethod.VSDC
+                        ,imkac, accountNoA, accountNoA_CSN
+                        ,etd.getATC(), null, etd.getDataNoPad()
+        );
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    public void testGenerateApplicationCryptogram_VSDC_P80() throws Throwable {
+        byte[] expected = ISOUtil.hex2byte("2263CD868F3E0234");
+        byte[] result = jcesecmod.generateApplicationCryptogram(MKDMethod.OPTION_A, SKDMethod.VSDC
+                        ,imkac, accountNoA, accountNoA_CSN
+                        ,etd.getATC(), null, etd.getDataPad80()
+        );
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    public void testGenerateApplicationCryptogram_MCHIP_P00() throws Throwable {
+        byte[] expected = ISOUtil.hex2byte("9FFD1D52AE0EC0F3");
+        byte[] result = jcesecmod.generateApplicationCryptogram(MKDMethod.OPTION_A, SKDMethod.MCHIP
+                        ,imkac, accountNoA, accountNoA_CSN
+                        ,etd.getATC(), etd.getUPN(), etd.getDataNoPad()
+        );
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    public void testGenerateApplicationCryptogram_MCHIP_P80() throws Throwable {
+        byte[] expected = ISOUtil.hex2byte("AC8074C9E62EE6EF");
+        byte[] result = jcesecmod.generateApplicationCryptogram(MKDMethod.OPTION_A, SKDMethod.MCHIP
+                        ,imkac, accountNoA, accountNoA_CSN
+                        ,etd.getATC(), etd.getUPN(), etd.getDataPad80()
+        );
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    public void testGenerateApplicationCryptogram_CSKD_P00() throws Throwable {
+        byte[] expected = ISOUtil.hex2byte("36DBEE15F36B1E7F");
+        byte[] result = jcesecmod.generateApplicationCryptogram(MKDMethod.OPTION_A, SKDMethod.EMV_CSKD
+                        ,imkac, accountNoA, accountNoA_CSN
+                        ,etd.getATC(), null, etd.getDataNoPad()
+        );
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    public void testGenerateApplicationCryptogram_CSKD_P80() throws Throwable {
+        byte[] expected = ISOUtil.hex2byte("55BE45DD2C9E0CBF");
+        byte[] result = jcesecmod.generateApplicationCryptogram(MKDMethod.OPTION_A, SKDMethod.EMV_CSKD
+                        ,imkac, accountNoA, accountNoA_CSN
+                        ,etd.getATC(), null, etd.getDataPad80()
+        );
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    public void testGenerateApplicationCryptogram_VSDC_P00_RoundTrip() throws Throwable {
+        byte[] generated = jcesecmod.generateApplicationCryptogram(MKDMethod.OPTION_A, SKDMethod.VSDC
+                        ,imkac, accountNoA, accountNoA_CSN
+                        ,etd.getATC(), null, etd.getDataNoPad()
+        );
+        assertTrue(jcesecmod.verifyARQC(MKDMethod.OPTION_A, SKDMethod.VSDC
+                        ,imkac, accountNoA, accountNoA_CSN, generated
+                        ,etd.getATC(), null, etd.getDataNoPad()
+        ));
+    }
+
+    @Test
+    public void testGenerateApplicationCryptogram_RejectsUnsupportedSKD() throws Throwable {
+        assertThrows(SMException.class, () -> {
+            jcesecmod.generateApplicationCryptogram(MKDMethod.OPTION_A, SKDMethod.AEPIS_V40
+                            ,imkac, accountNoA, accountNoA_CSN
+                            ,etd.getATC(), null, etd.getDataNoPad()
+            );
+        });
+    }
+
     @Test //OK
     public void testVerifyARQCGenerateARPCImpl_VSDC_P00_M1() throws Throwable {
         byte[] arqc   = ISOUtil.hex2byte("26C8A1042D1CAF3E");

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -1060,6 +1060,126 @@ public class JCESecurityModuleTest {
     }
 
     @Test
+    public void testGeneratedCVV_OptionA_KnownVector() throws Throwable {
+        String accountNo = "1234567890123456";
+        String expDate = "1310";
+        String serviceCode = "226";
+        byte[] atc = ISOUtil.hex2byte("3210");
+        String result = jcesecmod.generatedCVV(accountNo, imkac, expDate
+                        ,serviceCode, atc, MKDMethod.OPTION_A);
+        assertEquals("422", result);
+    }
+
+    @Test
+    public void testGeneratedCVV_OptionA_RoundTrip() throws Throwable {
+        String accountNo = "1234567890123456";
+        String expDate = "1310";
+        String serviceCode = "226";
+        byte[] atc = ISOUtil.hex2byte("3210");
+        String generated = jcesecmod.generatedCVV(accountNo, imkac, expDate
+                        ,serviceCode, atc, MKDMethod.OPTION_A);
+        assertTrue(jcesecmod.verifydCVV(accountNo, imkac, generated, expDate
+                        ,serviceCode, atc, MKDMethod.OPTION_A));
+    }
+
+    @Test
+    public void testGeneratedCVV_OptionB_KnownVector() throws Throwable {
+        String accountNo = "123456789012";
+        String expDate = "1310";
+        String serviceCode = "226";
+        byte[] atc = ISOUtil.hex2byte("3210");
+        String result = jcesecmod.generatedCVV(accountNo, imkac, expDate
+                        ,serviceCode, atc, MKDMethod.OPTION_B);
+        assertEquals("824", result);
+    }
+
+    @Test
+    public void testGeneratedCVV_OptionB_RoundTrip() throws Throwable {
+        String accountNo = "1234567890123456789";
+        String expDate = "1310";
+        String serviceCode = "226";
+        byte[] atc = ISOUtil.hex2byte("3210");
+        String generated = jcesecmod.generatedCVV(accountNo, imkac, expDate
+                        ,serviceCode, atc, MKDMethod.OPTION_B);
+        assertTrue(jcesecmod.verifydCVV(accountNo, imkac, generated, expDate
+                        ,serviceCode, atc, MKDMethod.OPTION_B));
+    }
+
+    @Test
+    public void testGeneratedCVV_RejectsEmptyAccountNo() throws Throwable {
+        String accountNo = "";
+        String expDate = "1310";
+        String serviceCode = "226";
+        byte[] atc = ISOUtil.hex2byte("3210");
+        assertThrows(IllegalArgumentException.class, () -> {
+            jcesecmod.generatedCVV(accountNo, imkac, expDate
+              ,serviceCode, atc, MKDMethod.OPTION_A);
+        });
+    }
+
+    @Test
+    public void testGenerateCVC3_OptionA_KnownVector() throws Throwable {
+        String accountNo = "1234567890123456";
+        String accntSeqNo = "00";
+        byte[] data = ISOUtil.hex2byte("1234567890123456D12012061000110000000FFFFFFFFFFF");
+        byte[] atc = ISOUtil.hex2byte("2710");
+        byte[] upn = ISOUtil.hex2byte("00002710");
+        String result = jcesecmod.generateCVC3(imkcvc3, accountNo, accntSeqNo, atc
+                        ,upn, data, MKDMethod.OPTION_A);
+        assertEquals("45423", result);
+    }
+
+    @Test
+    public void testGenerateCVC3_OptionA_IVCVC3() throws Throwable {
+        String accountNo = "1234567890123456";
+        String accntSeqNo = "00";
+        byte[] ivcvc3 = ISOUtil.hex2byte("CD76");
+        byte[] atc = ISOUtil.hex2byte("2710");
+        byte[] upn = ISOUtil.hex2byte("00002710");
+        String result = jcesecmod.generateCVC3(imkcvc3, accountNo, accntSeqNo, atc
+                        ,upn, ivcvc3, MKDMethod.OPTION_A);
+        assertEquals("39464", result);
+    }
+
+    @Test
+    public void testGenerateCVC3_OptionA_RoundTrip() throws Throwable {
+        String accountNo = "1234567890123456";
+        String accntSeqNo = "00";
+        byte[] data = ISOUtil.hex2byte("1234567890123456D12012061000110000000F");
+        byte[] atc = ISOUtil.hex2byte("2710");
+        byte[] upn = ISOUtil.hex2byte("00002710");
+        String generated = jcesecmod.generateCVC3(imkcvc3, accountNo, accntSeqNo, atc
+                        ,upn, data, MKDMethod.OPTION_A);
+        assertTrue(jcesecmod.verifyCVC3(imkcvc3, accountNo, accntSeqNo, atc
+                        ,upn, data, MKDMethod.OPTION_A, generated));
+    }
+
+    @Test
+    public void testGenerateCVC3_OptionB_KnownVector() throws Throwable {
+        String accountNo = "1234567890123456";
+        String accntSeqNo = "00";
+        byte[] data = ISOUtil.hex2byte("1234567890123456D12012061000110000000F");
+        byte[] atc = ISOUtil.hex2byte("2710");
+        byte[] upn = ISOUtil.hex2byte("00002710");
+        String result = jcesecmod.generateCVC3(imkcvc3, accountNo, accntSeqNo, atc
+                        ,upn, data, MKDMethod.OPTION_B);
+        assertEquals("03518", result);
+    }
+
+    @Test
+    public void testGenerateCVC3_OptionB_RoundTrip() throws Throwable {
+        String accountNo = "123456789012345";
+        String accntSeqNo = "00";
+        byte[] data = ISOUtil.hex2byte("123456789012345D12012061000110000000");
+        byte[] atc = ISOUtil.hex2byte("2710");
+        byte[] upn = ISOUtil.hex2byte("00002710");
+        String generated = jcesecmod.generateCVC3(imkcvc3, accountNo, accntSeqNo, atc
+                        ,upn, data, MKDMethod.OPTION_B);
+        assertTrue(jcesecmod.verifyCVC3(imkcvc3, accountNo, accntSeqNo, atc
+                        ,upn, data, MKDMethod.OPTION_B, generated));
+    }
+
+    @Test
     public void testGenerateARPCImpl_VSDC_M1() throws Throwable {
         byte[] arqc   = ISOUtil.hex2byte("26C8A1042D1CAF3E");
         byte[] arc    = ISOUtil.hex2byte("3030");

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -2502,4 +2502,94 @@ public class JCESecurityModuleTest {
         assertEquals(8, a.length);
     }
 
+    @Test
+    public void testEncryptSecureMessagingPIN_MCHIP_Format34_MatchesIntegrated() throws Throwable {
+        // Mirrors testTranslatePINGenerateSM_MACImpl1: MCHIP + FORMAT34, no UDK, no current PIN.
+        EMVDerivedKey<SecureDESKey> skSmc = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.MCHIP, imksmc,
+                accountNoA, accountNoA_CSN, null, arqc01);
+
+        EncryptedPIN result = jcesecmod.encryptSecureMessagingPIN(
+                skSmc.key(), pinUnderZPK, zpk, SMAdapter.FORMAT34,
+                PaddingMethod.MCHIP, null, null);
+
+        EncryptedPIN expected = new EncryptedPIN("F473D25D9B478970", SMAdapter.FORMAT34, accountNoA);
+        assertArrayEquals(expected.getPINBlock(), result.getPINBlock());
+        assertEquals(SMAdapter.FORMAT34, result.getPINBlockFormat());
+    }
+
+    @Test
+    public void testEncryptSecureMessagingPIN_CSKD_Format41_MatchesIntegrated() throws Throwable {
+        // Mirrors testTranslatePINGenerateSM_MACImpl2: EMV_CSKD + FORMAT41,
+        // CCD padding (the SKDMethod auto-derive); requires UDK-AC.
+        EMVDerivedKey<SecureDESKey> skSmc = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.EMV_CSKD, imksmc,
+                accountNoA, accountNoA_CSN, null, arqc01);
+        EMVDerivedKey<SecureDESKey> udkAc = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+
+        EncryptedPIN result = jcesecmod.encryptSecureMessagingPIN(
+                skSmc.key(), pinUnderZPK, zpk, SMAdapter.FORMAT41,
+                PaddingMethod.CCD, null, udkAc.key());
+
+        EncryptedPIN expected = new EncryptedPIN("E60663E4B11CDB2DE4667CC9433384B4",
+                SMAdapter.FORMAT41, accountNoA);
+        assertArrayEquals(expected.getPINBlock(), result.getPINBlock());
+        assertEquals(SMAdapter.FORMAT41, result.getPINBlockFormat());
+    }
+
+    @Test
+    public void testEncryptSecureMessagingPIN_VSDC_Format42_WithCurrentPIN_MatchesIntegrated() throws Throwable {
+        // Mirrors testTranslatePINGenerateSM_MACImpl6: VSDC + FORMAT42, requires
+        // both currentPIN and UDK-AC. VSDC SKDMethod auto-derives VSDC padding.
+        EMVDerivedKey<SecureDESKey> skSmc = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.VSDC, imksmc,
+                accountNoA, accountNoA_CSN, atc01, null);
+        EMVDerivedKey<SecureDESKey> udkAc = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        EncryptedPIN oldPin = new EncryptedPIN("33BADC0F07C6FB29",
+                SMAdapter.FORMAT01, accountNoA);
+
+        EncryptedPIN result = jcesecmod.encryptSecureMessagingPIN(
+                skSmc.key(), pinUnderZPK, zpk, SMAdapter.FORMAT42,
+                PaddingMethod.VSDC, oldPin, udkAc.key());
+
+        EncryptedPIN expected = new EncryptedPIN("74253653C81CE99140C47C0F7C572473",
+                SMAdapter.FORMAT42, accountNoA);
+        assertArrayEquals(expected.getPINBlock(), result.getPINBlock());
+        assertEquals(SMAdapter.FORMAT42, result.getPINBlockFormat());
+    }
+
+    @Test
+    public void testEncryptSecureMessagingPIN_NullPaddingDefaultsToMCHIP() throws Throwable {
+        EMVDerivedKey<SecureDESKey> skSmc = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.MCHIP, imksmc,
+                accountNoA, accountNoA_CSN, null, arqc01);
+
+        EncryptedPIN withNull = jcesecmod.encryptSecureMessagingPIN(
+                skSmc.key(), pinUnderZPK, zpk, SMAdapter.FORMAT34,
+                null, null, null);
+        EncryptedPIN withMCHIP = jcesecmod.encryptSecureMessagingPIN(
+                skSmc.key(), pinUnderZPK, zpk, SMAdapter.FORMAT34,
+                PaddingMethod.MCHIP, null, null);
+
+        assertArrayEquals(withMCHIP.getPINBlock(), withNull.getPINBlock());
+    }
+
+    @Test
+    public void testEncryptSecureMessagingPIN_Deterministic() throws Throwable {
+        EMVDerivedKey<SecureDESKey> skSmc = jcesecmod.deriveSecureMessagingSessionKey(
+                MKDMethod.OPTION_A, SKDMethod.MCHIP, imksmc,
+                accountNoA, accountNoA_CSN, null, arqc01);
+
+        EncryptedPIN a = jcesecmod.encryptSecureMessagingPIN(
+                skSmc.key(), pinUnderZPK, zpk, SMAdapter.FORMAT34,
+                PaddingMethod.MCHIP, null, null);
+        EncryptedPIN b = jcesecmod.encryptSecureMessagingPIN(
+                skSmc.key(), pinUnderZPK, zpk, SMAdapter.FORMAT34,
+                PaddingMethod.MCHIP, null, null);
+
+        assertArrayEquals(a.getPINBlock(), b.getPINBlock());
+    }
+
 }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -2226,4 +2226,95 @@ public class JCESecurityModuleTest {
         });
     }
 
+    @Test
+    public void testGenerateARPCDirect_VSDC_M1() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        byte[] arqc = ISOUtil.hex2byte("26C8A1042D1CAF3E");
+        byte[] arc  = ISOUtil.hex2byte("3030");
+        byte[] expectedArpc = ISOUtil.hex2byte("98DE7C7B3D80A831");
+        // VSDC: ARPC computed with the ICC MK directly (no session derivation)
+        byte[] result = jcesecmod.generateARPC(iccMk.key(), arqc,
+                ARPCMethod.METHOD_1, arc, null);
+        assertArrayEquals(expectedArpc, result);
+    }
+
+    @Test
+    public void testGenerateARPCDirect_MCHIP_M1() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        byte[] arqc = ISOUtil.hex2byte("AC8074C9E62EE6EF");
+        byte[] arc  = ISOUtil.hex2byte("0012");
+        byte[] expectedArpc = ISOUtil.hex2byte("5B5B712F9A644774");
+        // MCHIP: ARPC computed with the ICC MK directly (no ARPC-session derivation)
+        byte[] result = jcesecmod.generateARPC(iccMk.key(), arqc,
+                ARPCMethod.METHOD_1, arc, null);
+        assertArrayEquals(expectedArpc, result);
+    }
+
+    @Test
+    public void testGenerateARPCDirect_CSKD_M1() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveEMVSessionKey(
+                SKDMethod.EMV_CSKD, iccMk.key(), etd.getATC(), null);
+        byte[] arqc = ISOUtil.hex2byte("55BE45DD2C9E0CBF");
+        byte[] arc  = ISOUtil.hex2byte("0012");
+        byte[] expectedArpc = ISOUtil.hex2byte("01BAE8DE6A0DE9E0");
+        byte[] result = jcesecmod.generateARPC(session.key(), arqc,
+                ARPCMethod.METHOD_1, arc, null);
+        assertArrayEquals(expectedArpc, result);
+    }
+
+    @Test
+    public void testGenerateARPCDirect_CSKD_M2() throws Throwable {
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        EMVDerivedKey<SecureDESKey> session = jcesecmod.deriveEMVSessionKey(
+                SKDMethod.EMV_CSKD, iccMk.key(), etd.getATC(), null);
+        byte[] arqc = ISOUtil.hex2byte("55BE45DD2C9E0CBF");
+        byte[] csu  = ISOUtil.hex2byte("00120000");
+        byte[] expectedArpc = ISOUtil.hex2byte("B4C698B6");
+        byte[] result = jcesecmod.generateARPC(session.key(), arqc,
+                ARPCMethod.METHOD_2, csu, null);
+        assertArrayEquals(expectedArpc, result);
+    }
+
+    @Test
+    public void testGenerateARPCDirect_VSDC_M2_Succeeds_NoConstraint() throws Throwable {
+        // The master-key-based generateARPC rejects VSDC + METHOD_2 via
+        // constraintARPCM (see testGenerateARPCImpl_VSDC_M2). The direct
+        // overload deliberately drops that constraint — the math runs and
+        // returns a 4-byte ARPC. This test pins that behaviour and verifies
+        // the result is self-consistent with calculateARPC on the same key.
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        byte[] arqc = ISOUtil.hex2byte("26C8A1042D1CAF3E");
+        byte[] csu  = ISOUtil.hex2byte("00120000");
+        byte[] result = jcesecmod.generateARPC(iccMk.key(), arqc,
+                ARPCMethod.METHOD_2, csu, null);
+        assertEquals(4, result.length);
+        byte[] expected = jcesecmod.calculateARPC(
+                jcesecmod.decryptFromLMK(iccMk.key()), arqc,
+                ARPCMethod.METHOD_2, csu, null);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    public void testGenerateARPCDirect_MCHIP_M2_Succeeds_NoConstraint() throws Throwable {
+        // MCHIP + METHOD_2 also rejected by the master-key path; allowed
+        // here. Self-consistency check.
+        EMVDerivedKey<SecureDESKey> iccMk = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        byte[] arqc = ISOUtil.hex2byte("AC8074C9E62EE6EF");
+        byte[] csu  = ISOUtil.hex2byte("00120000");
+        byte[] result = jcesecmod.generateARPC(iccMk.key(), arqc,
+                ARPCMethod.METHOD_2, csu, null);
+        assertEquals(4, result.length);
+        byte[] expected = jcesecmod.calculateARPC(
+                jcesecmod.decryptFromLMK(iccMk.key()), arqc,
+                ARPCMethod.METHOD_2, csu, null);
+        assertArrayEquals(expected, result);
+    }
+
 }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -35,7 +35,9 @@ import org.jpos.core.SubConfiguration;
 import org.jpos.iso.ISOUtil;
 import org.jpos.security.ARPCMethod;
 import org.jpos.security.CipherMode;
+import org.jpos.security.EMVCAPublicKey;
 import org.jpos.security.EMVDerivedKey;
+import org.jpos.security.EMVIssuerPublicKey;
 import org.jpos.security.EncryptedPIN;
 import org.jpos.security.KeyScheme;
 import org.jpos.security.MKDMethod;
@@ -2590,6 +2592,230 @@ public class JCESecurityModuleTest {
                 PaddingMethod.MCHIP, null, null);
 
         assertArrayEquals(a.getPINBlock(), b.getPINBlock());
+    }
+
+    // ----------------------------------------------------------------------
+    // PR 9 — Recover Issuer Public Key (EMV 4.4 Book 2 §6)
+    // ----------------------------------------------------------------------
+    //
+    // Test strategy: hand-construct a synthetic CA+issuer RSA setup, build
+    // an Issuer Public Key Certificate by signing a known payload with the
+    // CA private key, then recover with the new public method. Tests use a
+    // mutator helper to corrupt one byte/field at a time for negative cases.
+
+    private static final int    PR9_NCA   = 128;          // 1024-bit CA modulus
+    private static final int    PR9_NI    = 96;           //  768-bit issuer modulus
+    private static final String PR9_PAN   = "12345678901234";
+    private static final byte[] PR9_ISSUER_ID  = ISOUtil.hex2byte("12345678");
+    private static final byte[] PR9_EXP_FUTURE = ISOUtil.hex2byte("1231");   // Dec 2031
+    private static final byte[] PR9_EXP_PAST   = ISOUtil.hex2byte("0101");   // Jan 2001
+    private static final byte[] PR9_SERIAL     = ISOUtil.hex2byte("000001");
+
+    private static java.math.BigInteger pr9CaN, pr9CaE, pr9CaD;
+    private static java.math.BigInteger pr9IssuerN;
+    private static byte[] pr9CaModulus, pr9CaExponent;
+    private static byte[] pr9IssuerExp;
+    private static byte[] pr9IssuerModulus;
+    private static EMVCAPublicKey pr9CaPublicKey;
+    private static byte[] pr9HappyCert;
+    private static byte[] pr9HappyRemainder;
+
+    @BeforeAll
+    public static void setUpPR9Fixtures() throws Exception {
+        java.security.KeyPairGenerator kpg = java.security.KeyPairGenerator.getInstance("RSA");
+
+        // CA keypair (1024 bits)
+        kpg.initialize(1024);
+        java.security.KeyPair caKp = kpg.generateKeyPair();
+        pr9CaN = ((java.security.interfaces.RSAPublicKey)  caKp.getPublic()).getModulus();
+        pr9CaE = ((java.security.interfaces.RSAPublicKey)  caKp.getPublic()).getPublicExponent();
+        pr9CaD = ((java.security.interfaces.RSAPrivateKey) caKp.getPrivate()).getPrivateExponent();
+
+        // Issuer keypair (768 bits → 96-byte modulus, exceeds NCA-36=92, so remainder present)
+        kpg.initialize(768);
+        java.security.KeyPair issuerKp = kpg.generateKeyPair();
+        pr9IssuerN = ((java.security.interfaces.RSAPublicKey) issuerKp.getPublic()).getModulus();
+        java.math.BigInteger issuerE = ((java.security.interfaces.RSAPublicKey) issuerKp.getPublic()).getPublicExponent();
+
+        pr9CaModulus  = bigIntToFixed(pr9CaN, PR9_NCA);
+        pr9CaExponent = trimLeadingZeros(pr9CaE.toByteArray());
+        pr9IssuerModulus = bigIntToFixed(pr9IssuerN, PR9_NI);
+        pr9IssuerExp     = trimLeadingZeros(issuerE.toByteArray());
+
+        pr9CaPublicKey = new EMVCAPublicKey(
+                ISOUtil.hex2byte("A000000003"), (byte) 0x07,
+                pr9CaModulus, pr9CaExponent,
+                (byte) 0x01, (byte) 0x01);
+
+        // Build and sign the canonical "happy" cert.
+        byte[] payload = buildPayload(PR9_ISSUER_ID, PR9_EXP_FUTURE, PR9_SERIAL,
+                (byte) 0x01, (byte) 0x01, pr9IssuerModulus, pr9IssuerExp);
+        pr9HappyCert = signWithCA(payload);
+        pr9HappyRemainder = java.util.Arrays.copyOfRange(pr9IssuerModulus, PR9_NCA - 36, PR9_NI);
+    }
+
+    private static byte[] buildPayload(byte[] issuerId, byte[] expDate, byte[] serial,
+            byte hashAlg, byte pkAlg, byte[] issuerModulus, byte[] issuerExp) throws Exception {
+        int nca = PR9_NCA;
+        int ni  = issuerModulus.length;
+        int ipkInCert = Math.min(ni, nca - 36);
+        byte[] payload = new byte[nca];
+        payload[0] = (byte) 0x6A;
+        payload[1] = (byte) 0x02;
+        System.arraycopy(issuerId, 0, payload, 2, 4);
+        System.arraycopy(expDate,  0, payload, 6, 2);
+        System.arraycopy(serial,   0, payload, 8, 3);
+        payload[11] = hashAlg;
+        payload[12] = pkAlg;
+        payload[13] = (byte) ni;
+        payload[14] = (byte) issuerExp.length;
+        System.arraycopy(issuerModulus, 0, payload, 15, ipkInCert);
+        // 0xBB padding for ni < nca - 36 (not exercised in happy fixture, but support it)
+        for (int i = 15 + ipkInCert; i < nca - 21; i++) payload[i] = (byte) 0xBB;
+        // SHA-1 over payload[1..nca-22] || remainder || exponent
+        java.security.MessageDigest sha = java.security.MessageDigest.getInstance("SHA-1");
+        sha.update(payload, 1, nca - 22);
+        if (ni > ipkInCert)
+            sha.update(issuerModulus, ipkInCert, ni - ipkInCert);
+        sha.update(issuerExp);
+        System.arraycopy(sha.digest(), 0, payload, nca - 21, 20);
+        payload[nca - 1] = (byte) 0xBC;
+        return payload;
+    }
+
+    private static byte[] signWithCA(byte[] payload) {
+        java.math.BigInteger m = new java.math.BigInteger(1, payload);
+        java.math.BigInteger s = m.modPow(pr9CaD, pr9CaN);
+        return bigIntToFixed(s, payload.length);
+    }
+
+    /** Decrypt the happy-cert payload, apply the mutator, re-sign. */
+    private static byte[] mutateAndSign(byte[] signedCert, java.util.function.Consumer<byte[]> mutator) {
+        java.math.BigInteger sig = new java.math.BigInteger(1, signedCert);
+        byte[] payload = bigIntToFixed(sig.modPow(pr9CaE, pr9CaN), signedCert.length);
+        mutator.accept(payload);
+        return signWithCA(payload);
+    }
+
+    private static byte[] bigIntToFixed(java.math.BigInteger value, int length) {
+        byte[] raw = value.toByteArray();
+        if (raw.length == length) return raw;
+        byte[] out = new byte[length];
+        if (raw.length > length)
+            System.arraycopy(raw, raw.length - length, out, 0, length);
+        else
+            System.arraycopy(raw, 0, out, length - raw.length, raw.length);
+        return out;
+    }
+
+    private static byte[] trimLeadingZeros(byte[] raw) {
+        int s = 0;
+        while (s < raw.length - 1 && raw[s] == 0) s++;
+        return java.util.Arrays.copyOfRange(raw, s, raw.length);
+    }
+
+    @Test
+    public void testRecoverIssuerPublicKey_HappyPath() throws Throwable {
+        EMVIssuerPublicKey result = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        assertArrayEquals(PR9_ISSUER_ID,  result.issuerIdentifier());
+        assertArrayEquals(PR9_EXP_FUTURE, result.expirationDate());
+        assertArrayEquals(PR9_SERIAL,     result.serialNumber());
+        assertArrayEquals(pr9IssuerModulus, result.modulus());
+        assertArrayEquals(pr9IssuerExp,   result.exponent());
+        assertEquals((byte) 0x01, result.hashAlgorithmIndicator());
+        assertEquals((byte) 0x01, result.publicKeyAlgorithmIndicator());
+    }
+
+    @Test
+    public void testRecoverIssuerPublicKey_NullPAN_SkipsIssuerIdCheck() throws Throwable {
+        EMVIssuerPublicKey result = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, null);
+        assertArrayEquals(PR9_ISSUER_ID, result.issuerIdentifier());
+    }
+
+    @Test
+    public void testRecoverIssuerPublicKey_BadHeader_Throws() throws Throwable {
+        byte[] bad = mutateAndSign(pr9HappyCert, p -> p[0] = (byte) 0x6B);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverIssuerPublicKey(pr9CaPublicKey, bad, pr9HappyRemainder,
+                        pr9IssuerExp, PR9_PAN));
+        assertTrue(ex.getMessage().toLowerCase().contains("header"),
+                "expected 'header' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverIssuerPublicKey_BadFormat_Throws() throws Throwable {
+        byte[] bad = mutateAndSign(pr9HappyCert, p -> p[1] = (byte) 0x03);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverIssuerPublicKey(pr9CaPublicKey, bad, pr9HappyRemainder,
+                        pr9IssuerExp, PR9_PAN));
+        assertTrue(ex.getMessage().toLowerCase().contains("certificate format"),
+                "expected 'certificate format' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverIssuerPublicKey_BadTrailer_Throws() throws Throwable {
+        byte[] bad = mutateAndSign(pr9HappyCert, p -> p[PR9_NCA - 1] = (byte) 0xBD);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverIssuerPublicKey(pr9CaPublicKey, bad, pr9HappyRemainder,
+                        pr9IssuerExp, PR9_PAN));
+        assertTrue(ex.getMessage().toLowerCase().contains("trailer"),
+                "expected 'trailer' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverIssuerPublicKey_BadHash_Throws() throws Throwable {
+        // Flip one bit inside the embedded hash (bytes nca-21..nca-2).
+        byte[] bad = mutateAndSign(pr9HappyCert, p -> p[PR9_NCA - 10] ^= 0x01);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverIssuerPublicKey(pr9CaPublicKey, bad, pr9HappyRemainder,
+                        pr9IssuerExp, PR9_PAN));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash"),
+                "expected 'hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverIssuerPublicKey_UnsupportedHashAlgo_Throws() throws Throwable {
+        byte[] bad = mutateAndSign(pr9HappyCert, p -> p[11] = (byte) 0x02);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverIssuerPublicKey(pr9CaPublicKey, bad, pr9HappyRemainder,
+                        pr9IssuerExp, PR9_PAN));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash algorithm"),
+                "expected 'hash algorithm' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverIssuerPublicKey_UnsupportedPKAlgo_Throws() throws Throwable {
+        byte[] bad = mutateAndSign(pr9HappyCert, p -> p[12] = (byte) 0x02);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverIssuerPublicKey(pr9CaPublicKey, bad, pr9HappyRemainder,
+                        pr9IssuerExp, PR9_PAN));
+        assertTrue(ex.getMessage().toLowerCase().contains("public key algorithm"),
+                "expected 'public key algorithm' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverIssuerPublicKey_ExpiredDate_Throws() throws Throwable {
+        // Build a cert with expDate in January 2001 (long-expired) and sign it.
+        byte[] payload = buildPayload(PR9_ISSUER_ID, PR9_EXP_PAST, PR9_SERIAL,
+                (byte) 0x01, (byte) 0x01, pr9IssuerModulus, pr9IssuerExp);
+        byte[] expiredCert = signWithCA(payload);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverIssuerPublicKey(pr9CaPublicKey, expiredCert, pr9HappyRemainder,
+                        pr9IssuerExp, PR9_PAN));
+        assertTrue(ex.getMessage().toLowerCase().contains("expired"),
+                "expected 'expired' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRecoverIssuerPublicKey_IssuerIdMismatch_Throws() throws Throwable {
+        // Happy cert is fine; just pass a PAN that doesn't match issuer ID 12345678.
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.recoverIssuerPublicKey(pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder,
+                        pr9IssuerExp, "99990000123456"));
+        assertTrue(ex.getMessage().toLowerCase().contains("issuer identifier"),
+                "expected 'issuer identifier' in error: " + ex.getMessage());
     }
 
 }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -2858,6 +2858,10 @@ public class JCESecurityModuleTest {
         java.security.KeyPair iccKp = kpg.generateKeyPair();
         java.math.BigInteger iccN = ((java.security.interfaces.RSAPublicKey) iccKp.getPublic()).getModulus();
         java.math.BigInteger iccE = ((java.security.interfaces.RSAPublicKey) iccKp.getPublic()).getPublicExponent();
+        // Capture ICC private + public exponents for PR 12 SDAD signing
+        pr12IccD = ((java.security.interfaces.RSAPrivateKey) iccKp.getPrivate()).getPrivateExponent();
+        pr12IccE = iccE;
+        pr12IccN = iccN;
 
         pr10IccModulus = bigIntToFixed(iccN, 64);
         pr10IccExp     = trimLeadingZeros(iccE.toByteArray());
@@ -2869,6 +2873,10 @@ public class JCESecurityModuleTest {
         int nic = pr10IccModulus.length;      // 64
         int iccInCert = Math.min(nic, PR9_NI - 42);  // min(64, 54) = 54
         pr10HappyRemainder = java.util.Arrays.copyOfRange(pr10IccModulus, iccInCert, nic);
+
+        // PR 12 follows here so JUnit 5's non-deterministic @BeforeAll
+        // ordering can't observe a null pr12IccD when buildSDAD runs.
+        setUpPR12Fixtures();
     }
 
     private static byte[] buildICCPayload(byte[] appPan, byte[] expDate, byte[] serial,
@@ -3196,6 +3204,169 @@ public class JCESecurityModuleTest {
         byte[] tooShort = java.util.Arrays.copyOfRange(pr11HappySSAD, 0, pr11HappySSAD.length - 1);
         SMException ex = assertThrows(SMException.class, () ->
                 jcesecmod.verifySDA(issuer, tooShort, PR10_SAD));
+        assertTrue(ex.getMessage().toLowerCase().contains("length"),
+                "expected 'length' in error: " + ex.getMessage());
+    }
+
+    // ----------------------------------------------------------------------
+    // PR 12 — Verify Signed Dynamic Application Data (EMV 4.4 Book 2 §6.5)
+    // ----------------------------------------------------------------------
+    //
+    // Chains PR 9 → PR 10 → PR 12: recover Issuer PK, recover ICC PK, sign
+    // an SDAD with the ICC private key, recover via verifyDDA.
+
+    private static final byte[] PR12_DDOL = ISOUtil.hex2byte("9F37049988776655");
+    private static final byte[] PR12_ICC_DYNAMIC_NUMBER = ISOUtil.hex2byte("12345678");
+
+    private static java.math.BigInteger pr12IccD;
+    private static java.math.BigInteger pr12IccE;
+    private static java.math.BigInteger pr12IccN;
+    private static byte[] pr12HappySDAD;
+
+    // Called from setUpPR10Fixtures (NOT a separate @BeforeAll method) to
+    // guarantee setUpPR9Fixtures and setUpPR10Fixtures have run first;
+    // JUnit 5 does not order multiple @BeforeAll methods deterministically.
+    private static void setUpPR12Fixtures() throws Exception {
+        // Builds the canonical "happy" SDAD signed with the ICC private key
+        // (pr12IccD captured during setUpPR10Fixtures).
+        pr12HappySDAD = buildSDAD(PR12_ICC_DYNAMIC_NUMBER, (byte) 0x01,
+                (byte) 0x05, (byte) 0xBB, PR12_DDOL);
+    }
+
+    private static byte[] buildSDAD(byte[] iccDynamicNumber, byte hashAlg, byte format,
+            byte padByte, byte[] ddol) throws Exception {
+        int nic = pr10IccModulus.length;      // 64
+        int ldn = iccDynamicNumber.length;
+        int ldd = 1 + ldn;                    // LDN byte + dynamic number bytes
+        byte[] payload = new byte[nic];
+        payload[0] = (byte) 0x6A;
+        payload[1] = format;
+        payload[2] = hashAlg;
+        payload[3] = (byte) ldd;
+        payload[4] = (byte) ldn;
+        System.arraycopy(iccDynamicNumber, 0, payload, 5, ldn);
+        for (int i = 4 + ldd; i < nic - 21; i++) payload[i] = padByte;
+        // Hash over payload[1..nic-21) || ddol
+        java.security.MessageDigest sha = java.security.MessageDigest.getInstance("SHA-1");
+        sha.update(payload, 1, nic - 22);
+        if (ddol != null && ddol.length > 0) sha.update(ddol);
+        System.arraycopy(sha.digest(), 0, payload, nic - 21, 20);
+        payload[nic - 1] = (byte) 0xBC;
+        return signWithICC(payload);
+    }
+
+    private static byte[] signWithICC(byte[] payload) {
+        java.math.BigInteger m = new java.math.BigInteger(1, payload);
+        java.math.BigInteger s = m.modPow(pr12IccD, pr12IccN);
+        return bigIntToFixed(s, payload.length);
+    }
+
+    private static byte[] mutateAndSignSDAD(byte[] signedSDAD, java.util.function.Consumer<byte[]> mutator) {
+        java.math.BigInteger sig = new java.math.BigInteger(1, signedSDAD);
+        byte[] payload = bigIntToFixed(sig.modPow(pr12IccE, pr12IccN), signedSDAD.length);
+        mutator.accept(payload);
+        return signWithICC(payload);
+    }
+
+    private static EMVICCPublicKey recoverICCForPR12() throws Exception {
+        EMVIssuerPublicKey issuer = jcesecmod.recoverIssuerPublicKey(
+                pr9CaPublicKey, pr9HappyCert, pr9HappyRemainder, pr9IssuerExp, PR9_PAN);
+        return jcesecmod.recoverICCPublicKey(issuer, pr10HappyCert, pr10HappyRemainder,
+                pr10IccExp, PR10_SAD, PR10_APP_PAN_STR);
+    }
+
+    @Test
+    public void testVerifyDDA_HappyPath() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] dyn = jcesecmod.verifyDDA(icc, pr12HappySDAD, PR12_DDOL);
+        assertArrayEquals(PR12_ICC_DYNAMIC_NUMBER, dyn);
+        assertEquals(4, dyn.length);
+    }
+
+    @Test
+    public void testVerifyDDA_BadHeader_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] bad = mutateAndSignSDAD(pr12HappySDAD, p -> p[0] = (byte) 0x6B);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyDDA(icc, bad, PR12_DDOL));
+        assertTrue(ex.getMessage().toLowerCase().contains("header"),
+                "expected 'header' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyDDA_BadFormat_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        // 0x05 → 0x03 (SSAD format used by mistake)
+        byte[] bad = mutateAndSignSDAD(pr12HappySDAD, p -> p[1] = (byte) 0x03);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyDDA(icc, bad, PR12_DDOL));
+        assertTrue(ex.getMessage().toLowerCase().contains("signed data format"),
+                "expected 'signed data format' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyDDA_BadTrailer_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] bad = mutateAndSignSDAD(pr12HappySDAD,
+                p -> p[pr10IccModulus.length - 1] = (byte) 0xBD);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyDDA(icc, bad, PR12_DDOL));
+        assertTrue(ex.getMessage().toLowerCase().contains("trailer"),
+                "expected 'trailer' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyDDA_UnsupportedHashAlgo_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] bad = mutateAndSignSDAD(pr12HappySDAD, p -> p[2] = (byte) 0x02);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyDDA(icc, bad, PR12_DDOL));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash algorithm"),
+                "expected 'hash algorithm' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyDDA_BadPadding_Throws() throws Throwable {
+        // Build SDAD with pad byte 0xBC instead of 0xBB. Hash signed
+        // consistently with the corrupt pad — structural check rejects.
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] badPadding = buildSDAD(PR12_ICC_DYNAMIC_NUMBER, (byte) 0x01,
+                (byte) 0x05, (byte) 0xBC, PR12_DDOL);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyDDA(icc, badPadding, PR12_DDOL));
+        assertTrue(ex.getMessage().toLowerCase().contains("pad pattern"),
+                "expected 'pad pattern' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyDDA_BadHash_Throws() throws Throwable {
+        // Flip a bit in the embedded hash (bytes nic-21..nic-2).
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] bad = mutateAndSignSDAD(pr12HappySDAD,
+                p -> p[pr10IccModulus.length - 10] ^= 0x01);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyDDA(icc, bad, PR12_DDOL));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash"),
+                "expected 'hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyDDA_DDOLCorruption_Throws() throws Throwable {
+        // Pass a different DDOL at verify than was used at signing.
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] wrongDDOL = ISOUtil.hex2byte("DEADBEEFCAFEBABE");
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyDDA(icc, pr12HappySDAD, wrongDDOL));
+        assertTrue(ex.getMessage().toLowerCase().contains("hash"),
+                "expected 'hash' in error: " + ex.getMessage());
+    }
+
+    @Test
+    public void testVerifyDDA_WrongLength_Throws() throws Throwable {
+        EMVICCPublicKey icc = recoverICCForPR12();
+        byte[] tooShort = java.util.Arrays.copyOfRange(pr12HappySDAD, 0, pr12HappySDAD.length - 1);
+        SMException ex = assertThrows(SMException.class, () ->
+                jcesecmod.verifyDDA(icc, tooShort, PR12_DDOL));
         assertTrue(ex.getMessage().toLowerCase().contains("length"),
                 "expected 'length' in error: " + ex.getMessage());
     }

--- a/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
+++ b/jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java
@@ -35,6 +35,7 @@ import org.jpos.core.SubConfiguration;
 import org.jpos.iso.ISOUtil;
 import org.jpos.security.ARPCMethod;
 import org.jpos.security.CipherMode;
+import org.jpos.security.EMVDerivedKey;
 import org.jpos.security.EncryptedPIN;
 import org.jpos.security.KeyScheme;
 import org.jpos.security.MKDMethod;
@@ -2048,6 +2049,86 @@ public class JCESecurityModuleTest {
         byte[] expected = java.util.Arrays.copyOfRange(
                 jcesecmod.jceHandler.encryptData(new byte[8], key), 0, 3);
         assertArrayEquals(expected, kcv);
+    }
+
+    @Test
+    public void testDeriveICCMasterKey_OptionA_MatchesInternalDerivation() throws Throwable {
+        // accountNoA = "1234567890123456" (16 digits), psn = "00"
+        // formatPANPSNOptionA: preparePANPSN("1234567890123456", "00") = hex2byte("123456789012345600")
+        // = 9 bytes, then last 8 bytes = "3456789012345600"
+        byte[] expectedPanpsn = ISOUtil.hex2byte("3456789012345600");
+        java.security.Key clearIMK = jcesecmod.decryptFromLMK(imkac);
+        java.security.Key expectedClearIcc = jcesecmod.deriveICCMasterKey(clearIMK, expectedPanpsn);
+        byte[] expectedBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, expectedClearIcc);
+
+        EMVDerivedKey<SecureDESKey> result = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        java.security.Key actualClearIcc = jcesecmod.decryptFromLMK(result.key());
+        byte[] actualBytes = jcesecmod.jceHandler
+                .extractDESKeyMaterial(SMAdapter.LENGTH_DES3_2KEY, actualClearIcc);
+
+        assertArrayEquals(expectedBytes, actualBytes);
+    }
+
+    @Test
+    public void testDeriveICCMasterKey_PreservesIMKMetadata() throws Throwable {
+        EMVDerivedKey<SecureDESKey> result = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        assertEquals(imkac.getKeyType(), result.key().getKeyType());
+        assertEquals(imkac.getKeyLength(), result.key().getKeyLength());
+    }
+
+    @Test
+    public void testDeriveICCMasterKey_KCVIsThreeBytes() throws Throwable {
+        EMVDerivedKey<SecureDESKey> result = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        assertNotNull(result.kcv());
+        assertEquals(3, result.kcv().length);
+        assertArrayEquals(result.kcv(), result.key().getKeyCheckValue());
+    }
+
+    @Test
+    public void testDeriveICCMasterKey_Deterministic() throws Throwable {
+        EMVDerivedKey<SecureDESKey> a = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        EMVDerivedKey<SecureDESKey> b = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        assertArrayEquals(a.kcv(), b.kcv());
+        assertArrayEquals(a.key().getKeyBytes(), b.key().getKeyBytes());
+    }
+
+    @Test
+    public void testDeriveICCMasterKey_NullMKDMDefaultsToOptionA() throws Throwable {
+        EMVDerivedKey<SecureDESKey> withNull = jcesecmod.deriveICCMasterKey(
+                null, imkac, accountNoA, accountNoA_CSN);
+        EMVDerivedKey<SecureDESKey> withOptionA = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        assertArrayEquals(withNull.kcv(), withOptionA.kcv());
+        assertArrayEquals(withNull.key().getKeyBytes(), withOptionA.key().getKeyBytes());
+    }
+
+    @Test
+    public void testDeriveICCMasterKey_OptionB_LongPAN_StructurallyValid() throws Throwable {
+        String longPan = "1234567890123456789"; // 19 digits — triggers OPTION_B SHA-1 path
+        EMVDerivedKey<SecureDESKey> result = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_B, imkac, longPan, "00");
+        assertNotNull(result.key());
+        assertEquals(SMAdapter.LENGTH_DES3_2KEY, result.key().getKeyLength());
+        assertEquals(3, result.kcv().length);
+
+        // OPTION_B with a long PAN should produce a different ICC MK than OPTION_A
+        // with the (short) accountNoA — basic sanity that the path actually ran.
+        EMVDerivedKey<SecureDESKey> optionA = jcesecmod.deriveICCMasterKey(
+                MKDMethod.OPTION_A, imkac, accountNoA, accountNoA_CSN);
+        assertFalse(java.util.Arrays.equals(result.kcv(), optionA.kcv()));
+    }
+
+    @Test
+    public void testDeriveICCMasterKey_NullPAN_Throws() throws Throwable {
+        assertThrows(Exception.class, () -> {
+            jcesecmod.deriveICCMasterKey(MKDMethod.OPTION_A, imkac, null, accountNoA_CSN);
+        });
     }
 
 }


### PR DESCRIPTION
# PR Description — `feature/emv-sm-adapter`

## Summary

Expands `org.jpos.security.SMAdapter`'s effective API with a complete EMV cryptographic surface, organised under a new `EMVSMAdapter<T>` sub-interface. Everything new lives on the sub-interface and on a small set of new value records — **the existing `SMAdapter<T>` interface is byte-identical to `main`** after the entire branch.

## What's new

### New public sub-interface: `EMVSMAdapter<T> extends SMAdapter<T>`

14 new methods across three families:

#### AC / Cryptogram (built on existing internal helpers)

| Method | Returns |
|---|---|
| `generateCVC3(T, …, MKDMethod)` | `String` (5-digit CVC3) |
| `generatedCVV(String accountNo, T, …, MKDMethod)` | `String` (3-digit dCVV) |
| `generateApplicationCryptogram(MKDMethod, SKDMethod, T imkac, …)` | 8-byte ARQC/TC/AAC |
| `deriveICCMasterKey(MKDMethod, T imk, pan, psn)` | `EMVDerivedKey<T>` |
| `deriveEMVSessionKey(SKDMethod, T iccMk, atc, upn)` | `EMVDerivedKey<T>` |
| `generateARPC(T key, arqc, ARPCMethod, arc, propAuthData)` (overload) | `byte[]` 8 or 4 |

#### Secure Messaging

| Method | Returns |
|---|---|
| `deriveSecureMessagingSessionKey(MKDMethod, SKDMethod, T imk, pan, psn, atc, arqc)` | `EMVDerivedKey<T>` |
| `generateSM_MAC(T sessionKey, byte[] data)` (overload) | 8-byte MAC |
| `encryptSecureMessagingPIN(T sessionKey, EncryptedPIN newPIN, T kd1, byte destFormat, PaddingMethod, EncryptedPIN currentPIN, T udkAc)` | `EncryptedPIN` |

#### Offline Data Authentication (new RSA + EMV cert recovery code)

| Method | Returns | EMV spec |
|---|---|---|
| `recoverIssuerPublicKey(EMVCAPublicKey, byte[] cert, byte[] remainder, byte[] exponent, String pan)` | `EMVIssuerPublicKey` | Book 2 §6.3 |
| `recoverICCPublicKey(EMVIssuerPublicKey, byte[] cert, byte[] remainder, byte[] exponent, byte[] sad, String pan)` | `EMVICCPublicKey` | Book 2 §6.4 |
| `verifySDA(EMVIssuerPublicKey, byte[] ssad, byte[] sad)` | 2-byte DAC | Book 2 §5.4 |
| `verifyDDA(EMVICCPublicKey, byte[] sdad, byte[] ddolData)` | ICC Dynamic Number | Book 2 §6.5 |
| `verifyCDA(EMVICCPublicKey, byte[] sdad, byte[] un, byte[] ac, byte[] txnData)` | `EMVCDAResult` (ICC Dynamic Number + CID) | Book 2 §6.6 |

### New public records (in `org.jpos.security`)

All Java 25 records with content-aware `equals` / `hashCode` / `toString` and **defensive copies of `byte[]` fields** on construction and access. Hex rendering in `toString` for safe logging.

| Record | Fields |
|---|---|
| `EMVDerivedKey<T>` | `T key, byte[] kcv` |
| `EMVCAPublicKey` | `byte[] rid, byte index, byte[] modulus, byte[] exponent, byte hashAlgInd, byte pkAlgInd` |
| `EMVIssuerPublicKey` | `byte[] issuerIdentifier, byte[] expirationDate, byte[] serialNumber, byte[] modulus, byte[] exponent, byte hashAlgInd, byte pkAlgInd` |
| `EMVICCPublicKey` | `byte[] applicationPan, byte[] expirationDate, byte[] serialNumber, byte[] modulus, byte[] exponent, byte hashAlgInd, byte pkAlgInd` |
| `EMVCDAResult` | `byte[] iccDynamicNumber, byte cid` |

## Architectural conventions

- **`*Impl` extension pattern** — every public method on `BaseSMAdapter` is a logging/error-handling wrapper that delegates to a protected `*Impl`. Defaults throw `SMException("Operation not supported in: …")` so third-party HSM adapters (Thales, Atalla, Futurex) keep compiling without code changes.
- **`JCESecurityModule extends BaseSMAdapter<SecureDESKey>` is the software adapter** and overrides every `*Impl` it can support. Reuses existing internal helpers (`calculateARQC`, `calculateCVC3`, `calculatedCVV`, `deriveICCMasterKey`, `deriveCommonSK_*`, `deriveSK_*`, `paddingISO9797Method2`, `calculateMACISO9797Alg3`, `calculateARPC`, `translatePINExt`, `encryptToLMK`, `decryptFromLMK`).
- **TR-31 / X9.143 forward compatibility** — every method returning or accepting a derived symmetric key is parametric on `T`. The verb-level API never refers to `SecureDESKey` directly. A future HSM adapter speaking ANSI X9.143 / TR-31 key blocks would extend `BaseSMAdapter<SecureKeyBlock>` without touching the interface.

## Visibility lifts on `JCESecurityModule`

Six internal helpers widened from `private` → `protected` to enable byte-for-byte tests against the internal derivation paths and to give HSM-backed subclasses extension hooks. All binary-compatible widenings; no member ever narrowed.

| Helper | Lifted in commit |
|---|---|
| `deriveCommonSK_AC` | PR 5 |
| `deriveSK_MK` | PR 5 |
| `deriveSK_VISA` | PR 7 |
| `deriveCommonSK_SM` | PR 7 |
| `paddingISO9797Method2` | PR 8 |
| `calculateMACISO9797Alg3` | PR 8 |

## Testing approach

- **PRs 1–8b** cross-check new public methods against the **known reference vectors** already in `JCESecurityModuleTest.java`. The new methods are proven bit-for-bit equivalent to the existing `verify*` / integrated paths.
- **PRs 9–13** use a self-consistent synthetic RSA fixture chain: 1024-bit CA + 768-bit Issuer + 512-bit ICC keypairs generated once at `@BeforeAll`, certificates constructed byte-by-byte per the EMV Book 2 table layouts, signed via `BigInteger.modPow`, then recovered with the new method. Negative tests use a decrypt-mutate-resign helper so each corruption case is a single-line lambda.

Every negative-path test cross-references a specific EMV-mandated validation step (header `0x6A`, format byte, trailer `0xBC`, hash algorithm indicator, pad pattern `0xBB`, hash binding, plus CDA's AC and transaction-data-hash bindings).

- Validate **pad patterns** in issuer and ICC PK certificate recovery.
- Reject DDA SDAD whose **LDD ≠ LDN + 1**.
- **Defensive copies** of `byte[]` fields in all EMV records—on construction (compact constructor) and on every accessor. Equality/hash semantics and key/result contents are no longer externally mutable.
- Regression tests for each hardening.

## Files

| Status | Path |
|---|---|
| NEW | `jpos/src/main/java/org/jpos/security/EMVSMAdapter.java` |
| NEW | `jpos/src/main/java/org/jpos/security/EMVDerivedKey.java` |
| NEW | `jpos/src/main/java/org/jpos/security/EMVCAPublicKey.java` |
| NEW | `jpos/src/main/java/org/jpos/security/EMVIssuerPublicKey.java` |
| NEW | `jpos/src/main/java/org/jpos/security/EMVICCPublicKey.java` |
| NEW | `jpos/src/main/java/org/jpos/security/EMVCDAResult.java` |
| NEW | `jpos/src/test/java/org/jpos/security/EMVDerivedKeyTest.java` |
| NEW | `jpos/src/test/java/org/jpos/security/EMVCAPublicKeyTest.java` |
| NEW | `jpos/src/test/java/org/jpos/security/EMVIssuerPublicKeyTest.java` |
| NEW | `jpos/src/test/java/org/jpos/security/EMVICCPublicKeyTest.java` |
| NEW | `jpos/src/test/java/org/jpos/security/EMVCDAResultTest.java` |
| MODIFIED | `jpos/src/main/java/org/jpos/security/BaseSMAdapter.java` (wrappers + default-throw `*Impl` per method) |
| MODIFIED | `jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java` (overrides; visibility lifts) |
| MODIFIED | `jpos/src/test/java/org/jpos/security/jceadapter/JCESecurityModuleTest.java` (140+ new tests) |
| UNCHANGED | `jpos/src/main/java/org/jpos/security/SMAdapter.java` (byte-identical to `main`) |

## EMV spec coverage

| EMV 4.4 Book 2 | Section | Implementation |
|---|---|---|
| Issuer Public Key recovery | §6.3 | `recoverIssuerPublicKey` |
| ICC Public Key recovery | §6.4 | `recoverICCPublicKey` |
| Signed Static Application Data | §5.4 | `verifySDA` |
| Dynamic Data Authentication | §6.5 | `verifyDDA` |
| ICC Dynamic Data | §6.5.2 | used by `verifyDDA` / `verifyCDA` |
| Combined Data Authentication | §6.6 | `verifyCDA` |
| EMV ICC Master Key derivation | §A1.4 | already in `JCESecurityModule`, now reachable via `deriveICCMasterKey` |
| Common Session Key derivation | §A1.3.1 | already internal, now reachable via `deriveEMVSessionKey` / `deriveSecureMessagingSessionKey` |
