### PR TITLE
build: remove legacy IDEA ipr customization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,20 +162,6 @@ subprojects {
     }
 }
 
-// Configure IDEA to use Git
-idea {
-    project {
-        ipr {
-            withXml { 
-                provider -> provider.node.component.find { 
-                    it.@name == 'VcsDirectoryMappings' 
-                }.mapping.@vcs = 'Git' 
-            }
-        }
-        languageLevel = '19'
-    }
-}
-
 task aggregatedJavadoc (type: Javadoc, description: "Aggregated Javadocs") {
     source subprojects.collect {project ->
         project.sourceSets.main.allJava


### PR DESCRIPTION
## Summary

- remove the obsolete IDEA `ipr` XML customization
- let IntelliJ IDEA derive its project configuration from `build.gradle`

## Verification

- `sdk env && ./gradlew --no-daemon help --warning-mode all`
- `sdk env && ./gradlew --no-daemon test --max-workers=1 --warning-mode all` (4,388 tests; 0 failures/errors)
