### PR TITLE
Log full Throwable on Q2 start failure

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/Q2.java
+++ b/jpos/src/main/java/org/jpos/q2/Q2.java
@@ -387,7 +387,7 @@ public class Q2 implements FileFilter, Runnable {
                 } catch (InterruptedException | IllegalAccessError ignored) {
                     // NOPMD
                 } catch (Throwable t) {
-                    log.error("start", t.getMessage());
+                    log.error("start", t);
                     relax();
                 }
             }


### PR DESCRIPTION
`Q2`'s main loop caught `Throwable` and logged only `t.getMessage()`, which turns diagnosable failures into one-line riddles.

Real case that prompted this: a user running with BouncyCastle missing from the runtime classpath got only

```xml
<log realm="q2/lifecycle" at="...">
  <error>
    start
    org/bouncycastle/bcpg/ArmoredInputStream
  </error>
</log>
```

No stack trace, no indication that the failure was `logVersion()` → `PGPHelper.getLicense()` failing to link, and no way to tell a missing jar from an API break. Every other `catch` block in `Q2` logs the `Throwable` itself; this one now does too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)