### PR TITLE
Add optional channel connection logging

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/BaseChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/BaseChannel.java
@@ -125,6 +125,7 @@ public abstract class BaseChannel extends Observable
     private int nextHostPort = 0;
     private boolean roundRobin = false;
     private boolean debugIsoError = true;
+    private boolean logConnections = false;
 
     private ISOMsgMetrics isoMsgMetrics;
 
@@ -477,6 +478,7 @@ public abstract class BaseChannel extends Observable
         ChannelEvent jfr = new ChannelEvent.Connect();
         jfr.begin();
         LogEvent evt = new LogEvent (this, "connect").withTraceId(uuid);
+        boolean logEvent = logConnections;
         try {
             socket = newSocket (hosts, ports, evt);
             if (getHost() != null)
@@ -490,9 +492,11 @@ public abstract class BaseChannel extends Observable
             jfr = new ChannelEvent.ConnectionException(jfr.getDetail());
             jfr.begin();
             jfr.append (e.getMessage());
+            logEvent = true;
             throw e;
         } finally {
-            Logger.log (evt);
+            if (logEvent)
+                Logger.log (evt);
             jfr.commit();
         }
     }
@@ -897,6 +901,7 @@ public abstract class BaseChannel extends Observable
         byte[] b=null;
         byte[] header=null;
         LogEvent evt = new LogEvent (this, "receive").withTraceId(getSocketUUID());
+        boolean logEvent = true;
         ISOMsg m = createMsg ();  // call createMsg instead of createISOMsg for backward compatibility
 
         m.setSource (this);
@@ -963,10 +968,13 @@ public abstract class BaseChannel extends Observable
             }
             throw e;
         } catch (IOException e) {
-            evt.addMessage (
-              new Disconnect(socket.getInetAddress().getHostAddress(), socket.getPort(), socket.getLocalPort(),
-                "%s (%s)".formatted(Caller.shortClassName(e.getClass().getName()), Caller.info()), e.getMessage())
-            );
+            logEvent = logConnections || !isRoutineDisconnect(e);
+            if (logEvent) {
+                evt.addMessage (
+                  new Disconnect(socket.getInetAddress().getHostAddress(), socket.getPort(), socket.getLocalPort(),
+                    "%s (%s)".formatted(Caller.shortClassName(e.getClass().getName()), Caller.info()), e.getMessage())
+                );
+            }
             closeSocket();
             throw e;
         } catch (Exception e) {
@@ -975,7 +983,8 @@ public abstract class BaseChannel extends Observable
             evt.addMessage (e);
             throw new IOException ("unexpected exception", e);
         } finally {
-            Logger.log (evt);
+            if (logEvent)
+                Logger.log (evt);
         }
         jfr.setDetail(m.toString());
         jfr.commit();
@@ -1270,6 +1279,7 @@ public abstract class BaseChannel extends Observable
         expectKeepAlive = cfg.getBoolean ("expect-keep-alive", false);
         roundRobin = cfg.getBoolean ("round-robin", false);
         debugIsoError = cfg.getBoolean ("debug-iso-error", true);
+        logConnections = cfg.getBoolean ("log-connections", false);
         if (socketFactory != this && socketFactory instanceof Configurable)
             ((Configurable)socketFactory).setConfiguration (cfg);
         try {
@@ -1326,6 +1336,23 @@ public abstract class BaseChannel extends Observable
      */
     public boolean isOverrideHeader () {
         return overrideHeader;
+    }
+    /**
+     * Controls whether routine connection lifecycle events are logged.
+     * @param logConnections if true, log successful connects and normal disconnects
+     */
+    public void setLogConnections (boolean logConnections) {
+        this.logConnections = logConnections;
+    }
+    /**
+     * Returns whether routine connection lifecycle events are logged.
+     * @return true if routine connection lifecycle logging is enabled
+     */
+    public boolean isLogConnections () {
+        return logConnections;
+    }
+    private boolean isRoutineDisconnect(IOException e) {
+        return e instanceof EOFException || e instanceof SocketException;
     }
     /**
      * Retrieves a channel instance by name from the NameRegistrar.

--- a/jpos/src/main/java/org/jpos/iso/BaseChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/BaseChannel.java
@@ -125,7 +125,7 @@ public abstract class BaseChannel extends Observable
     private int nextHostPort = 0;
     private boolean roundRobin = false;
     private boolean debugIsoError = true;
-    private boolean logConnections = false;
+    private boolean logConnections = true;
 
     private ISOMsgMetrics isoMsgMetrics;
 
@@ -1279,7 +1279,7 @@ public abstract class BaseChannel extends Observable
         expectKeepAlive = cfg.getBoolean ("expect-keep-alive", false);
         roundRobin = cfg.getBoolean ("round-robin", false);
         debugIsoError = cfg.getBoolean ("debug-iso-error", true);
-        logConnections = cfg.getBoolean ("log-connections", false);
+        logConnections = cfg.getBoolean ("log-connections", true);
         if (socketFactory != this && socketFactory instanceof Configurable)
             ((Configurable)socketFactory).setConfiguration (cfg);
         try {

--- a/jpos/src/main/java/org/jpos/metrics/MeterInfo.java
+++ b/jpos/src/main/java/org/jpos/metrics/MeterInfo.java
@@ -34,8 +34,16 @@ public enum MeterInfo {
 
     /** Active inbound connections accepted by ISOServer. */
     ISOSERVER_CONNECTION_COUNT("jpos.server.connections", "Incoming active connections"),
+    /** Total inbound connections accepted by ISOServer. */
+    ISOSERVER_ACCEPTS("jpos.server.accepts", "Accepted incoming connections"),
+    /** Total inbound connections disconnected from ISOServer. */
+    ISOSERVER_DISCONNECTS("jpos.server.disconnects", "Disconnected incoming connections"),
     /** Active outbound connections opened by ISOChannel. */
     ISOCHANNEL_CONNECTION_COUNT("jpos.channel.connections", "Outgoing active connections"),
+    /** Total outbound connections opened by ISOChannel. */
+    ISOCHANNEL_CONNECTS("jpos.channel.connects", "Opened outgoing connections"),
+    /** Total outbound connections disconnected by ISOChannel. */
+    ISOCHANNEL_DISCONNECTS("jpos.channel.disconnects", "Disconnected outgoing connections"),
 
     /** Outbound ISO message counter, tagged {@code direction=out}. */
     ISOMSG_OUT("jpos.isomsg", "Transmitted messages", Tags.of ("direction", "out")),

--- a/jpos/src/main/java/org/jpos/q2/iso/ChannelAdaptor.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/ChannelAdaptor.java
@@ -18,6 +18,7 @@
 
 package org.jpos.q2.iso;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.BaseUnits;
@@ -84,6 +85,8 @@ public class ChannelAdaptor
     private ScheduledExecutorService scheduledExecutor;
 
     private Gauge connectionsGauge;
+    private Counter connectsCounter;
+    private Counter disconnectsCounter;
 
     @Config("soft-stop") private long softStop;
 
@@ -524,10 +527,13 @@ public class ChannelAdaptor
             } catch (IOException ignored) {
                 // channel.connect already logs - no need for more warnings
             }
-            if (!channel.isConnected ())
+            if (!channel.isConnected ()) {
                 ISOUtil.sleep (delay);
-            else
+            } else {
                 connects++;
+                if (connectsCounter != null)
+                    connectsCounter.increment();
+            }
         }
         if (running() && sp.rdp (ready) == null)
             sp.out (ready, new Date());
@@ -541,6 +547,8 @@ public class ChannelAdaptor
             try {
                 SpaceUtil.wipe(sp, ready);
                 channel.disconnect();
+                if (disconnectsCounter != null)
+                    disconnectsCounter.increment();
             } catch (Exception e) {
                 getLog().warn("disconnect", e);
             }
@@ -649,6 +657,8 @@ public class ChannelAdaptor
               BaseUnits.SESSIONS,
               () -> isConnected() ? 1 : 0
             );
+        connectsCounter = MeterFactory.counter(registry, MeterInfo.ISOCHANNEL_CONNECTS, tags);
+        disconnectsCounter = MeterFactory.counter(registry, MeterInfo.ISOCHANNEL_DISCONNECTS, tags);
 
         if (channel instanceof ISOMsgMetrics.Source ms) {
             ISOMsgMetrics mtr = ms.getISOMsgMetrics();
@@ -661,7 +671,7 @@ public class ChannelAdaptor
 
     private void removeMeters() {
         var registry = getServer().getMeterRegistry();
-        registry.remove(connectionsGauge);
+        MeterFactory.remove(registry, connectionsGauge, connectsCounter, disconnectsCounter);
 
         if (channel instanceof ISOMsgMetrics.Source ms) {
             ISOMsgMetrics mtr = ms.getISOMsgMetrics();

--- a/jpos/src/main/java/org/jpos/q2/iso/ChannelAdaptor.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/ChannelAdaptor.java
@@ -547,10 +547,11 @@ public class ChannelAdaptor
             try {
                 SpaceUtil.wipe(sp, ready);
                 channel.disconnect();
-                if (disconnectsCounter != null)
-                    disconnectsCounter.increment();
             } catch (Exception e) {
                 getLog().warn("disconnect", e);
+            } finally {
+                if (disconnectsCounter != null && !channel.isConnected())
+                    disconnectsCounter.increment();
             }
         }
     }

--- a/jpos/src/main/java/org/jpos/q2/iso/QServer.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QServer.java
@@ -69,6 +69,7 @@ public class QServer
     private Gauge connectionsGauge;
     private Counter acceptsCounter;
     private Counter disconnectsCounter;
+    private ISOServerEventListener metricsEventListener;
     private static final String CHANNEL_NAME_REGEXP = " (?=\\d+ \\S+:\\S+)";
 
     /** Default constructor. */
@@ -405,12 +406,13 @@ public class QServer
             );
         acceptsCounter = MeterFactory.counter(registry, MeterInfo.ISOSERVER_ACCEPTS, tags);
         disconnectsCounter = MeterFactory.counter(registry, MeterInfo.ISOSERVER_DISCONNECTS, tags);
-        server.addServerEventListener(event -> {
+        metricsEventListener = event -> {
             if (event instanceof ISOServerAcceptEvent && acceptsCounter != null)
                 acceptsCounter.increment();
             else if (event instanceof ISOServerClientDisconnectEvent && disconnectsCounter != null)
                 disconnectsCounter.increment();
-        });
+        };
+        server.addServerEventListener(metricsEventListener);
 
         if (channel instanceof ISOMsgMetrics.Source ms) {
             ISOMsgMetrics mtr = ms.getISOMsgMetrics();
@@ -423,7 +425,14 @@ public class QServer
 
     private void removeMeters() {
         var registry = getServer().getMeterRegistry();
+        if (metricsEventListener != null) {
+            server.removeServerEventListener(metricsEventListener);
+            metricsEventListener = null;
+        }
         MeterFactory.remove(registry, connectionsGauge, acceptsCounter, disconnectsCounter);
+        connectionsGauge = null;
+        acceptsCounter = null;
+        disconnectsCounter = null;
 
         if (channel instanceof ISOMsgMetrics.Source ms) {
             ISOMsgMetrics mtr = ms.getISOMsgMetrics();

--- a/jpos/src/main/java/org/jpos/q2/iso/QServer.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QServer.java
@@ -18,6 +18,7 @@
 
 package org.jpos.q2.iso;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.BaseUnits;
@@ -66,6 +67,8 @@ public class QServer
     AtomicInteger msgn = new AtomicInteger();
 
     private Gauge connectionsGauge;
+    private Counter acceptsCounter;
+    private Counter disconnectsCounter;
     private static final String CHANNEL_NAME_REGEXP = " (?=\\d+ \\S+:\\S+)";
 
     /** Default constructor. */
@@ -400,6 +403,14 @@ public class QServer
               BaseUnits.SESSIONS,
               server::getActiveConnections
             );
+        acceptsCounter = MeterFactory.counter(registry, MeterInfo.ISOSERVER_ACCEPTS, tags);
+        disconnectsCounter = MeterFactory.counter(registry, MeterInfo.ISOSERVER_DISCONNECTS, tags);
+        server.addServerEventListener(event -> {
+            if (event instanceof ISOServerAcceptEvent && acceptsCounter != null)
+                acceptsCounter.increment();
+            else if (event instanceof ISOServerClientDisconnectEvent && disconnectsCounter != null)
+                disconnectsCounter.increment();
+        });
 
         if (channel instanceof ISOMsgMetrics.Source ms) {
             ISOMsgMetrics mtr = ms.getISOMsgMetrics();
@@ -412,7 +423,7 @@ public class QServer
 
     private void removeMeters() {
         var registry = getServer().getMeterRegistry();
-        registry.remove(connectionsGauge);
+        MeterFactory.remove(registry, connectionsGauge, acceptsCounter, disconnectsCounter);
 
         if (channel instanceof ISOMsgMetrics.Source ms) {
             ISOMsgMetrics mtr = ms.getISOMsgMetrics();

--- a/jpos/src/test/java/org/jpos/iso/BaseChannelTest.java
+++ b/jpos/src/test/java/org/jpos/iso/BaseChannelTest.java
@@ -304,7 +304,6 @@ public class BaseChannelTest {
             BaseChannel rawChannel = new RawChannel();
             rawChannel.setLogger(logger, "comm/channel");
             rawChannel.setHost("127.0.0.1", serverSocket.getLocalPort());
-            rawChannel.setLogConnections(true);
             rawChannel.connect();
             try (Socket peer = accepted.get()) {
                 assertEquals("comm/channel", rawChannel.getRealm(), "rawChannel.getRealm()");
@@ -323,7 +322,7 @@ public class BaseChannelTest {
     }
 
     @Test
-    public void testConnectDoesNotLogByDefault() throws Throwable {
+    public void testConnectDoesNotLogWhenDisabled() throws Throwable {
         List<LogEvent> events = new ArrayList<>();
         Logger logger = new Logger();
         logger.setName("test-connect-default-logger");
@@ -338,6 +337,7 @@ public class BaseChannelTest {
             BaseChannel rawChannel = new RawChannel();
             rawChannel.setLogger(logger, "comm/channel");
             rawChannel.setHost("127.0.0.1", serverSocket.getLocalPort());
+            rawChannel.setLogConnections(false);
             rawChannel.connect();
             try (Socket peer = accepted.get()) {
                 assertFalse(events.stream().anyMatch(ev -> "connect".equals(ev.getTag())), "connect log event");
@@ -715,22 +715,22 @@ public class BaseChannelTest {
     }
 
     @Test
-    public void testLogConnectionsDefaultsToFalse() throws Throwable {
+    public void testLogConnectionsDefaultsToTrue() throws Throwable {
         BaseChannel channel = new PADChannel();
         channel.setConfiguration(new SimpleConfiguration());
 
-        assertFalse(channel.isLogConnections(), "channel.isLogConnections()");
+        assertTrue(channel.isLogConnections(), "channel.isLogConnections()");
     }
 
     @Test
-    public void testSetConfigurationEnablesLogConnections() throws Throwable {
+    public void testSetConfigurationDisablesLogConnections() throws Throwable {
         SimpleConfiguration cfg = new SimpleConfiguration();
-        cfg.put("log-connections", "true");
+        cfg.put("log-connections", "false");
         BaseChannel channel = new PADChannel();
 
         channel.setConfiguration(cfg);
 
-        assertTrue(channel.isLogConnections(), "channel.isLogConnections()");
+        assertFalse(channel.isLogConnections(), "channel.isLogConnections()");
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/iso/BaseChannelTest.java
+++ b/jpos/src/test/java/org/jpos/iso/BaseChannelTest.java
@@ -304,6 +304,7 @@ public class BaseChannelTest {
             BaseChannel rawChannel = new RawChannel();
             rawChannel.setLogger(logger, "comm/channel");
             rawChannel.setHost("127.0.0.1", serverSocket.getLocalPort());
+            rawChannel.setLogConnections(true);
             rawChannel.connect();
             try (Socket peer = accepted.get()) {
                 assertEquals("comm/channel", rawChannel.getRealm(), "rawChannel.getRealm()");
@@ -315,6 +316,32 @@ public class BaseChannelTest {
                 assertTrue(connect.getTags().containsKey("endpoint"), "connect.getTags().containsKey(endpoint)");
                 rawChannel.disconnect();
                 assertEquals("comm/channel", rawChannel.getRealm(), "rawChannel.getRealm()");
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    public void testConnectDoesNotLogByDefault() throws Throwable {
+        List<LogEvent> events = new ArrayList<>();
+        Logger logger = new Logger();
+        logger.setName("test-connect-default-logger");
+        logger.addListener(ev -> {
+            events.add(ev);
+            return ev;
+        });
+
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            Future<Socket> accepted = executor.submit(serverSocket::accept);
+            BaseChannel rawChannel = new RawChannel();
+            rawChannel.setLogger(logger, "comm/channel");
+            rawChannel.setHost("127.0.0.1", serverSocket.getLocalPort());
+            rawChannel.connect();
+            try (Socket peer = accepted.get()) {
+                assertFalse(events.stream().anyMatch(ev -> "connect".equals(ev.getTag())), "connect log event");
+                rawChannel.disconnect();
             } finally {
                 executor.shutdownNow();
             }
@@ -685,6 +712,25 @@ public class BaseChannelTest {
         x25Channel.setOverrideHeader(true);
         boolean result = x25Channel.isOverrideHeader();
         assertTrue(result, "result");
+    }
+
+    @Test
+    public void testLogConnectionsDefaultsToFalse() throws Throwable {
+        BaseChannel channel = new PADChannel();
+        channel.setConfiguration(new SimpleConfiguration());
+
+        assertFalse(channel.isLogConnections(), "channel.isLogConnections()");
+    }
+
+    @Test
+    public void testSetConfigurationEnablesLogConnections() throws Throwable {
+        SimpleConfiguration cfg = new SimpleConfiguration();
+        cfg.put("log-connections", "true");
+        BaseChannel channel = new PADChannel();
+
+        channel.setConfiguration(cfg);
+
+        assertTrue(channel.isLogConnections(), "channel.isLogConnections()");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add `log-connections` to `BaseChannel`, defaulting to `true`, so legacy successful connect and normal disconnect logging remains enabled unless explicitly disabled
- allow deployments to opt out of routine channel lifecycle logs with `<property name="log-connections" value="false" />` on the `<channel>` element
- keep failed connection attempts, protocol errors, and non-routine I/O failures logged
- add Micrometer counters for total channel/server connection lifecycle events alongside the existing active-connection gauges
- update BaseChannel tests for the legacy default and explicit opt-out behavior

## Compatibility note
The default remains compatible with existing deployments: routine successful connection and normal disconnection events are logged by default. Deployments that want the quieter behavior can set `log-connections=false` on the channel configuration.

## Verification
- `JAVA_HOME=$HOME/.sdkman/candidates/java/26.0.1-amzn ./gradlew :jpos:test --tests org.jpos.iso.BaseChannelTest --tests org.jpos.q2.iso.ChannelAdaptorTest --tests org.jpos.q2.iso.QServerTest`
- `git diff --check`