### PR TITLE
Harden self-inclusive binary prefixes and add packager tests

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOBinaryFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBinaryFieldPackager.java
@@ -92,19 +92,19 @@ public class ISOBinaryFieldPackager extends ISOFieldPackager implements GenericP
     }
 
     /**
-     * Supports the {@code inclusive="true"} GenericPackager attribute for
-     * one- and two-byte binary length prefixes.
+     * Supports the {@code inclusive="true"} GenericPackager attribute, which
+     * makes a binary length prefix self-inclusive (the encoded length counts
+     * the prefix bytes themselves). Requires the field to use a binary length
+     * prefix, e.g. {@code IFB_LLHBINARY} or {@code IFB_LLLHBINARY}.
      */
     @Override
-    public void setGenericPackagerParams(Attributes atts) {
+    public void setGenericPackagerParams(Attributes atts) throws ISOException {
         if (!Boolean.parseBoolean(atts.getValue("inclusive")))
             return;
-        if (prefixer == BinaryPrefixer.B)
-            prefixer = SelfInclusiveBinaryPrefixer.B;
-        else if (prefixer == BinaryPrefixer.BB)
-            prefixer = SelfInclusiveBinaryPrefixer.BB;
-        else
-            throw new IllegalArgumentException("The inclusive attribute requires a binary length prefix");
+        if (!(prefixer instanceof BinaryPrefixer))
+            throw new ISOException(
+                "the inclusive attribute requires a binary length prefix (e.g. IFB_LLHBINARY or IFB_LLLHBINARY)");
+        prefixer = SelfInclusiveBinaryPrefixer.of((BinaryPrefixer) prefixer);
     }
 
     public int getMaxPackedLength()

--- a/jpos/src/main/java/org/jpos/iso/SelfInclusiveBinaryPrefixer.java
+++ b/jpos/src/main/java/org/jpos/iso/SelfInclusiveBinaryPrefixer.java
@@ -34,6 +34,22 @@ public class SelfInclusiveBinaryPrefixer implements Prefixer {
         this.prefixer = prefixer;
     }
 
+    /**
+     * Returns a self-inclusive prefixer wrapping the given binary prefixer,
+     * reusing the {@link #B} and {@link #BB} singletons for the common one- and
+     * two-byte cases.
+     *
+     * @param prefixer the underlying binary length prefixer
+     * @return a self-inclusive view over {@code prefixer}
+     */
+    public static SelfInclusiveBinaryPrefixer of(BinaryPrefixer prefixer) {
+        if (prefixer == BinaryPrefixer.B)
+            return B;
+        if (prefixer == BinaryPrefixer.BB)
+            return BB;
+        return new SelfInclusiveBinaryPrefixer(prefixer);
+    }
+
     @Override
     public void encodeLength(int length, byte[] b) throws ISOException {
         int inclusiveLength = length + getPackedLength();
@@ -56,6 +72,7 @@ public class SelfInclusiveBinaryPrefixer implements Prefixer {
     }
 
     private int maxLength() {
-        return getPackedLength() == 1 ? 0xFF : 0xFFFF;
+        int n = getPackedLength();
+        return n >= 4 ? Integer.MAX_VALUE : (1 << (8 * n)) - 1;
     }
 }

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericPackagerParams.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericPackagerParams.java
@@ -18,6 +18,7 @@
 
 package org.jpos.iso.packager;
 
+import org.jpos.iso.ISOException;
 import org.xml.sax.Attributes;
 
 /** Interface defining configuration parameters for generic packagers. */
@@ -25,6 +26,7 @@ public interface GenericPackagerParams {
     /**
      * Applies packager configuration from the SAX attributes of the packager XML element.
      * @param atts the SAX attributes from the packager element
+     * @throws ISOException if the supplied attributes are invalid for this packager
      */
-    void setGenericPackagerParams(Attributes atts);
+    void setGenericPackagerParams(Attributes atts) throws ISOException;
 }

--- a/jpos/src/test/java/org/jpos/iso/packager/GenericPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/GenericPackagerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -43,6 +44,8 @@ import org.jpos.iso.IFA_BITMAP;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOBinaryField;
 import org.jpos.iso.ISOFieldPackager;
+import org.jpos.iso.ISOMsg;
+import org.jpos.iso.ISOUtil;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.Attributes;
@@ -69,6 +72,50 @@ public class GenericPackagerTest {
         ISOBinaryField unpacked = new ISOBinaryField(126);
         assertEquals(3, fieldPackager.unpack(unpacked, packed, 0));
         assertArrayEquals(new byte[] { 0x12, 0x34 }, (byte[]) unpacked.getValue());
+    }
+
+    @Test
+    public void testInclusiveIsoFieldPackagerWithSubfields() throws Exception {
+        // Mirrors Visa Base I field 126.18: a self-inclusive 1-byte length prefix
+        // wrapping a subfield packager. The length byte counts itself, so
+        // 5 + 5 value bytes are encoded as 0x0B (=11) and the subfields survive.
+        String xml = "<!DOCTYPE isopackager PUBLIC \"-//jPOS/jPOS Generic Packager DTD 1.0//EN\" \"http://jpos.org/dtd/generic-packager-1.0.dtd\">"
+            + "<isopackager>"
+            + "<isofieldpackager id=\"48\" length=\"10\" name=\"Sub\""
+            + " class=\"org.jpos.iso.IFB_LLHBINARY\" inclusive=\"true\""
+            + " emitBitmap=\"false\" firstField=\"1\""
+            + " packager=\"org.jpos.iso.packager.GenericSubFieldPackager\">"
+            + "<isofield id=\"1\" length=\"5\" name=\"Id\" class=\"org.jpos.iso.IFE_CHAR\"/>"
+            + "<isofield id=\"2\" length=\"5\" name=\"Reserved\" class=\"org.jpos.iso.IFB_BINARY\"/>"
+            + "</isofieldpackager>"
+            + "</isopackager>";
+        GenericPackager packager = new GenericPackager(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        ISOFieldPackager fieldPackager = packager.getFieldPackager(48);
+
+        ISOMsg sub = new ISOMsg(48);
+        sub.set(1, "VCIND");
+        sub.set(2, ISOUtil.hex2byte("F1F1F1F1F1"));
+
+        byte[] packed = fieldPackager.pack(sub);
+        assertEquals(11, packed.length);
+        assertEquals(0x0B, packed[0] & 0xFF);
+
+        ISOMsg out = new ISOMsg(48);
+        assertEquals(11, fieldPackager.unpack(out, packed, 0));
+        assertEquals("VCIND", out.getString(1));
+        assertArrayEquals(ISOUtil.hex2byte("F1F1F1F1F1"), out.getBytes(2));
+    }
+
+    @Test
+    public void testInclusiveRejectsNonBinaryPrefix() {
+        // IFB_BINARY has no binary length prefix (NullPrefixer); inclusive="true"
+        // must be rejected rather than silently ignored.
+        String xml = "<!DOCTYPE isopackager PUBLIC \"-//jPOS/jPOS Generic Packager DTD 1.0//EN\" \"http://jpos.org/dtd/generic-packager-1.0.dtd\">"
+            + "<isopackager>"
+            + "<isofield id=\"48\" length=\"10\" name=\"Fixed\" class=\"org.jpos.iso.IFB_BINARY\" inclusive=\"true\"/>"
+            + "</isopackager>";
+        ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+        assertThrows(ISOException.class, () -> new GenericPackager(in));
     }
 
     @Test


### PR DESCRIPTION
Follow-ups to #740 (self-inclusive binary length prefixes).

### Robustness
- `SelfInclusiveBinaryPrefixer.of(BinaryPrefixer)` — a factory that reuses the `B`/`BB` singletons for the common one- and two-byte cases and wraps any other binary prefixer. `maxLength()` is generalized from the hard-coded 1-/2-byte cap to n-byte prefixes.
- `ISOBinaryFieldPackager.setGenericPackagerParams` now selects the inclusive prefixer via `instanceof BinaryPrefixer` + the factory, instead of comparing against the `BinaryPrefixer.B`/`.BB` singleton instances. A field that installs a non-singleton `new BinaryPrefixer(n)` now works instead of being wrongly rejected.

### Error handling
- `GenericPackagerParams.setGenericPackagerParams` now declares `throws ISOException`, and the non-binary-prefix rejection throws `ISOException` (checked) rather than an unchecked `IllegalArgumentException`. This matches the packager-XML error convention (`GenericPackager.readFile` surfaces it as `ISOException`). Existing overriding implementations are unaffected — an override may declare fewer checked exceptions.

### Tests
- `testInclusiveIsoFieldPackagerWithSubfields` — `inclusive="true"` on an `isofieldpackager` whose value is a subfield packager (the Visa Base I field 126.18 shape: 1-byte self-inclusive length wrapping `IFE_CHAR` + `IFB_BINARY` subfields), asserting the `0x0B` prefix, the recovered subfields, and consumed length. This is the motivating real-world path, which #740 did not cover with a test.
- `testInclusiveRejectsNonBinaryPrefix` — `inclusive="true"` on `IFB_BINARY` (no binary length prefix) is rejected rather than silently ignored.

`./gradlew :jpos:test` passes (Java 26.0.1-amzn).