### PR TITLE
iso: use JSSE endpoint identification

### DIFF
--- a/doc/src/asciidoc/ch05/ssl_channels.adoc
+++ b/doc/src/asciidoc/ch05/ssl_channels.adoc
@@ -81,3 +81,11 @@ want to enable. If these properties are not configured, all protocols and cipher
 available to the JVM will be enabled, something you probably don't want.
 ====
 
+[TIP]
+====
+Set `serverauth` to `true` on an outbound channel to validate both the server
+certificate chain and its DNS identity.  jPOS uses JSSE HTTPS endpoint
+identification, including standard certificate SAN and wildcard handling.  The
+optional `servername` property overrides the DNS name to verify, for example
+when the network endpoint is reached through an alias.
+====

--- a/jpos/src/main/java/org/jpos/iso/GenericSSLSocketFactory.java
+++ b/jpos/src/main/java/org/jpos/iso/GenericSSLSocketFactory.java
@@ -23,21 +23,12 @@ import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
 import org.jpos.util.SimpleLogSource;
 
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
-import javax.naming.ldap.Rdn;
 import javax.net.ssl.*;
-import javax.security.auth.x500.X500Principal;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.UnknownHostException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.SecureRandom;
@@ -101,9 +92,9 @@ public class GenericSSLSocketFactory
     }
 
     /**
-     * Sets the Common Name (CN) used to verify the peer certificate.
+     * Sets the server name used to identify the peer certificate.
      *
-     * @param serverName expected Common Name (CN) of the peer certificate
+     * @param serverName expected DNS name of the peer certificate
      */
     public void setServerName(String serverName){
         this.serverName=serverName;
@@ -119,9 +110,9 @@ public class GenericSSLSocketFactory
     }
 
     /**
-     * Toggles whether outbound sockets validate the server certificate chain.
+     * Toggles whether outbound sockets validate the server certificate chain and hostname.
      *
-     * @param serverAuthNeeded validate the server certificate chain on outbound sockets
+     * @param serverAuthNeeded validate the server certificate chain and hostname on outbound sockets
      */
     public void setServerAuthNeeded(boolean serverAuthNeeded){
         this.serverAuthNeeded=serverAuthNeeded;
@@ -246,85 +237,14 @@ public class GenericSSLSocketFactory
         throws IOException, ISOException
     {
         if(socketFactory==null) socketFactory=createSocketFactory();
-        SSLSocket s = (SSLSocket) socketFactory.createSocket(host,port);
-        verifyHostname(s);
+        String peerHost = serverAuthNeeded && serverName != null && !serverName.isEmpty() ? serverName : host;
+        SSLSocket s = (SSLSocket) socketFactory.createSocket(new Socket(host, port), peerHost, port, true);
+        if (serverAuthNeeded) {
+            SSLParameters parameters = s.getSSLParameters();
+            parameters.setEndpointIdentificationAlgorithm("HTTPS");
+            s.setSSLParameters(parameters);
+        }
         return s;
-    }
-
-    /**
-     * Verify that serverName and CN equals.
-     *
-     * <pre>
-     * Origin:      jakarta-commons/httpclient
-     * File:        StrictSSLProtocolSocketFactory.java
-     * Revision:    1.5
-     * License:     Apache-2.0
-     * </pre>
-     *
-     * @param socket a SSLSocket value
-     * @exception SSLPeerUnverifiedException  If there are problems obtaining
-     * the server certificates from the SSL session, or the server host name 
-     * does not match with the "Common Name" in the server certificates 
-     * SubjectDN.
-     * @exception UnknownHostException  If we are not able to resolve
-     * the SSL sessions returned server host name. 
-     */
-    private void verifyHostname(SSLSocket socket)
-        throws SSLPeerUnverifiedException, UnknownHostException
-    {
-        if (!serverAuthNeeded) {
-            return; 
-        }
-
-        SSLSession session = socket.getSession();
-
-        if (serverName==null || serverName.length()==0) {
-            serverName = session.getPeerHost();
-            try {
-                InetAddress addr = InetAddress.getByName(serverName);
-            } catch (UnknownHostException uhe) {
-                throw new UnknownHostException("Could not resolve SSL " +
-                                               "server name " + serverName);
-            }
-        }
-
-
-        Certificate[] certs = session.getPeerCertificates();
-        if (certs==null || certs.length==0)
-            throw new SSLPeerUnverifiedException("No server certificates found");
-
-        if (!(certs[0] instanceof X509Certificate cert))
-            throw new SSLPeerUnverifiedException("Server certificate is not X.509");
-
-        String cn = getCN(cert);
-        if (!serverName.equalsIgnoreCase(cn)) {
-            throw new SSLPeerUnverifiedException("Invalid SSL server name. "+
-                    "Expected '" + serverName +
-                    "', got '" + cn + "'");
-        }
-    }
-
-    /**
-     * Extracts the Common Name (CN) from an X.509 certificate's subject DN
-     * using the standard {@link X500Principal} and {@link LdapName} APIs,
-     * which correctly handle quoting and escaping per RFC 2253.
-     *
-     * @param cert  an X.509 certificate
-     * @return the value of the "Common Name" field, or null if not present.
-     */
-    private String getCN(X509Certificate cert) throws SSLPeerUnverifiedException {
-        try {
-            X500Principal principal = cert.getSubjectX500Principal();
-            LdapName ln = new LdapName(principal.getName(X500Principal.RFC2253));
-            for (Rdn rdn : ln.getRdns()) {
-                if ("CN".equalsIgnoreCase(rdn.getType())) {
-                    return rdn.getValue().toString();
-                }
-            }
-            return null;
-        } catch (InvalidNameException e) {
-            throw new SSLPeerUnverifiedException("Invalid subject DN: " + e.getMessage());
-        }
     }
 
     /**
@@ -359,9 +279,9 @@ public class GenericSSLSocketFactory
     }
 
     /**
-     * Returns the configured peer certificate Common Name.
+     * Returns the configured peer certificate DNS name.
      *
-     * @return expected Common Name (CN) of the peer certificate
+     * @return expected DNS name of the peer certificate
      */
     public String getServerName() {
         return serverName;

--- a/jpos/src/test/java/org/jpos/iso/SslChannelIntegrationTest.java
+++ b/jpos/src/test/java/org/jpos/iso/SslChannelIntegrationTest.java
@@ -27,6 +27,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.hamcrest.Description;
@@ -38,6 +40,8 @@ import org.jpos.iso.channel.XMLChannel;
 import org.jpos.iso.packager.XMLPackager;
 import org.jpos.util.Logger;
 import org.jpos.util.SimpleLogListener;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +54,29 @@ public class SslChannelIntegrationTest {
 
     private static final int PORT = 4000;
 
+    private static Path keyStore;
     private Logger logger;
+
+    @BeforeAll
+    static void createKeyStore() throws Exception {
+        keyStore = Files.createTempFile("jpos-ssl-", ".jks");
+        Files.delete(keyStore);
+        String keytoolCommand = System.getProperty("os.name").startsWith("Windows") ? "keytool.exe" : "keytool";
+        Process keytool = new ProcessBuilder(
+            Path.of(System.getProperty("java.home"), "bin", keytoolCommand).toString(),
+            "-genkeypair", "-alias", "selfsigned", "-keyalg", "RSA",
+            "-dname", "CN=unused.example.com", "-ext", "SAN=dns:*.visa.com",
+            "-validity", "365", "-keystore", keyStore.toString(), "-storetype", "JKS",
+            "-storepass", "password", "-keypass", "password", "-noprompt"
+        ).inheritIO().start();
+        if (keytool.waitFor() != 0)
+            throw new IOException("Unable to create SSL test keystore");
+    }
+
+    @AfterAll
+    static void removeKeyStore() throws IOException {
+        Files.deleteIfExists(keyStore);
+    }
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -59,7 +85,7 @@ public class SslChannelIntegrationTest {
     }
 
     @Test
-    public void serverSideDisconnect() throws Exception {
+    public void serverAuthenticationSupportsWildcardCertificates() throws Exception {
         ISOServer isoServer = newIsoServer();
         new Thread(isoServer).start();
 
@@ -108,30 +134,9 @@ public class SslChannelIntegrationTest {
         return isoServer;
     }
 
-// keystore.jks created using the following command in a shell:
-//
-//    [user@hostname]$ keytool -genkey -keyalg RSA -alias selfsigned -keystore keystore.jks -storepass password
-//    What is your first and last name?
-//      [Unknown]:  localhost
-//    What is the name of your organizational unit?
-//      [Unknown]:  Dummy
-//    What is the name of your organization?
-//      [Unknown]:  Dummy
-//    What is the name of your City or Locality?
-//      [Unknown]:  Somewhere
-//    What is the name of your State or Province?
-//      [Unknown]:  Somewhere
-//    What is the two-letter country code for this unit?
-//      [Unknown]:  AU
-//    Is CN=localhost, OU=Dummy, O=Dummy, L=Somewhere, ST=Somewhere, C=AU correct?
-//      [no]:  yes
-//
-//    Enter key password for <selfsigned>
-//    	(RETURN if same as keystore password):
-
     private Configuration serverConfiguration() {
         Properties props = new Properties();
-        props.put("keystore", "src/test/resources/keystore.jks");
+        props.put("keystore", keyStore.toString());
         props.put("storepassword", "password");
         props.put("keypassword", "password");
         // props.put("addEnabledCipherSuite", "SSL_RSA_WITH_3DES_EDE_CBC_SHA");
@@ -140,8 +145,9 @@ public class SslChannelIntegrationTest {
 
     private Configuration clientConfiguration() {
         Properties props = new Properties();
-        props.put("keystore", "src/test/resources/keystore.jks");
-        props.put("serverauth", "false");
+        props.put("keystore", keyStore.toString());
+        props.put("serverauth", "true");
+        props.put("servername", "gateway.visa.com");
         props.put("storepassword", "password");
         props.put("keypassword", "password");
         // props.put("addEnabledCipherSuite", "SSL_RSA_WITH_3DES_EDE_CBC_SHA");


### PR DESCRIPTION
Replaces the custom CN-only hostname verifier with JSSE HTTPS endpoint identification when server authentication is enabled.

The TLS peer host is the configured servername when present, otherwise the network host. This enables standard SAN, wildcard, and IP-address verification.

Includes a fresh JDK-generated wildcard-SAN integration certificate; the test connects to localhost while verifying gateway.visa.com against DNS:*.visa.com.

Tested with:
./gradlew :jpos:test --tests org.jpos.iso.SslChannelIntegrationTest --rerun-tasks --no-daemon