### PR TITLE
build: upgrade Gradle to 9.6.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Summary

- upgrade the Gradle wrapper from 9.5.1 to 9.6.1

## Verification

- `./gradlew --no-daemon test` (Java 26.0.1-amzn / Gradle 9.6.1; 4,388 tests, 0 failures/errors)
