### PR TITLE
Add CMF field 113.38 (Cardholder Name Verification Result).

### DIFF
--- a/jpos/src/main/resources/packager/cmf.xml
+++ b/jpos/src/main/resources/packager/cmf.xml
@@ -1054,6 +1054,11 @@
           name="Interchange fee"
           class="org.jpos.iso.IFB_LLCHAR" />
       <isofield
+          id="38"
+          length="1"
+          name="Cardholder Name Verification Result"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
           id="39"
           length="4"
           name="Remote ISO result code"


### PR DESCRIPTION
## Summary

  This adds a new sub-field definition to the CMF packager so that payment switches can include a cardholder name verification result in ISO 8583 messages.

  ### Change

  Added sub-field 113.38 (`Cardholder Name Verification Result`) to `packager/cmf.xml`:

  - **Type:** `IF_CHAR` (fixed-length character)
  - **Length:** 1
  - **Values:** `M` (match), `P` (partial match), `N` (no match) — consistent with AVS/CVV2 result code conventions in field 49