### PR TITLE
feat(txn): support enum keys in TM contracts

### DIFF
--- a/doc/src/asciidoc/ch09/transaction_participants.adoc
+++ b/doc/src/asciidoc/ch09/transaction_participants.adoc
@@ -11,6 +11,18 @@ either be 'yes/no/true/false` or a list of environment names (i.e.: `prod, stagi
 
 In addition as of jPOS 3.0.0, it supports the `timeout` and `max-time` attributes and
 global 'max-time' property.
+
+Participants can also declare Context contracts with `requires`, `optional`,
+and `provides` child elements. Bare entries are treated as String keys. Enum
+keys can be declared explicitly with `enum:` followed by the fully qualified
+enum constant, for example:
+
+[source,xml]
+----
+<requires>enum:org.example.ContextKeys.REQUEST,TRACE_ID</requires>
+<optional>enum:org.example.ContextKeys.SESSION</optional>
+<provides>enum:org.example.ContextKeys.RESPONSE</provides>
+----
 =====
 
 include::participants/switch.adoc[]
@@ -20,4 +32,3 @@ include::participants/query_host.adoc[]
 include::participants/send_response.adoc[]
 include::participants/jsparticipant.adoc[]
 include::participants/pause.adoc[]
-

--- a/jpos/src/main/java/org/jpos/transaction/Context.java
+++ b/jpos/src/main/java/org/jpos/transaction/Context.java
@@ -149,7 +149,10 @@ public class Context implements Externalizable, Loggeable, Cloneable, Pausable, 
               if (key == null) {
                   return m.containsKey(null);  // Explicit null check
               }
-              String s = (key instanceof String a ? a : key.toString()).strip();
+              if (!(key instanceof String s)) {
+                  return m.containsKey(key) || m.containsKey(key.toString().strip());
+              }
+              s = s.strip();
               if (s.contains("|")) {
                   return Arrays.stream(s.split("\\|"))
                     .map(String::strip)
@@ -192,7 +195,7 @@ public class Context implements Externalizable, Loggeable, Cloneable, Pausable, 
                       keyPresent = m.containsKey(s);
                   }
               } else {
-                  keyPresent = m.containsKey(key);
+                  keyPresent = m.containsKey(key) || m.containsKey(key.toString().strip());
               }
 
               if (!keyPresent) {
@@ -477,10 +480,8 @@ public class Context implements Externalizable, Loggeable, Cloneable, Pausable, 
                     .map(String::strip)
                     .map(str -> (Object) str);  // Split strings into keys
               } else {
-                  String s = obj.toString().strip();  // Convert non-String to String
-                  return Arrays.stream(s.split("\\|"))
-                    .map(String::strip)
-                    .map(str -> (Object) str);
+                  Object fallback = obj.toString().strip();
+                  return Stream.of(obj, fallback);
               }
           })
           .filter(m::containsKey)  // Check if the key exists in the map

--- a/jpos/src/main/java/org/jpos/transaction/TransactionManager.java
+++ b/jpos/src/main/java/org/jpos/transaction/TransactionManager.java
@@ -89,6 +89,7 @@ public class TransactionManager
     public static final Integer COMMITTING = 1;
     /** State marker indicating a transaction has reached its terminal state. */
     public static final Integer DONE       = 2;
+    private static final String ENUM_KEY_PREFIX = "enum:";
     /** Group name used when no explicit group is configured. */
     public static final String  DEFAULT_GROUP = "";
     /** Hard ceiling on participants traversed per transaction (loop prevention). */
@@ -954,9 +955,9 @@ public class TransactionManager
                 participantShortName,
                 getLong (e, "timeout", 0L),
                 getLong (e, "max-time", globalMaxTime),
-                getSet(e.getChild("requires")),
-                getSet(e.getChild("provides")),
-                getSet(e.getChild("optional")),
+                getSet(e.getChild("requires"), participant.getClass().getClassLoader()),
+                getSet(e.getChild("provides"), participant.getClass().getClassLoader()),
+                getSet(e.getChild("optional"), participant.getClass().getClassLoader()),
                 getOrCreateTimers(participant)
               )
             );
@@ -1426,18 +1427,18 @@ public class TransactionManager
      * @param name     short name used in trace messages and timer tags
      * @param timeout  per-transaction soft timeout in milliseconds
      * @param maxTime  hard ceiling in milliseconds (overrides {@code timeout} when smaller)
-     * @param requires names this participant requires from a prior {@code provides}
-     * @param provides names this participant exports for downstream {@code requires}
-     * @param optional names this participant may consume but does not require
+     * @param requires keys this participant requires from a prior {@code provides}
+     * @param provides keys this participant exports for downstream {@code requires}
+     * @param optional keys this participant may consume but does not require
      * @param timers   per-phase Micrometer timers
      */
     private record ParticipantParams (
       String name,
       long timeout,
       long maxTime,
-      Set<String> requires,
-      Set<String> provides,
-      Set<String> optional,
+      Set<Object> requires,
+      Set<Object> provides,
+      Set<Object> optional,
       Timers timers
     )
     {
@@ -1493,8 +1494,35 @@ public class TransactionManager
         }
     }
 
-    private Set<String> getSet (Element e) {
-        return e != null ? new HashSet<>(Arrays.asList(ISOUtil.commaDecode(e.getTextTrim()))) : Collections.emptySet();
+    private Set<Object> getSet (Element e, ClassLoader loader) throws ClassNotFoundException {
+        if (e == null) {
+            return Collections.emptySet();
+        }
+        Set<Object> set = new HashSet<>();
+        for (String s : ISOUtil.commaDecode(e.getTextTrim())) {
+            set.add(parseContextKey(s, loader));
+        }
+        return set;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private Object parseContextKey (String key, ClassLoader loader) throws ClassNotFoundException {
+        String value = key.strip();
+        if (!value.startsWith(ENUM_KEY_PREFIX)) {
+            return value;
+        }
+        String enumName = value.substring(ENUM_KEY_PREFIX.length()).strip();
+        int separator = enumName.lastIndexOf('.');
+        if (separator <= 0 || separator == enumName.length() - 1) {
+            throw new IllegalArgumentException("Invalid enum context key: " + value);
+        }
+        String className = enumName.substring(0, separator);
+        String constantName = enumName.substring(separator + 1);
+        Class<?> enumClass = Class.forName(className, true, loader);
+        if (!Enum.class.isAssignableFrom(enumClass)) {
+            throw new IllegalArgumentException("Context key class is not an enum: " + className);
+        }
+        return Enum.valueOf((Class<? extends Enum>) enumClass.asSubclass(Enum.class), constantName);
     }
 
     private int prepareOrAbort (TransactionParticipant p, long id, Serializable context, ParticipantParams pp, TriFunction<TransactionParticipant, Long, Serializable, Integer> preparationFunction) {
@@ -1507,7 +1535,7 @@ public class TransactionManager
             } else {
                 Context c = ctx.clone(pp.requires.toArray(), pp.optional.toArray());
                 action = preparationFunction.apply(p, id, c);
-                if (!pp.requires.contains(LOGEVT.toString())) {
+                if (!pp.requires.contains(LOGEVT) && !pp.requires.contains(LOGEVT.toString())) {
                     // if we are not inheriting parent's log event and there's a log event
                     // in the childs context, copy it.
                     LogEvent evt = c.get(LOGEVT.toString());

--- a/jpos/src/test/java/org/jpos/transaction/ContextTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/ContextTest.java
@@ -387,6 +387,11 @@ public class ContextTest {
 
         assertFalse (ctx.clone("A", "B").hasKey("C"));
         assertTrue(ctx.clone("A", "B", "C").hasPersistedKey("C"));
+
+        ctx.put(ContextConstants.REQUEST, "REQ");
+        Context enumClone = ctx.clone(ContextConstants.REQUEST);
+        assertEquals("REQ", enumClone.get(ContextConstants.REQUEST));
+        assertFalse(enumClone.hasKey(ContextConstants.REQUEST.toString()));
     }
 
     @Test
@@ -402,6 +407,10 @@ public class ContextTest {
         assertTrue (ctx.hasKeys(" A ", "B | C"));
         assertEquals ("C", ctx.keysNotPresent("A", "B", "C"));
         assertEquals ("C,D,E|F", ctx.keysNotPresent("A", "B", "C", "D", "E|F"));
+        ctx.put(ContextConstants.REQUEST, "REQ");
+        assertTrue(ctx.hasKeys(ContextConstants.REQUEST));
+        assertEquals("", ctx.keysNotPresent(ContextConstants.REQUEST));
+        assertEquals("RESPONSE", ctx.keysNotPresent(ContextConstants.RESPONSE));
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/transaction/TransactionManagerLoggingTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/TransactionManagerLoggingTest.java
@@ -23,6 +23,7 @@ import org.jdom2.Element;
 import org.jpos.q2.Q2;
 import org.jpos.q2.QFactory;
 import org.jpos.util.Caller;
+import org.jpos.util.Chronometer;
 import org.jpos.util.Log;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -93,9 +95,41 @@ public class TransactionManagerLoggingTest {
         assertEquals(Caller.shortClassName(FailingParticipant.class.getName()), event.getTags().get("participant"));
     }
 
+    @Test
+    void participantContractsSupportEnumContextKeys() throws Exception {
+        Element e = new Element("participant");
+        e.setAttribute("class", EnumContractParticipant.class.getName());
+        e.addContent(new Element("requires")
+          .setText("enum:org.jpos.transaction.TransactionManagerLoggingTest$EnumKey.REQUEST,STRING_REQUEST"));
+        e.addContent(new Element("optional")
+          .setText("enum:org.jpos.transaction.TransactionManagerLoggingTest$EnumKey.SOURCE"));
+        e.addContent(new Element("provides")
+          .setText("enum:org.jpos.transaction.TransactionManagerLoggingTest$EnumKey.RESPONSE,STRING_RESPONSE"));
+        when(factory.newInstance(EnumContractParticipant.class.getName())).thenReturn(new EnumContractParticipant());
+
+        TransactionParticipant participant = tm.createParticipant(e);
+        Context ctx = new Context();
+        ctx.put(EnumKey.REQUEST, "request");
+        ctx.put(EnumKey.SOURCE, "source");
+        ctx.put("STRING_REQUEST", "string-request");
+        ctx.put("UNPUBLISHED", "unpublished");
+
+        int result = tm.invokePrepareWithContracts(participant, 11L, ctx);
+
+        assertEquals(TransactionConstants.PREPARED, result);
+        assertEquals("response", ctx.get(EnumKey.RESPONSE));
+        assertEquals("string-response", ctx.get("STRING_RESPONSE"));
+        assertNull(ctx.get("LOCAL_ONLY"));
+    }
+
     static class TestTransactionManager extends TransactionManager {
         int invokePrepare(TransactionParticipant participant, long id, Serializable context) {
             return prepare(participant, id, context);
+        }
+
+        int invokePrepareWithContracts(TransactionParticipant participant, long id, Serializable context) {
+            return prepare(0, id, context, new ArrayList<>(), List.of(participant).iterator(),
+              false, null, null, new Chronometer());
         }
     }
 
@@ -115,5 +149,34 @@ public class TransactionManagerLoggingTest {
         @Override
         public void abort(long id, Serializable context) {
         }
+    }
+
+    public static class EnumContractParticipant implements TransactionParticipant {
+        @Override
+        public int prepare(long id, Serializable context) {
+            Context ctx = (Context) context;
+            if (!ctx.hasKey(EnumKey.REQUEST)
+              || !ctx.hasKey(EnumKey.SOURCE)
+              || !ctx.hasKey("STRING_REQUEST")
+              || ctx.hasKey("UNPUBLISHED")) {
+                return ABORTED;
+            }
+            ctx.put(EnumKey.RESPONSE, "response");
+            ctx.put("STRING_RESPONSE", "string-response");
+            ctx.put("LOCAL_ONLY", "local-only");
+            return PREPARED | READONLY | NO_JOIN;
+        }
+
+        @Override
+        public void commit(long id, Serializable context) {
+        }
+
+        @Override
+        public void abort(long id, Serializable context) {
+        }
+    }
+
+    enum EnumKey {
+        REQUEST, SOURCE, RESPONSE
     }
 }


### PR DESCRIPTION
Closes #732.

This adds explicit enum-key support to TransactionManager participant contracts while keeping existing bare entries as String keys.

Changes:
- Parse `enum:<fully.qualified.Enum.CONSTANT>` entries in `<requires>`, `<optional>`, and `<provides>` into enum constants.
- Preserve object keys through constrained `Context.hasKeys`, `keysNotPresent`, and `clone` paths while retaining the previous String fallback behavior.
- Document the enum-key syntax in the transaction participant docs.
- Add regression coverage for constrained participants using mixed enum and String keys.

Verification:
- `./gradlew :jpos:test --tests org.jpos.transaction.ContextTest --tests org.jpos.transaction.TransactionManagerLoggingTest`
- `./gradlew :jpos:test`
- `git diff --check`
