### PR TITLE
Add CMF field 113.38 to cmfv3 packager

### DIFF
--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -1069,6 +1069,11 @@
           name="Interchange fee"
           class="org.jpos.iso.IFB_LLCHAR" />
       <isofield
+          id="38"
+          length="1"
+          name="Cardholder Name Verification Result"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
           id="39"
           length="4"
           name="Remote ISO result code"


### PR DESCRIPTION
Mirrors the CMF field 113.38 addition from PR #727 in the CMF v3 packager.

Verification:
- git diff --check
- xmllint --noout jpos/src/main/resources/packager/cmfv3.xml
- ./gradlew :jpos:classes