### PR TITLE
Bump dependency catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@ jdom = "2.0.6.1"
 sleepycatje = "18.3.12"
 commonscli = "1.11.0"
 commonslang3 = "3.20.0"
-jline = "4.1.1"
-jna = '5.18.1'
+jline = "4.1.3"
+jna = '5.19.0'
 jansi = '2.4.3'
 beanshell = "2.0b6"
 javatuples = "1.2"
@@ -19,7 +19,7 @@ hdrhistogram = "2.2.2"
 yaml = "2.6"
 micrometercore = "1.16.5"
 micrometerprometheus = "1.16.5"
-jackson = '2.21.3'
+jackson = '2.22.0'
 jdbm = '1.0'
 
 [libraries]


### PR DESCRIPTION
Summary:
- bump JLine from 4.1.1 to 4.1.3
- bump JNA from 5.18.1 to 5.19.0
- bump Jackson from 2.21.3 to 2.22.0

Validation:
- ./gradlew help
- ./gradlew :jpos:compileJava
- ./gradlew :jpos:test
- git diff --check