### PR TITLE
Fix Prometheus scrape allocations and bound JFR recording

### DIFF
--- a/jpos/src/main/java/org/jpos/metrics/PrometheusService.java
+++ b/jpos/src/main/java/org/jpos/metrics/PrometheusService.java
@@ -27,6 +27,7 @@ import org.jpos.q2.QBeanSupport;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 
 /**
  * QBean that exposes the Q2 Prometheus meter registry over an embedded HTTP
@@ -49,20 +50,20 @@ public class PrometheusService extends QBeanSupport {
             final var registry =  getServer().getPrometheusMeterRegistry();
             server = HttpServer.create(new InetSocketAddress(port), 0);
             server.createContext(path, httpExchange -> {
-                String response = registry.scrape();
                 httpExchange.getResponseHeaders().add("Content-Type", "text/plain; version=0.0.4");
-                httpExchange.sendResponseHeaders(200, response.getBytes().length);
+                httpExchange.sendResponseHeaders(200, 0);
                 try (OutputStream os = httpExchange.getResponseBody()) {
-                    os.write(response.getBytes());
+                    registry.scrape(os);
                 }
             });
             if (statusPath != null) {
                 server.createContext(statusPath, httpExchange -> {
-                    String response = getServer().running() ? "running\n" : "stopping\n";
+                    byte[] response = (getServer().running() ? "running\n" : "stopping\n")
+                      .getBytes(StandardCharsets.UTF_8);
                     httpExchange.getResponseHeaders().add("Content-Type", "text/plain");
-                    httpExchange.sendResponseHeaders(200, response.getBytes().length);
+                    httpExchange.sendResponseHeaders(200, response.length);
                     try (OutputStream os = httpExchange.getResponseBody()) {
-                        os.write(response.getBytes());
+                        os.write(response);
                     }
                 });
             }

--- a/jpos/src/main/java/org/jpos/q2/Q2.java
+++ b/jpos/src/main/java/org/jpos/q2/Q2.java
@@ -1678,6 +1678,8 @@ public class Q2 implements FileFilter, Runnable {
         try {
             if (!disableJFR) {
                 recording = new Recording(Configuration.getConfiguration("default"));
+                recording.setMaxSize(250L * 1024 * 1024);
+                recording.setMaxAge(Duration.ofHours(4));
                 recording.start();
             }
         } catch (IOException | ParseException e) {
@@ -1700,7 +1702,9 @@ public class Q2 implements FileFilter, Runnable {
             @Override
             public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
                 if (id.getName().equals(MeterInfo.TM_OPERATION.id())) {
-                    return DistributionStatisticConfig.builder().serviceLevelObjectives(
+                    return DistributionStatisticConfig.builder()
+                      .percentilesHistogram(false)
+                      .serviceLevelObjectives(
                         Duration.ofMillis(10).toNanos(),
                         Duration.ofMillis(100).toNanos(),
                         Duration.ofMillis(500).toNanos(),

--- a/jpos/src/test/java/org/jpos/q2/Q2Test.java
+++ b/jpos/src/test/java/org/jpos/q2/Q2Test.java
@@ -30,14 +30,18 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
+import java.time.Duration;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 
+import io.micrometer.core.instrument.Tags;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jpos.core.Environment;
+import org.jpos.metrics.MeterFactory;
+import org.jpos.metrics.MeterInfo;
 import org.jpos.q2.qbean.SystemMonitor;
 import org.jpos.util.Log;
 import org.jpos.util.Realm;
@@ -93,6 +97,19 @@ public class Q2Test {
     public void testConstructor() throws Throwable {
         assertEquals("deploy", m_q2.getDeployDir().getName(), "m_q2.getDeployDir().getName()");
         assertSame(m_args, m_q2.getCommandLineArgs(), "m_q2.getCommandLineArgs()");
+    }
+
+    @Test
+    public void testTMOperationHistogramUsesOnlyServiceLevelObjectives() {
+        var timer = MeterFactory.timer(
+          m_q2.getMeterRegistry(), MeterInfo.TM_OPERATION, Tags.of("test", "q2-histogram")
+        );
+        timer.record(Duration.ofMillis(50));
+
+        long buckets = m_q2.getPrometheusMeterRegistry().scrape().lines()
+          .filter(line -> line.startsWith("jpos_tm_op_seconds_bucket{") && line.contains("test=\"q2-histogram\""))
+          .count();
+        assertEquals(7, buckets, "six configured SLO buckets plus +Inf");
     }
 
     @Test

--- a/jpos/src/test/java/org/jpos/q2/Q2Test.java
+++ b/jpos/src/test/java/org/jpos/q2/Q2Test.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.UUID;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectInstance;
@@ -101,15 +102,21 @@ public class Q2Test {
 
     @Test
     public void testTMOperationHistogramUsesOnlyServiceLevelObjectives() {
+        String testId = UUID.randomUUID().toString();
+        var registry = m_q2.getMeterRegistry();
         var timer = MeterFactory.timer(
-          m_q2.getMeterRegistry(), MeterInfo.TM_OPERATION, Tags.of("test", "q2-histogram")
+          registry, MeterInfo.TM_OPERATION, Tags.of("test", testId)
         );
-        timer.record(Duration.ofMillis(50));
+        try {
+            timer.record(Duration.ofMillis(50));
 
-        long buckets = m_q2.getPrometheusMeterRegistry().scrape().lines()
-          .filter(line -> line.startsWith("jpos_tm_op_seconds_bucket{") && line.contains("test=\"q2-histogram\""))
-          .count();
-        assertEquals(7, buckets, "six configured SLO buckets plus +Inf");
+            long buckets = m_q2.getPrometheusMeterRegistry().scrape().lines()
+              .filter(line -> line.startsWith("jpos_tm_op_seconds_bucket{") && line.contains("test=\"" + testId + "\""))
+              .count();
+            assertEquals(7, buckets, "six configured SLO buckets plus +Inf");
+        } finally {
+            registry.remove(timer);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What Problem This Solves

Idle Q2 instances can accumulate humongous Prometheus scrape allocations in Old Gen, expose an oversized TM operation histogram, and let the always-on JFR repository grow without bounds.

## Why This Change Was Made

- stream Prometheus exposition directly to the HTTP response using chunked transfer encoding instead of building and copying a large `String`
- disable Micrometer's automatic percentile histogram for `jpos.tm.op`, retaining the six explicit SLO buckets
- cap the default JFR recording at 250 MiB and four hours
- encode the small status response once with UTF-8

## User Impact

Prometheus scrapes no longer create repeated full-payload byte arrays, TM-bearing instances expose a substantially smaller metrics document, and Q2's default JFR repository remains bounded during long uptimes.

## Evidence

- `./gradlew :jpos:test --tests org.jpos.q2.Q2Test --no-daemon`
- `./gradlew :jpos:test --no-daemon`
- regression test verifies that TM operation timers expose only the six configured SLO buckets plus `+Inf`

Fixes jpos/jPOS#755
