### PR TITLE
context: suppress inhibited keys in logs

### DIFF
--- a/jpos/src/main/java/org/jpos/transaction/Context.java
+++ b/jpos/src/main/java/org/jpos/transaction/Context.java
@@ -60,7 +60,7 @@ public class Context implements Externalizable, Loggeable, Cloneable, Pausable, 
      * @param value the value to store
      */
     public void put (Object key, Object value) {
-        if (trace) {
+        if (trace && !(key instanceof Inhibit)) {
             getProfiler().checkPoint(
                 String.format("%s='%s' [%s]", getKeyName(key), value, Caller.info(1))
             );
@@ -77,7 +77,7 @@ public class Context implements Externalizable, Loggeable, Cloneable, Pausable, 
      * @param persist true to also store in the persistent map
      */
     public void put (Object key, Object value, boolean persist) {
-        if (trace) {
+        if (trace && !(key instanceof Inhibit)) {
             getProfiler().checkPoint(
                 String.format("%s(P)='%s' [%s]", getKeyName(key), value, Caller.info(1))
             );
@@ -316,7 +316,7 @@ public class Context implements Externalizable, Loggeable, Cloneable, Pausable, 
         Map<String, Object> out = new LinkedHashMap<>();
         getMapClone().forEach((k, v) -> {
             String key = getKeyName(k);
-            if (key.startsWith(".") || key.startsWith("*"))
+            if (k instanceof Inhibit || key.startsWith(".") || key.startsWith("*"))
                 return;
             out.put(key, convertEntry(v));
         });
@@ -571,7 +571,7 @@ public class Context implements Externalizable, Loggeable, Cloneable, Pausable, 
      */
     protected void dumpEntry (PrintStream p, String indent, Map.Entry<Object,Object> entry) {
         String key = getKeyName(entry.getKey());
-        if (key.startsWith(".") || key.startsWith("*"))
+        if (entry.getKey() instanceof Inhibit || key.startsWith(".") || key.startsWith("*"))
             return; // see jPOS-63
 
         p.printf("%s%s%s: ", indent, key, pmap != null && pmap.containsKey(key) ? "(P)" : "");

--- a/jpos/src/main/java/org/jpos/util/Inhibit.java
+++ b/jpos/src/main/java/org/jpos/util/Inhibit.java
@@ -1,0 +1,25 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.util;
+
+/**
+ * Marks a Context key whose value must not be rendered by Context logging.
+ */
+public interface Inhibit {
+}

--- a/jpos/src/test/java/org/jpos/transaction/ContextTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/ContextTest.java
@@ -46,12 +46,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jpos.log.AuditLogEvent;
 import org.jpos.log.AuditLogEventRegistry;
 import org.jpos.log.evt.ContextEvt;
+import org.jpos.util.Inhibit;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Profiler;
 import org.jpos.util.Serializer;
 import org.junit.jupiter.api.Test;
 
 public class ContextTest {
+    private enum HiddenKey implements Inhibit {
+        SECRET
+    }
 
     @Test
     public void testCheckPoint() throws Throwable {
@@ -478,5 +482,23 @@ public class ContextTest {
         Object converted = evt.entries().get("PROFILER");
         assertTrue(converted instanceof AuditLogEvent,
             "Profiler should expand to nested AuditLogEvent (got " + converted + ")");
+    }
+
+    @Test
+    public void inhibitsSensitiveContextKeysFromLogs() {
+        Context ctx = new Context();
+        ctx.setTrace(true);
+        ctx.put(HiddenKey.SECRET, "do-not-log");
+        ctx.put("visible", "safe");
+        assertEquals("do-not-log", ctx.get(HiddenKey.SECRET));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ctx.dump(new PrintStream(out), "");
+        ctx.getProfiler().dump(new PrintStream(out), "");
+        String rendered = out.toString();
+
+        assertFalse(rendered.contains("do-not-log"));
+        assertTrue(rendered.contains("safe"));
+        assertFalse(((ContextEvt) ctx.toAuditEvent()).entries().containsValue("do-not-log"));
     }
 }


### PR DESCRIPTION
Adds `org.jpos.util.Inhibit`, a marker for Context keys whose values must not be rendered.

`Context` now excludes inhibited keys from trace checkpoints, XML/text dumps, and structured audit events while preserving normal programmatic access.

Tests:
- `./gradlew :jpos:test --tests org.jpos.transaction.ContextTest`