### PR TITLE
core: normalize raw Track 2 data

### DIFF
--- a/jpos/src/main/java/org/jpos/core/Track2.java
+++ b/jpos/src/main/java/org/jpos/core/Track2.java
@@ -235,11 +235,12 @@ public class Track2 {
         {
             if (s == null)
                 throw new InvalidCardException ("null track2 data");
-            if (s.length() > 37)
+            String normalized = normalize(s);
+            if (normalized.length() > 37)
                 throw new InvalidCardException("track2 too long");
 
             track = s;
-            Matcher matcher = pattern.matcher(s);
+            Matcher matcher = pattern.matcher(normalized);
             int cnt = matcher.groupCount();
             if (matcher.find() && cnt >= 1) {
                 pan = matcher.group(1);
@@ -255,6 +256,16 @@ public class Track2 {
                 throw new InvalidCardException ("invalid track2");
             }
             return this;
+        }
+
+        /** Normalize raw magstripe Track 2 delimiters to the ISO DE35 form. */
+        private static String normalize(String track) {
+            String normalized = track.trim();
+            if (normalized.startsWith(";"))
+                normalized = normalized.substring(1);
+            if (normalized.endsWith("?"))
+                normalized = normalized.substring(0, normalized.length() - 1);
+            return normalized.replace('d', 'D');
         }
 
         /**

--- a/jpos/src/test/java/org/jpos/core/CardTest.java
+++ b/jpos/src/test/java/org/jpos/core/CardTest.java
@@ -45,6 +45,19 @@ public class CardTest  {
     }
 
     @Test
+    public void testCardNormalizesRawTrack2FromIsoMessage() throws Throwable {
+        ISOMsg m = new ISOMsg("0100");
+        m.set(35, ";4111111111111111d40111234561234567890?");
+
+        Card card = Card.builder().isomsg(m).build();
+
+        assertEquals("4111111111111111", card.getPan(), "pan");
+        assertEquals("4011", card.getExp(), "exp");
+        assertEquals("123", card.getServiceCode(), "serviceCode");
+        assertTrue(card.hasTrack2(), "track2");
+    }
+
+    @Test
     public void testShortTrack2() throws Throwable {
         Track2 t2 = Track2.builder()
                 .track("4111111111111111=").build();


### PR DESCRIPTION
Normalizes raw magstripe Track 2 sentinels and lowercase `d` separators before `Track2` parsing.

This lets `Card.builder().isomsg(...)` accept common Track 2 representations while retaining the existing `CardValidator` cross-checks and pluggable LUHN validation. The raw track value is retained for callers.

Validation:
- `:jpos:test --tests "org.jpos.core.CardTest"`