### PR TITLE
Fix revision metadata in Git worktrees

### DIFF
--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -196,9 +196,26 @@ class GitRevisionTask extends DefaultTask
     boolean gotHead
 
     @InputFile @Optional
+    File commonDirFile
+
+    @InputFile @Optional
     File getRefFile() {
-        File rf = new File(gitHead.parent,gitHead.text.replace('ref: ', '').trim())
-        return rf.exists() ? rf : gitHead
+        if (gitHead == null)
+            return null
+
+        String head = gitHead.getText('UTF-8').trim()
+        if (!head.startsWith('ref: '))
+            return null
+
+        File gitDir = gitHead.parentFile
+        File commonDir = gitDir
+        if (commonDirFile != null) {
+            File pointedCommonDir = new File(commonDirFile.getText('UTF-8').trim())
+            commonDir = (pointedCommonDir.isAbsolute() ? pointedCommonDir :
+              new File(gitDir, pointedCommonDir.path)).canonicalFile
+        }
+        File rf = new File(commonDir, head.substring('ref: '.length()).trim())
+        return rf.isFile() ? rf : null
     }
 
     @OutputFile
@@ -210,7 +227,7 @@ class GitRevisionTask extends DefaultTask
         Properties props=new Properties()
         if (gotHead) {
             File ref=getRefFile()
-            if (ref != null && ref.exists()) {
+            if (ref != null) {
                 props.put("branch",ref.getName())
                 props.put("revision",ref.text.substring(0,7))
             } else {
@@ -243,10 +260,23 @@ class BuildTimestampTask extends DefaultTask {
 }
 
 task createRevisionPropertyFile(type: GitRevisionTask) {
-    gitHead = "$rootDir/.git/HEAD" as File
-    gotHead = gitHead.exists()
-    if (!gotHead)
-        gitHead = null;
+    File dotGit = "$rootDir/.git" as File
+    File gitDir = dotGit.isDirectory() ? dotGit : null
+    if (gitDir == null && dotGit.isFile()) {
+        String pointer = dotGit.getText('UTF-8').trim()
+        if (pointer.startsWith('gitdir:')) {
+            File pointedGitDir = new File(pointer.substring('gitdir:'.length()).trim())
+            gitDir = (pointedGitDir.isAbsolute() ? pointedGitDir :
+              new File(dotGit.parentFile, pointedGitDir.path)).canonicalFile
+        }
+    }
+
+    File head = gitDir != null ? new File(gitDir, 'HEAD') : null
+    gitHead = head != null && head.isFile() ? head : null
+    gotHead = gitHead != null
+
+    File commonDir = gitDir != null ? new File(gitDir, 'commondir') : null
+    commonDirFile = commonDir != null && commonDir.isFile() ? commonDir : null
     outputFile = "$sourceSets.main.output.resourcesDir/org/jpos/q2/revision.properties" as File
 }
 


### PR DESCRIPTION
## What Problem This Solves

Any Gradle build invoked from a linked Git worktree fails during task input fingerprinting because the revision task assumes `.git` is a directory and dereferences a missing `.git/HEAD`.

## Why This Change Was Made

- resolve `.git` when it is either a directory or a worktree `gitdir:` pointer
- resolve symbolic branch refs through the worktree's `commondir`
- make the optional ref input null-safe
- preserve detached-HEAD metadata and the existing `unknown/unknown` fallback for exported source

This uses Git's metadata files directly, without requiring the `git` executable or adding a dependency.

## User Impact

jPOS can be built normally from linked Git worktrees, and generated `revision.properties` contains the correct branch/revision metadata. Builds from source exports without `.git` continue to work with unknown revision metadata.

## Evidence

- `./gradlew :jpos:compileJava --no-daemon` from a linked worktree
- `./gradlew jpos:check --no-daemon`
- verified `createRevisionPropertyFile` in an ordinary checkout, a branch worktree, a detached worktree, and a source export without `.git`

Fixes jpos/jPOS#757
