### PR TITLE
Add CMF DE 113.34 packager field

### DIFF
--- a/jpos/src/main/resources/packager/cmf.xml
+++ b/jpos/src/main/resources/packager/cmf.xml
@@ -1054,6 +1054,11 @@
           name="Interchange fee"
           class="org.jpos.iso.IFB_LLCHAR" />
       <isofield
+          id="34"
+          length="1"
+          name="Extended Authorization Indicator"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
           id="38"
           length="1"
           name="Cardholder Name Verification Result"

--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -1069,6 +1069,11 @@
           name="Interchange fee"
           class="org.jpos.iso.IFB_LLCHAR" />
       <isofield
+          id="34"
+          length="1"
+          name="Extended Authorization Indicator"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
           id="38"
           length="1"
           name="Cardholder Name Verification Result"

--- a/jpos/src/test/java/org/jpos/iso/TPPDataElementsTest.java
+++ b/jpos/src/test/java/org/jpos/iso/TPPDataElementsTest.java
@@ -46,4 +46,25 @@ public class TPPDataElementsTest {
         assertEquals(m.getString("113.70"), "2222");
         assertEquals(m.getString("113.71"), "1111");
     }
+
+    @Test
+    public void testExtendedAuthorizationIndicator() throws ISOException {
+        assertExtendedAuthorizationIndicator("jar:packager/cmf.xml");
+        assertExtendedAuthorizationIndicator("jar:packager/cmfv3.xml");
+    }
+
+    private void assertExtendedAuthorizationIndicator(String packagerResource) throws ISOException {
+        ISOPackager p = new GenericPackager(packagerResource);
+        ISOMsg m = new ISOMsg("2100");
+        m.setPackager(p);
+        m.set("113.34", "Y");
+
+        byte[] packed = m.pack();
+
+        ISOMsg unpacked = new ISOMsg();
+        unpacked.setPackager(p);
+        unpacked.unpack(packed);
+
+        assertEquals("Y", unpacked.getString("113.34"));
+    }
 }


### PR DESCRIPTION
## Summary
- add DE 113.34 Extended Authorization Indicator to `cmf.xml`
- add the same subfield to `cmfv3.xml`
- cover the new subfield with a CMF/CMFv3 round-trip test

## Verification
- `xmllint --noout jpos/src/main/resources/packager/cmf.xml jpos/src/main/resources/packager/cmfv3.xml`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/26.0.1-amzn ./gradlew :jpos:test --tests org.jpos.iso.TPPDataElementsTest`