### PR TITLE
Add CMF DE 113.72 and 113.73 packager fields

### DIFF
--- a/jpos/src/main/resources/packager/cmf.xml
+++ b/jpos/src/main/resources/packager/cmf.xml
@@ -1098,6 +1098,16 @@
           length="19"
           name="Transaction GroupID"
           class="org.jpos.iso.IFB_NUMERIC" />
+      <isofield
+          id="72"
+          length="1"
+          name="Crypto Card Indicator"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
+          id="73"
+          length="999"
+          name="Age Verification Data"
+          class="org.jpos.iso.IFB_LLLCHAR" />
   </isofieldpackager>
   <isofield
       id="114"

--- a/jpos/src/main/resources/packager/cmfv3.xml
+++ b/jpos/src/main/resources/packager/cmfv3.xml
@@ -1209,6 +1209,16 @@
           length="19"
           name="Transaction Group ID"
           class="org.jpos.iso.IFB_LLNUM" />
+      <isofield
+          id="72"
+          length="1"
+          name="Crypto Card Indicator"
+          class="org.jpos.iso.IF_CHAR" />
+      <isofield
+          id="73"
+          length="999"
+          name="Age Verification Data"
+          class="org.jpos.iso.IFB_LLLCHAR" />
   </isofieldpackager>
   <isofield
       id="114"

--- a/jpos/src/test/java/org/jpos/iso/TPPDataElementsTest.java
+++ b/jpos/src/test/java/org/jpos/iso/TPPDataElementsTest.java
@@ -67,4 +67,32 @@ public class TPPDataElementsTest {
 
         assertEquals("Y", unpacked.getString("113.34"));
     }
+
+    @Test
+    public void testCryptoCardIndicator() throws ISOException {
+        assertPackUnpackPreservesFieldValue("jar:packager/cmf.xml", "113.72", "C");
+        assertPackUnpackPreservesFieldValue("jar:packager/cmfv3.xml", "113.72", "C");
+    }
+
+    @Test
+    public void testAgeVerificationData() throws ISOException {
+        String value = "00100321D00200318D"; // two TLV records: tag 001, len 003, value 21D; tag 002, len 003, value 18D
+        assertPackUnpackPreservesFieldValue("jar:packager/cmf.xml", "113.73", value);
+        assertPackUnpackPreservesFieldValue("jar:packager/cmfv3.xml", "113.73", value);
+    }
+
+    private void assertPackUnpackPreservesFieldValue(String packagerResource, String fieldPath, String value) throws ISOException {
+        ISOPackager p = new GenericPackager(packagerResource);
+        ISOMsg m = new ISOMsg("2100");
+        m.setPackager(p);
+        m.set(fieldPath, value);
+
+        byte[] packed = m.pack();
+
+        ISOMsg unpacked = new ISOMsg();
+        unpacked.setPackager(p);
+        unpacked.unpack(packed);
+
+        assertEquals(value, unpacked.getString(fieldPath));
+    }
 }


### PR DESCRIPTION
## Summary
- add DE 113.72 Crypto Card Indicator (`ANS1`, `IF_CHAR`) to `cmf.xml`
- add DE 113.73 Age Verification Data (`ANS..999`, `LLLVAR`, `IFB_LLLCHAR`) to `cmf.xml`
- add the same subfields to `cmfv3.xml`
- cover the new subfields with CMF/CMFv3 pack/unpack tests

## Verification
- `xmllint --noout jpos/src/main/resources/packager/cmf.xml jpos/src/main/resources/packager/cmfv3.xml`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/26.0.1-amzn ./gradlew :jpos:test --tests org.jpos.iso.TPPDataElementsTest`