### PR TITLE
Enhanced Switch with prefix fallback mode

### DIFF
--- a/doc/src/asciidoc/ch09/participants/switch.adoc
+++ b/doc/src/asciidoc/ch09/participants/switch.adoc
@@ -9,8 +9,13 @@ value to return a set of groups picked from a standard `Configuration`.
 |========================================================================
 |Property  | Description                                 | Default Value
 |txnname   | Context entry to use as key                 | `TXNNAME` 
+|mode      | Match mode (`strict` or `prefix`)           | `strict`
 |unknown   | Set of groups to be used on not found       | ""
 |========================================================================
+
+In `prefix` mode, the selector first tries an exact match. If none is found,
+it uses the longest configured key that is a prefix of the context value. This
+gives more-specific routes priority over generic fallback routes.
 
 Here is a sample configuration taken from jCard:
 
@@ -19,6 +24,7 @@ Here is a sample configuration taken from jCard:
 
  <participant class="org.jpos.transaction.participant.Switch" 
       logger="Q2" realm="Switch">
+  <property name="mode" value="prefix" />
   <property name="100.30" 
            value="balanceinquiry prepareresponse logit close sendresponse" />
   <property name="100.30.182" 
@@ -39,4 +45,3 @@ Here is a sample configuration taken from jCard:
 
 A previous participant puts in the context under the key `TXNNAME` data taken from
 the request ISOMsg (i.e. MTI, processing code, function code).
-

--- a/jpos/src/main/java/org/jpos/core/SubConfiguration.java
+++ b/jpos/src/main/java/org/jpos/core/SubConfiguration.java
@@ -18,8 +18,8 @@
 
 package org.jpos.core;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * SubConfiguration objects lets childs objects access attributes
@@ -136,11 +136,9 @@ public class SubConfiguration implements Configuration {
     }
     @Override
     public Set<String> keySet() {
-        Set<String> keys = new HashSet<String>();
-        for (String k : cfg.keySet())
-            if (k.startsWith(prefix))
-                keys.add(k);
-
-        return keys;
+        return cfg.keySet().stream()
+          .filter(k -> k.startsWith(prefix))
+          .map(k -> k.substring(prefix.length()))
+          .collect(Collectors.toSet());
     }
 }

--- a/jpos/src/main/java/org/jpos/transaction/participant/Switch.java
+++ b/jpos/src/main/java/org/jpos/transaction/participant/Switch.java
@@ -32,7 +32,7 @@ import static org.jpos.transaction.ContextConstants.TXNNAME;
  * {@link GroupSelector} that picks the next participant group based on the
  * transaction name stored in the context (default key {@link
  * org.jpos.transaction.ContextConstants#TXNNAME}).
- * When configured with {@code mode=prefix}, the tradicional exact match is attempted
+ * When configured with {@code mode=prefix}, the traditional exact match is attempted
  * first, followed by the longest configured key that prefixes the transaction name.
  */
 @SuppressWarnings("unused")

--- a/jpos/src/main/java/org/jpos/transaction/participant/Switch.java
+++ b/jpos/src/main/java/org/jpos/transaction/participant/Switch.java
@@ -19,6 +19,9 @@
 package org.jpos.transaction.participant;
 
 import java.io.Serializable;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 import org.jpos.core.Configurable;
 import org.jpos.core.Configuration;
 import org.jpos.transaction.Context;
@@ -29,30 +32,61 @@ import static org.jpos.transaction.ContextConstants.TXNNAME;
  * {@link GroupSelector} that picks the next participant group based on the
  * transaction name stored in the context (default key {@link
  * org.jpos.transaction.ContextConstants#TXNNAME}).
+ * When configured with {@code mode=prefix}, the tradicional exact match is attempted
+ * first, followed by the longest configured key that prefixes the transaction name.
  */
 @SuppressWarnings("unused")
 public class Switch implements Configurable, GroupSelector {
+    private static final String PREFIX_MODE = "prefix";
+    private static final Set<String> SELECTOR_PROPERTIES = Set.of("mode", "txnname", "unknown");
+
     /** Creates the selector; configuration is supplied via {@link #setConfiguration(Configuration)}. */
-    public Switch() {}
     private Configuration cfg;
     private String txnNameEntry;
+    private boolean prefixMode;
+    private List<String> sortedRoutingKeys = List.of();   // kept sorted from longest to shortest
+
+    public Switch() {}
+
     public String select (long id, Serializable ser) {
-        Context ctx = (Context) ser;
+        Context ctx   = (Context) ser;
         String type   = ctx.getString (txnNameEntry);
         String groups = null;
-        if (type != null)
+
+        if (type != null) {
             groups = cfg.get (type, null);
+
+            if (groups == null && prefixMode) {
+                String matchedKey = sortedRoutingKeys.stream()
+                  .filter(type::startsWith)
+                  .findFirst()
+                  .orElse(null);
+
+                if (matchedKey != null) {
+                    groups = cfg.get (matchedKey, null);
+                }
+            }
+        }
+
         if (groups == null)
             groups = cfg.get ("unknown", "");
         ctx.log ("SWITCH " + type + " (" + groups + ")");
 
         return groups;
     }
+
     public int prepare (long id, Serializable o) {
         return PREPARED | READONLY | NO_JOIN;
     }
+
     public void setConfiguration (Configuration cfg) {
         this.cfg = cfg;
         txnNameEntry = cfg.get("txnname", TXNNAME.toString());
+        prefixMode = PREFIX_MODE.equals(cfg.get("mode", "strict"));
+        if (prefixMode)
+            sortedRoutingKeys = cfg.keySet().stream()
+              .filter(key -> !SELECTOR_PROPERTIES.contains(key))
+              .sorted(Comparator.comparingInt(String::length).reversed())
+              .toList();
     }
 }

--- a/jpos/src/test/java/org/jpos/core/SubConfigurationTest.java
+++ b/jpos/src/test/java/org/jpos/core/SubConfigurationTest.java
@@ -27,6 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 public class SubConfigurationTest {
@@ -43,6 +45,18 @@ public class SubConfigurationTest {
         SubConfiguration subConfiguration = new SubConfiguration(cfg, "testSubConfigurationPrefix");
         assertSame(cfg, subConfiguration.cfg, "subConfiguration.cfg");
         assertEquals("testSubConfigurationPrefix", subConfiguration.prefix, "subConfiguration.prefix");
+    }
+
+    @Test
+    public void testKeySetUsesSubConfigurationNamespace() {
+        Configuration cfg = new SimpleConfiguration();
+        cfg.put("switch.mode", "prefix");
+        cfg.put("switch.100", "generic");
+        cfg.put("other", "ignored");
+
+        SubConfiguration subConfiguration = new SubConfiguration(cfg, "switch.");
+
+        assertEquals(Set.of("mode", "100"), subConfiguration.keySet());
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/transaction/participant/SwitchTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/participant/SwitchTest.java
@@ -20,6 +20,7 @@ package org.jpos.transaction.participant;
 
 import org.jpos.core.Configuration;
 import org.jpos.core.SimpleConfiguration;
+import org.jpos.core.SubConfiguration;
 import org.jpos.transaction.Context;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -175,6 +176,17 @@ public class SwitchTest {
 
         System.setProperty(GROUP_PROPERTY, "updated-group");
         assertEquals("updated-group", select("100.30"));
+    }
+
+    @Test
+    public void testPrefixModeWorksWithSubConfiguration() {
+        Configuration parent = new SimpleConfiguration();
+        parent.put("switch.mode", "prefix");
+        parent.put("switch.100", "generic");
+        parent.put("switch.unknown", UNKNOWN_GROUP);
+        selector.setConfiguration(new SubConfiguration(parent, "switch."));
+
+        assertEquals("generic", select("100.30"));
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/transaction/participant/SwitchTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/participant/SwitchTest.java
@@ -1,0 +1,248 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.transaction.participant;
+
+import org.jpos.core.Configuration;
+import org.jpos.core.SimpleConfiguration;
+import org.jpos.transaction.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.jpos.transaction.ContextConstants.TXNNAME;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SwitchTest {
+    private static final String UNKNOWN_GROUP = "unknown-group";
+    private static final String GROUP_PROPERTY = "org.jpos.transaction.participant.SwitchTest.group";
+
+    private Switch selector;
+    private Configuration cfg;
+    private String previousGroupProperty;
+
+    @BeforeEach
+    public void setUp() {
+        previousGroupProperty = System.getProperty(GROUP_PROPERTY);
+        selector = new Switch();
+        cfg = configuration();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        restoreSystemProperty(GROUP_PROPERTY, previousGroupProperty);
+    }
+
+    @Test
+    public void testSelectExactMatchInDefaultStrictMode() {
+        cfg.put("100.30", "balance-inquiry");
+        selector.setConfiguration(cfg);
+
+        assertEquals("balance-inquiry", select("100.30"));
+    }
+
+    @Test
+    public void testDefaultStrictModeDoesNotUsePrefix() {
+        cfg.put("100.30", "balance-inquiry");
+        selector.setConfiguration(cfg);
+
+        assertEquals(UNKNOWN_GROUP, select("100.30.182"));
+    }
+
+    @Test
+    public void testExplicitStrictModeDoesNotUsePrefix() {
+        cfg.put("mode", "strict");
+        cfg.put("100.30", "balance-inquiry");
+        selector.setConfiguration(cfg);
+
+        assertEquals(UNKNOWN_GROUP, select("100.30.182"));
+    }
+
+    @Test
+    public void testExactMatchTakesPrecedenceInPrefixMode() {
+        cfg.put("mode", "prefix");
+        cfg.put("100", "generic");
+        cfg.put("100.30", "balance-inquiry");
+        selector.setConfiguration(cfg);
+
+        assertEquals("balance-inquiry", select("100.30"));
+    }
+
+    @Test
+    public void testExactEmptyGroupDoesNotFallBack() {
+        cfg.put("mode", "prefix");
+        cfg.put("100", "generic");
+        cfg.put("100.30", "");
+        selector.setConfiguration(cfg);
+
+        assertEquals("", select("100.30"));
+    }
+
+    @Test
+    public void testLongestPrefixTakesPrecedence() {
+        cfg.put("mode", "prefix");
+        cfg.put("100.30", "specific");
+        cfg.put("100", "generic");
+        cfg.put("100.30.182", "most-specific");
+        selector.setConfiguration(cfg);
+
+        assertEquals("most-specific", select("100.30.182.001"));
+    }
+
+    @Test
+    public void testFallsBackToShorterMatchingPrefix() {
+        cfg.put("mode", "prefix");
+        cfg.put("100.30", "specific");
+        cfg.put("100", "generic");
+        selector.setConfiguration(cfg);
+
+        assertEquals("generic", select("100.20.001"));
+    }
+
+    @Test
+    public void testPrefixMustStartTheTransactionName() {
+        cfg.put("mode", "prefix");
+        cfg.put("00.30", "substring");
+        cfg.put("100.30.182", "more-specific-than-type");
+        selector.setConfiguration(cfg);
+
+        assertAll(
+          () -> assertEquals(UNKNOWN_GROUP, select("100.30.001")),
+          () -> assertEquals(UNKNOWN_GROUP, select("100.30"))
+        );
+    }
+
+    @Test
+    public void testUnknownGroupForMissingOrUnmatchedTransactionName() {
+        cfg.put("mode", "prefix");
+        cfg.put("100", "generic");
+        selector.setConfiguration(cfg);
+
+        assertAll(
+          () -> assertEquals(UNKNOWN_GROUP, select(null)),
+          () -> assertEquals(UNKNOWN_GROUP, select("200.30"))
+        );
+    }
+
+    @Test
+    public void testUnknownDefaultsToEmptyGroup() {
+        cfg = new SimpleConfiguration();
+        cfg.put("mode", "prefix");
+        cfg.put("100", "generic");
+        selector.setConfiguration(cfg);
+
+        assertEquals("", select("200.30"));
+    }
+
+    @Test
+    public void testConfiguredContextEntry() {
+        cfg.put("mode", "prefix");
+        cfg.put("txnname", "MY_TXNNAME");
+        cfg.put("100.30", "balance-inquiry");
+        selector.setConfiguration(cfg);
+
+        Context ctx = new Context();
+        ctx.put(TXNNAME.toString(), "does-not-match");
+        ctx.put("MY_TXNNAME", "100.30.182");
+
+        assertEquals("balance-inquiry", selector.select(1L, ctx));
+    }
+
+    @Test
+    public void testPrefixValueIsResolvedAtSelectionTime() {
+        System.setProperty(GROUP_PROPERTY, "original-group");
+        cfg.put("mode", "prefix");
+        cfg.put("100", "$sys{" + GROUP_PROPERTY + "}");
+        selector.setConfiguration(cfg);
+
+        assertEquals("original-group", select("100.30"));
+
+        System.setProperty(GROUP_PROPERTY, "updated-group");
+        assertEquals("updated-group", select("100.30"));
+    }
+
+    @Test
+    public void testSetConfigurationReplacesConfiguration() {
+        cfg.put("mode", "prefix");
+        cfg.put("100", "old-group");
+        selector.setConfiguration(cfg);
+
+        Configuration newCfg = configuration();
+        newCfg.put("mode", "prefix");
+        newCfg.put("200", "new-group");
+        selector.setConfiguration(newCfg);
+
+        assertAll(
+          () -> assertEquals("new-group", select("200.30")),
+          () -> assertEquals(UNKNOWN_GROUP, select("100.30"))
+        );
+    }
+
+    @Test
+    public void testSetConfigurationDisablesPrefixMode() {
+        cfg.put("mode", "prefix");
+        cfg.put("100", "old-group");
+        selector.setConfiguration(cfg);
+
+        Configuration strictCfg = configuration();
+        strictCfg.put("100", "strict-group");
+        selector.setConfiguration(strictCfg);
+
+        assertAll(
+          () -> assertEquals("strict-group", select("100")),
+          () -> assertEquals(UNKNOWN_GROUP, select("100.30"))
+        );
+    }
+
+    @Test
+    public void testSelectorPropertiesAreNotPrefixRoutes() {
+        cfg.put("mode", "prefix");
+        selector.setConfiguration(cfg);
+
+        assertAll(
+          () -> assertEquals(UNKNOWN_GROUP, select("mode.suffix")),
+          () -> assertEquals(UNKNOWN_GROUP, select("txnname.suffix"))
+        );
+    }
+
+    @Test
+    public void testPrepareIsReadOnlyAndDoesNotJoin() {
+        assertEquals(Switch.PREPARED | Switch.READONLY | Switch.NO_JOIN, selector.prepare(1L, new Context()));
+    }
+
+    private Configuration configuration() {
+        Configuration configuration = new SimpleConfiguration();
+        configuration.put("unknown", UNKNOWN_GROUP);
+        return configuration;
+    }
+
+    private String select(String txnName) {
+        Context ctx = new Context();
+        if (txnName != null)
+            ctx.put(TXNNAME.toString(), txnName);
+        return selector.select(1L, ctx);
+    }
+
+    private void restoreSystemProperty(String name, String value) {
+        if (value != null)
+            System.setProperty(name, value);
+        else
+            System.clearProperty(name);
+    }
+}


### PR DESCRIPTION
This PR extends `Switch` with **optional** prefix-based routing while preserving the existing strict behavior by default. Prefix matching is enabled only when configured with `mode=prefix`.

### How it works

In **prefix** mode, `Switch` first attempts the traditional **exact** (strict) lookup. If no exact match exists, it checks the configured routing keys **from longest to shortest**, giving the most specific (i.e., longest) prefix priority.

For efficiency, the configured `<property>` keys are **sorted once** during configuration in a cached list, while group values continue to be retrieved from the `Configuration` at selection time.

### Test and docs
* A thorough `SwitchTest` is provided (one did not exist before).
* The documentation in the proguide has been updated.

**OBSERVATIONS:**

* The pre-sorting caching mechanism **could break under property reconfiguration** (only if changing the key set) after the initial instantiation and configuration of the participant. But this is a very unusual situation, and probably bad practice.

* **Only the key set** is pre-sorted. The values themselves are still retrieved from `cfg` every time (as it was before) because that allows the value to be resolved dynamically each time if they use some jPOS Environment expression or jPOS Environment Provider string. 

### Configuration example

```xml
<participant class="org.jpos.transaction.participant.Switch"
             logger="Q2" realm="Switch">
    <property name="mode" value="prefix" />

    <property name="100"
              value="generic" />
    <property name="100.30"
              value="balance-inquiry" />
    <property name="100.30.182"
              value="customer-balance-inquiry" />

    <property name="unknown"
              value="unsupported" />
</participant>

