### PR TITLE
docs: document Switch constructor

### DIFF
--- a/jpos/src/main/java/org/jpos/transaction/participant/Switch.java
+++ b/jpos/src/main/java/org/jpos/transaction/participant/Switch.java
@@ -40,12 +40,12 @@ public class Switch implements Configurable, GroupSelector {
     private static final String PREFIX_MODE = "prefix";
     private static final Set<String> SELECTOR_PROPERTIES = Set.of("mode", "txnname", "unknown");
 
-    /** Creates the selector; configuration is supplied via {@link #setConfiguration(Configuration)}. */
     private Configuration cfg;
     private String txnNameEntry;
     private boolean prefixMode;
     private List<String> sortedRoutingKeys = List.of();   // kept sorted from longest to shortest
 
+    /** Creates the selector; configuration is supplied via {@link #setConfiguration(Configuration)}. */
     public Switch() {}
 
     public String select (long id, Serializable ser) {


### PR DESCRIPTION
Moves the existing selector-construction Javadoc from the configuration field to the Switch constructor, making the Javadoc task warning-free.