### PR TITLE
Registered Kind vocabulary with family projection and type-implied kinds

### DIFF
--- a/jpos/src/main/java/org/jpos/log/AuditLogEventProvider.java
+++ b/jpos/src/main/java/org/jpos/log/AuditLogEventProvider.java
@@ -18,10 +18,14 @@
 
 package org.jpos.log;
 
+import org.jpos.util.Kind;
+
 import java.util.Collection;
+import java.util.List;
 
 /**
- * SPI for contributing additional {@link AuditLogEvent} implementations.
+ * SPI for contributing additional {@link AuditLogEvent} implementations and
+ * {@link Kind} registrations.
  *
  * <p>External modules register their event classes by declaring an implementation in
  * {@code META-INF/services/org.jpos.log.AuditLogEventProvider}; the
@@ -43,4 +47,19 @@ public interface AuditLogEventProvider {
      * @return the type mappings contributed by this provider; must not be {@code null}.
      */
     Collection<AuditLogEventType> types();
+
+    /**
+     * Returns the kinds contributed by this provider that have no typed
+     * payload of their own. Kinds implied by {@link #types()} need not be
+     * listed here unless they are new; a kind implied by a type must be
+     * registered by core or by some provider's {@code kinds()}.
+     *
+     * <p>Registering a kind already known with a different family is an
+     * error. Prefer an existing kind, and an existing family, over new ones.</p>
+     *
+     * @return kind definitions; never {@code null}
+     */
+    default Collection<Kind.Def> kinds() {
+        return List.of();
+    }
 }

--- a/jpos/src/main/java/org/jpos/log/AuditLogEventRegistry.java
+++ b/jpos/src/main/java/org/jpos/log/AuditLogEventRegistry.java
@@ -41,6 +41,7 @@ import org.jpos.log.evt.TraceEvt;
 import org.jpos.log.evt.Txn;
 import org.jpos.log.evt.UnDeploy;
 import org.jpos.log.evt.Warning;
+import org.jpos.util.Kind;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -66,30 +67,33 @@ import java.util.ServiceLoader;
  */
 public final class AuditLogEventRegistry {
     private static final List<AuditLogEventType> BUILTINS = List.of(
-      new AuditLogEventType("warn", Warning.class),
-      new AuditLogEventType("start", Start.class),
-      new AuditLogEventType("stop", Stop.class),
-      new AuditLogEventType("deploy", Deploy.class),
-      new AuditLogEventType("undeploy", UnDeploy.class),
-      new AuditLogEventType("msg", LogMessage.class),
-      new AuditLogEventType("shutdown", Shutdown.class),
-      new AuditLogEventType("deploy-activity", DeployActivity.class),
-      new AuditLogEventType("throwable", ThrowableAuditLogEvent.class),
-      new AuditLogEventType("license", License.class),
-      new AuditLogEventType("sysinfo", SysInfo.class),
-      new AuditLogEventType("connect", Connect.class),
-      new AuditLogEventType("disconnect", Disconnect.class),
-      new AuditLogEventType("listen", Listen.class),
-      new AuditLogEventType("session-start", SessionStart.class),
-      new AuditLogEventType("session-end", SessionEnd.class),
-      new AuditLogEventType("txn", Txn.class),
+      new AuditLogEventType("warn", Warning.class, Kind.WARN),
+      new AuditLogEventType("start", Start.class, Kind.LIFECYCLE),
+      new AuditLogEventType("stop", Stop.class, Kind.LIFECYCLE),
+      new AuditLogEventType("deploy", Deploy.class, Kind.DEPLOY),
+      new AuditLogEventType("undeploy", UnDeploy.class, Kind.DEPLOY),
+      new AuditLogEventType("msg", LogMessage.class, Kind.INFO),
+      new AuditLogEventType("shutdown", Shutdown.class, Kind.LIFECYCLE),
+      new AuditLogEventType("deploy-activity", DeployActivity.class, Kind.DEPLOY),
+      new AuditLogEventType("throwable", ThrowableAuditLogEvent.class, Kind.ERROR),
+      new AuditLogEventType("license", License.class, Kind.LIFECYCLE),
+      new AuditLogEventType("sysinfo", SysInfo.class, Kind.STATUS),
+      new AuditLogEventType("connect", Connect.class, Kind.ISO_SESSION),
+      new AuditLogEventType("disconnect", Disconnect.class, Kind.ISO_SESSION),
+      new AuditLogEventType("listen", Listen.class, Kind.ISO_SESSION),
+      new AuditLogEventType("session-start", SessionStart.class, Kind.ISO_SESSION),
+      new AuditLogEventType("session-end", SessionEnd.class, Kind.ISO_SESSION),
+      new AuditLogEventType("txn", Txn.class, Kind.TXN),
+      // secondary payloads: ride along inside another event, imply no kind
       new AuditLogEventType("profiler", ProfilerEvt.class),
       new AuditLogEventType("context", ContextEvt.class),
-      new AuditLogEventType("logevt", LogEventEvt.class),
+      new AuditLogEventType("logevt", LogEventEvt.class, Kind.INFO),
       new AuditLogEventType("trace", TraceEvt.class)
     );
 
-    private static volatile Map<String, AuditLogEventType> types;
+    private record Snapshot(Map<String, AuditLogEventType> byName, Map<Class<?>, AuditLogEventType> byClass) { }
+
+    private static volatile Snapshot snapshot;
 
     private AuditLogEventRegistry() { }
 
@@ -99,7 +103,27 @@ public final class AuditLogEventRegistry {
      * @return all known type mappings, built-ins first, then ServiceLoader-discovered.
      */
     public static Collection<AuditLogEventType> types() {
-        return load().values();
+        return load().byName().values();
+    }
+
+    /**
+     * Looks up a registered type by its discriminator id.
+     *
+     * @param name the {@code t} value
+     * @return the type, or {@code null} when unknown
+     */
+    public static AuditLogEventType typeOf(String name) {
+        return name == null ? null : load().byName().get(name);
+    }
+
+    /**
+     * Looks up a registered type by its implementation class.
+     *
+     * @param clazz the {@link AuditLogEvent} implementation
+     * @return the type, or {@code null} when unknown
+     */
+    public static AuditLogEventType typeOf(Class<?> clazz) {
+        return clazz == null ? null : load().byClass().get(clazz);
     }
 
     /**
@@ -113,7 +137,7 @@ public final class AuditLogEventRegistry {
      * @return the same mapper for chaining
      */
     public static <M extends ObjectMapper> M register(M mapper) {
-        for (AuditLogEventType t : load().values()) {
+        for (AuditLogEventType t : types()) {
             mapper.registerSubtypes(new NamedType(t.clazz(), t.name()));
         }
         return mapper;
@@ -125,17 +149,17 @@ public final class AuditLogEventRegistry {
      * fixed for the lifetime of the JVM.
      */
     static synchronized void reload() {
-        types = null;
+        snapshot = null;
         load();
     }
 
-    private static Map<String, AuditLogEventType> load() {
-        Map<String, AuditLogEventType> snapshot = types;
-        if (snapshot != null)
-            return snapshot;
+    private static Snapshot load() {
+        Snapshot s = snapshot;
+        if (s != null)
+            return s;
         synchronized (AuditLogEventRegistry.class) {
-            if (types != null)
-                return types;
+            if (snapshot != null)
+                return snapshot;
             Map<String, AuditLogEventType> map = new LinkedHashMap<>();
             for (AuditLogEventType t : BUILTINS)
                 map.put(t.name(), t);
@@ -154,8 +178,11 @@ public final class AuditLogEventRegistry {
                     map.put(t.name(), t);
                 }
             }
-            types = Collections.unmodifiableMap(map);
-            return types;
+            Map<Class<?>, AuditLogEventType> byClass = new LinkedHashMap<>();
+            for (AuditLogEventType t : map.values())
+                byClass.put(t.clazz(), t);
+            snapshot = new Snapshot(Collections.unmodifiableMap(map), Collections.unmodifiableMap(byClass));
+            return snapshot;
         }
     }
 }

--- a/jpos/src/main/java/org/jpos/log/AuditLogEventType.java
+++ b/jpos/src/main/java/org/jpos/log/AuditLogEventType.java
@@ -18,31 +18,54 @@
 
 package org.jpos.log;
 
+import org.jpos.util.Kind;
+
 import java.util.Objects;
 
 /**
- * Pairs a stable type id with the {@link AuditLogEvent} implementation it identifies.
+ * Pairs a stable type id with the {@link AuditLogEvent} implementation it identifies,
+ * and optionally with the {@link Kind} the type implies.
  *
  * <p>Used by {@link AuditLogEventProvider} implementations and by
  * {@link AuditLogEventRegistry} to register Jackson subtype mappings.</p>
  *
+ * <p>When {@code kind} is set, events created through
+ * {@link org.jpos.util.Log#createEvent(AuditLogEvent)} carry it as their tag.
+ * The kind must be registered (by core or by a provider's
+ * {@link AuditLogEventProvider#kinds()}). Leave it {@code null} for secondary
+ * payloads that ride along inside another event.</p>
+ *
  * @param name  stable type id used as the JSON/XML discriminator value (e.g. {@code "warn"})
  * @param clazz the {@link AuditLogEvent} implementation
+ * @param kind  the kind this type implies, or {@code null}
  *
  * @since 3.0.0
  */
-public record AuditLogEventType(String name, Class<? extends AuditLogEvent> clazz) {
+public record AuditLogEventType(String name, Class<? extends AuditLogEvent> clazz, String kind) {
     /**
      * Validates the record components: {@code name} must be non-null and
-     * non-blank, and {@code clazz} must be non-null.
+     * non-blank, {@code clazz} must be non-null, and {@code kind}, when
+     * present, must be well-formed.
      *
      * @throws NullPointerException     if {@code name} or {@code clazz} is {@code null}
-     * @throws IllegalArgumentException if {@code name} is blank
+     * @throws IllegalArgumentException if {@code name} is blank or {@code kind} is malformed
      */
     public AuditLogEventType {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(clazz, "clazz");
         if (name.isBlank())
             throw new IllegalArgumentException("name must not be blank");
+        if (kind != null && !Kind.isValid(kind))
+            throw new IllegalArgumentException("invalid kind '" + kind + "' for type '" + name + "'");
+    }
+
+    /**
+     * Creates a type that implies no kind.
+     *
+     * @param name  stable type id
+     * @param clazz the {@link AuditLogEvent} implementation
+     */
+    public AuditLogEventType(String name, Class<? extends AuditLogEvent> clazz) {
+        this(name, clazz, null);
     }
 }

--- a/jpos/src/main/java/org/jpos/util/Kind.java
+++ b/jpos/src/main/java/org/jpos/util/Kind.java
@@ -1,0 +1,336 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.util;
+
+import org.jpos.log.AuditLogEvent;
+import org.jpos.log.AuditLogEventProvider;
+import org.jpos.log.AuditLogEventRegistry;
+import org.jpos.log.AuditLogEventType;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Registered log-event kinds and their severity families.
+ *
+ * <p>A {@link LogEvent}'s tag is its <em>kind</em>: what happened. Kinds
+ * sit between two other levels:</p>
+ * <ul>
+ *   <li><b>family</b> — a coarse severity projection ({@link Family}) used
+ *       for row colouring and alerting; every kind maps to exactly one;</li>
+ *   <li><b>type</b> — the {@code t} discriminator of an {@link AuditLogEvent}
+ *       payload, registered through {@link AuditLogEventRegistry}. A type
+ *       may imply a kind; many types share one kind (for example
+ *       {@code connect}, {@code listen} and {@code session-start} all land
+ *       in {@link #ISO_SESSION}).</li>
+ * </ul>
+ *
+ * <p>Core registers only the kinds it emits. jPOS-EE modules and
+ * applications register their own through
+ * {@link AuditLogEventProvider#kinds()} and by declaring the implied kind
+ * in their {@link AuditLogEventType}s. Prefer an existing kind and a new
+ * type over a new kind, and an existing family over a new one: facets and
+ * viewers enumerate these.</p>
+ *
+ * <p>Ad-hoc kinds that are not registered anywhere should be dot-namespaced
+ * ({@code jcard.pin-change}) so log consumers can collapse them by prefix.
+ * Nothing in core rewrites or rejects a tag; validation is the log
+ * consumer's job.</p>
+ *
+ * @since 3.0.0
+ */
+public final class Kind {
+    /** Maximum kind length. */
+    public static final int MAX_LENGTH = 48;
+
+    /** Severity families. Modules may register further ones; keep the set small. */
+    public static final class Family {
+        /** The {@code fail} family. */
+        public static final String FAIL = "fail";
+        /** The {@code warn} family. */
+        public static final String WARN = "warn";
+        /** The {@code commit} family. */
+        public static final String COMMIT = "commit";
+        /** The {@code abort} family. */
+        public static final String ABORT = "abort";
+        /** The {@code transport} family. */
+        public static final String TRANSPORT = "transport";
+        /** The {@code telemetry} family. */
+        public static final String TELEMETRY = "telemetry";
+        /** The {@code security} family. */
+        public static final String SECURITY = "security";
+        /** Family for kinds that are unknown, unregistered or blank. */
+        public static final String NEUTRAL = "neutral";
+
+        private Family() { }
+    }
+
+    /**
+     * A kind registration: name plus family.
+     *
+     * @param name   kind, must satisfy {@link Kind#isValid(String)}
+     * @param family family, lowercase kebab
+     */
+    public record Def(String name, String family) {
+        /** Validates name and family. @throws IllegalArgumentException when either is malformed */
+        public Def {
+            if (!isValid(name))
+                throw new IllegalArgumentException("invalid kind '" + name + "'");
+            if (family == null || !FAMILY_RE.matcher(family).matches())
+                throw new IllegalArgumentException("invalid family '" + family + "' for kind '" + name + "'");
+        }
+    }
+
+    // fail
+    /** The {@code error} kind. */
+    public static final String ERROR = "error";
+    /** The {@code fatal} kind. */
+    public static final String FATAL = "fatal";
+    /** The {@code session-error} kind. */
+    public static final String SESSION_ERROR = "session-error";
+    /** The {@code pack-error} kind. */
+    public static final String PACK_ERROR = "pack-error";
+    /** The {@code unpack-error} kind. */
+    public static final String UNPACK_ERROR = "unpack-error";
+    // warn
+    /** The {@code warn} kind. */
+    public static final String WARN = "warn";
+    /** The {@code session-warning} kind. */
+    public static final String SESSION_WARNING = "session-warning";
+    // commit / abort
+    /** The {@code commit} kind. */
+    public static final String COMMIT = "commit";
+    /** The {@code abort} kind. */
+    public static final String ABORT = "abort";
+    // transport
+    /** The {@code iso-session} kind. */
+    public static final String ISO_SESSION = "iso-session";
+    /** The {@code send} kind. */
+    public static final String SEND = "send";
+    /** The {@code receive} kind. */
+    public static final String RECEIVE = "receive";
+    /** The {@code poll} kind. */
+    public static final String POLL = "poll";
+    /** The {@code usable} kind. */
+    public static final String USABLE = "usable";
+    // telemetry
+    /** The {@code info} kind. */
+    public static final String INFO = "info";
+    /** The {@code debug} kind. */
+    public static final String DEBUG = "debug";
+    /** The {@code trace} kind. */
+    public static final String TRACE = "trace";
+    /** The {@code status} kind. */
+    public static final String STATUS = "status";
+    // security
+    /** The {@code s-m-operation} kind. */
+    public static final String S_M_OPERATION = "s-m-operation";
+    /** The {@code jce-provider} kind. */
+    public static final String JCE_PROVIDER = "jce-provider";
+    /** The {@code local-master-keys} kind. */
+    public static final String LOCAL_MASTER_KEYS = "local-master-keys";
+    /** The {@code get-key} kind. */
+    public static final String GET_KEY = "get-key";
+    /** The {@code set-key} kind. */
+    public static final String SET_KEY = "set-key";
+    // neutral
+    /** The {@code txn} kind. */
+    public static final String TXN = "txn";
+    /** The {@code lifecycle} kind. */
+    public static final String LIFECYCLE = "lifecycle";
+    /** The {@code deploy} kind. */
+    public static final String DEPLOY = "deploy";
+    /** The {@code prepare} kind. */
+    public static final String PREPARE = "prepare";
+    /** The {@code prepare-for-abort} kind. */
+    public static final String PREPARE_FOR_ABORT = "prepare-for-abort";
+    /** The {@code select} kind. */
+    public static final String SELECT = "select";
+    /** The {@code recover} kind. */
+    public static final String RECOVER = "recover";
+    /** The {@code config} kind. */
+    public static final String CONFIG = "config";
+    /** The {@code notify} kind. */
+    public static final String NOTIFY = "notify";
+    /** The {@code pack} kind. */
+    public static final String PACK = "pack";
+    /** The {@code unpack} kind. */
+    public static final String UNPACK = "unpack";
+    /** The {@code validate} kind. */
+    public static final String VALIDATE = "validate";
+
+    private static final Pattern KIND_RE   = Pattern.compile("^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*)*$");
+    private static final Pattern FAMILY_RE = Pattern.compile("^[a-z][a-z0-9-]*$");
+
+    private static final List<Def> BUILTINS = List.of(
+      new Def(ERROR, Family.FAIL),
+      new Def(FATAL, Family.FAIL),
+      new Def(SESSION_ERROR, Family.FAIL),
+      new Def(PACK_ERROR, Family.FAIL),
+      new Def(UNPACK_ERROR, Family.FAIL),
+      new Def(WARN, Family.WARN),
+      new Def(SESSION_WARNING, Family.WARN),
+      new Def(COMMIT, Family.COMMIT),
+      new Def(ABORT, Family.ABORT),
+      new Def(ISO_SESSION, Family.TRANSPORT),
+      new Def(SEND, Family.TRANSPORT),
+      new Def(RECEIVE, Family.TRANSPORT),
+      new Def(POLL, Family.TRANSPORT),
+      new Def(USABLE, Family.TRANSPORT),
+      new Def(INFO, Family.TELEMETRY),
+      new Def(DEBUG, Family.TELEMETRY),
+      new Def(TRACE, Family.TELEMETRY),
+      new Def(STATUS, Family.TELEMETRY),
+      new Def(S_M_OPERATION, Family.SECURITY),
+      new Def(JCE_PROVIDER, Family.SECURITY),
+      new Def(LOCAL_MASTER_KEYS, Family.SECURITY),
+      new Def(GET_KEY, Family.SECURITY),
+      new Def(SET_KEY, Family.SECURITY),
+      new Def(TXN, Family.NEUTRAL),
+      new Def(LIFECYCLE, Family.NEUTRAL),
+      new Def(DEPLOY, Family.NEUTRAL),
+      new Def(PREPARE, Family.NEUTRAL),
+      new Def(PREPARE_FOR_ABORT, Family.NEUTRAL),
+      new Def(SELECT, Family.NEUTRAL),
+      new Def(RECOVER, Family.NEUTRAL),
+      new Def(CONFIG, Family.NEUTRAL),
+      new Def(NOTIFY, Family.NEUTRAL),
+      new Def(PACK, Family.NEUTRAL),
+      new Def(UNPACK, Family.NEUTRAL),
+      new Def(VALIDATE, Family.NEUTRAL)
+    );
+
+    private static volatile Map<String, String> families;
+
+    private Kind() { }
+
+    /**
+     * Severity family for a kind.
+     *
+     * <p>Matching is case-insensitive. The legacy {@code warning} tag maps to
+     * the {@link Family#WARN} family. Null, blank, unregistered and
+     * namespaced kinds map to {@link Family#NEUTRAL}.</p>
+     *
+     * @param kind a kind, raw or normalized
+     * @return the family; never {@code null}
+     */
+    public static String family(String kind) {
+        if (kind == null || kind.isBlank())
+            return Family.NEUTRAL;
+        String k = kind.trim().toLowerCase(Locale.ROOT);
+        if ("warning".equals(k))
+            k = WARN;
+        return load().getOrDefault(k, Family.NEUTRAL);
+    }
+
+    /**
+     * Kind implied by a registered audit-event type id.
+     *
+     * @param type the {@code t} discriminator
+     * @return the implied kind, or {@link #INFO} when the type is unknown or implies none
+     */
+    public static String kindOf(String type) {
+        return kindOf(AuditLogEventRegistry.typeOf(type));
+    }
+
+    /**
+     * Kind implied by an audit-event payload's registered type.
+     *
+     * @param evt the payload
+     * @return the implied kind, or {@link #INFO} when its type is unknown or implies none
+     */
+    public static String kindOf(AuditLogEvent evt) {
+        return kindOf(evt == null ? null : AuditLogEventRegistry.typeOf(evt.getClass()));
+    }
+
+    private static String kindOf(AuditLogEventType t) {
+        return t == null || t.kind() == null ? INFO : t.kind();
+    }
+
+    /**
+     * Whether a value is a well-formed kind: lowercase kebab segments,
+     * optionally dot-namespaced, at most {@link #MAX_LENGTH} characters.
+     *
+     * @param kind candidate
+     * @return true when well-formed
+     */
+    public static boolean isValid(String kind) {
+        return kind != null && kind.length() <= MAX_LENGTH && KIND_RE.matcher(kind).matches();
+    }
+
+    /**
+     * Whether a kind is registered by core or by a provider.
+     *
+     * @param kind candidate (exact match, no folding)
+     * @return true when registered
+     */
+    public static boolean isRegistered(String kind) {
+        return kind != null && load().containsKey(kind);
+    }
+
+    /** @return immutable snapshot of every registered kind */
+    public static Set<String> registered() {
+        return load().keySet();
+    }
+
+    private static Map<String, String> load() {
+        Map<String, String> snapshot = families;
+        if (snapshot != null)
+            return snapshot;
+        synchronized (Kind.class) {
+            if (families != null)
+                return families;
+            Map<String, String> map = new LinkedHashMap<>();
+            for (Def d : BUILTINS)
+                register(map, d, "core");
+            for (AuditLogEventProvider provider : ServiceLoader.load(AuditLogEventProvider.class)) {
+                Collection<Def> contributed = provider.kinds();
+                if (contributed == null)
+                    continue;
+                for (Def d : contributed)
+                    register(map, d, provider.getClass().getName());
+            }
+            for (AuditLogEventType t : AuditLogEventRegistry.types()) {
+                if (t.kind() != null && !map.containsKey(t.kind()))
+                    throw new IllegalStateException(
+                      "AuditLogEventType '" + t.name() + "' implies unregistered kind '" + t.kind() + "'");
+            }
+            families = Collections.unmodifiableMap(map);
+            return families;
+        }
+    }
+
+    static void register(Map<String, String> map, Def d, String source) {
+        String existing = map.get(d.name());
+        if (existing != null && !existing.equals(d.family())) {
+            throw new IllegalStateException(
+              source + " attempted to register kind '" + d.name() + "' with family '" + d.family()
+                + "' (already registered with family '" + existing + "')");
+        }
+        map.put(d.name(), Objects.requireNonNull(d.family()));
+    }
+}

--- a/jpos/src/main/java/org/jpos/util/Log.java
+++ b/jpos/src/main/java/org/jpos/util/Log.java
@@ -18,6 +18,8 @@
 
 package org.jpos.util;
 
+import org.jpos.log.AuditLogEvent;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -37,18 +39,18 @@ public class Log implements LogSource {
     /** Default tags applied to every {@link LogEvent} created by this {@code Log}. */
     protected final Map<String,String> defaultTags = Collections.synchronizedMap(new LinkedHashMap<>());
 
-    /** Level constant for trace events. */
-    public static final String TRACE   = "trace";
-    /** Level constant for debug events. */
-    public static final String DEBUG   = "debug";
-    /** Level constant for informational events. */
-    public static final String INFO    = "info";
-    /** Level constant for warning events. */
-    public static final String WARN    = "warn";
-    /** Level constant for error events. */
-    public static final String ERROR   = "error";
-    /** Level constant for fatal events. */
-    public static final String FATAL   = "fatal";
+    /** Level constant for trace events; same value as {@link Kind#TRACE}. */
+    public static final String TRACE   = Kind.TRACE;
+    /** Level constant for debug events; same value as {@link Kind#DEBUG}. */
+    public static final String DEBUG   = Kind.DEBUG;
+    /** Level constant for informational events; same value as {@link Kind#INFO}. */
+    public static final String INFO    = Kind.INFO;
+    /** Level constant for warning events; same value as {@link Kind#WARN}. */
+    public static final String WARN    = Kind.WARN;
+    /** Level constant for error events; same value as {@link Kind#ERROR}. */
+    public static final String ERROR   = Kind.ERROR;
+    /** Level constant for fatal events; same value as {@link Kind#FATAL}. */
+    public static final String FATAL   = Kind.FATAL;
 
     /** Default constructor. */
     public Log () {
@@ -287,23 +289,42 @@ public class Log implements LogSource {
         Logger.log (evt);
     }
     /**
-     * Creates a new {@link LogEvent} at the given level decorated with this {@code Log}'s default tags.
+     * Creates a new {@link LogEvent} of the given kind decorated with this {@code Log}'s default tags.
      *
-     * @param level event level (one of the {@code TRACE}/{@code DEBUG}/{@code INFO}/{@code WARN}/{@code ERROR}/{@code FATAL} constants)
+     * <p>The kind is the event's tag: what happened. Prefer a {@link Kind}
+     * constant (the {@code TRACE}/{@code DEBUG}/{@code INFO}/{@code WARN}/{@code ERROR}/{@code FATAL}
+     * level constants are kinds too) or a kind registered by a module. Ad-hoc
+     * kinds should be dot-namespaced, e.g. {@code jcard.pin-change}.</p>
+     *
+     * @param level event kind
      * @return a new event ready to be populated and logged
+     * @see Kind
      */
     public LogEvent createLogEvent (String level) {
         return applyDefaultTags(new LogEvent (this, level));
     }
     /**
-     * Creates a new {@link LogEvent} at the given level with an initial payload.
+     * Creates a new {@link LogEvent} of the given kind with an initial payload.
      *
-     * @param level event level
+     * @param level event kind (see {@link #createLogEvent(String)})
      * @param detail initial event payload
      * @return a new event ready to be populated and logged
      */
     public LogEvent createLogEvent (String level, Object detail) {
         return applyDefaultTags(new LogEvent (this, level, detail));
+    }
+    /**
+     * Creates a new {@link LogEvent} whose kind is implied by the payload's
+     * registered {@link org.jpos.log.AuditLogEventType}, decorated with this
+     * {@code Log}'s default tags. Falls back to {@link Kind#INFO} when the
+     * type is unknown or implies no kind.
+     *
+     * @param detail typed event payload
+     * @return a new event ready to be populated and logged
+     * @see Kind#kindOf(AuditLogEvent)
+     */
+    public LogEvent createEvent (AuditLogEvent detail) {
+        return applyDefaultTags(new LogEvent (this, detail));
     }
     /**
      * Creates an empty trace-level event.

--- a/jpos/src/main/java/org/jpos/util/LogEvent.java
+++ b/jpos/src/main/java/org/jpos/util/LogEvent.java
@@ -58,7 +58,14 @@ public class LogEvent implements AuditLogEventConvertible {
     /**
      * Constructs an empty event with the given tag.
      *
-     * @param tag log tag (level/event name)
+     * <p>The tag is the event's <em>kind</em>: what happened. Prefer a
+     * {@link Kind} constant or a kind registered by a module through
+     * {@link org.jpos.log.AuditLogEventProvider}; ad-hoc kinds should be
+     * dot-namespaced ({@code jcard.pin-change}). Nothing in core rewrites
+     * or rejects a tag.</p>
+     *
+     * @param tag event kind
+     * @see Kind
      */
     public LogEvent (String tag) {
         super();
@@ -74,7 +81,7 @@ public class LogEvent implements AuditLogEventConvertible {
     /**
      * Constructs an event with the given tag and an initial payload entry.
      *
-     * @param tag log tag (level/event name)
+     * @param tag event kind (see {@link #LogEvent(String)})
      * @param msg initial payload entry
      */
     public LogEvent (String tag, Object msg) {
@@ -85,7 +92,7 @@ public class LogEvent implements AuditLogEventConvertible {
      * Constructs an event tied to a {@link LogSource}.
      *
      * @param source source whose logger and realm govern this event
-     * @param tag log tag (level/event name)
+     * @param tag event kind (see {@link #LogEvent(String)})
      */
     public LogEvent (LogSource source, String tag) {
         this (tag);
@@ -96,7 +103,7 @@ public class LogEvent implements AuditLogEventConvertible {
      * Constructs an event tied to a {@link LogSource} with an initial payload entry.
      *
      * @param source source whose logger and realm govern this event
-     * @param tag log tag (level/event name)
+     * @param tag event kind (see {@link #LogEvent(String)})
      * @param msg initial payload entry
      */
     public LogEvent (LogSource source, String tag, Object msg) {
@@ -104,6 +111,18 @@ public class LogEvent implements AuditLogEventConvertible {
         this.source  = source;
         honorSourceLogger = true;
         addMessage(msg);
+    }
+    /**
+     * Constructs an event tied to a {@link LogSource} whose kind is implied by
+     * the payload's registered {@link org.jpos.log.AuditLogEventType}.
+     * Falls back to {@link Kind#INFO} when the type is unknown or implies no kind.
+     *
+     * @param source source whose logger and realm govern this event
+     * @param evt typed payload
+     * @see Kind#kindOf(AuditLogEvent)
+     */
+    public LogEvent (LogSource source, AuditLogEvent evt) {
+        this (source, Kind.kindOf(evt), evt);
     }
     /**
      * Returns the log tag.

--- a/jpos/src/test/java/org/jpos/log/TestAuditLogEventProvider.java
+++ b/jpos/src/test/java/org/jpos/log/TestAuditLogEventProvider.java
@@ -18,18 +18,31 @@
 
 package org.jpos.log;
 
+import org.jpos.util.Kind;
+
 import java.util.List;
 
 /**
- * Provider used by the {@code AuditLogEventRegistry} tests to verify
- * {@link java.util.ServiceLoader} discovery of external types.
+ * Provider used by the {@code AuditLogEventRegistry} and {@code Kind} tests
+ * to verify {@link java.util.ServiceLoader} discovery of external types and kinds.
  */
 public class TestAuditLogEventProvider implements AuditLogEventProvider {
+
+    public static final String CUSTOM_KIND = "custom-kind";
+    public static final String UNTYPED_KIND = "custom-untyped";
 
     public record CustomEvent(String value) implements AuditLogEvent { }
 
     @Override
     public List<AuditLogEventType> types() {
-        return List.of(new AuditLogEventType("custom-test", CustomEvent.class));
+        return List.of(new AuditLogEventType("custom-test", CustomEvent.class, CUSTOM_KIND));
+    }
+
+    @Override
+    public List<Kind.Def> kinds() {
+        return List.of(
+          new Kind.Def(CUSTOM_KIND, Kind.Family.TELEMETRY),
+          new Kind.Def(UNTYPED_KIND, "custom-family")
+        );
     }
 }

--- a/jpos/src/test/java/org/jpos/util/KindTest.java
+++ b/jpos/src/test/java/org/jpos/util/KindTest.java
@@ -1,0 +1,173 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.util;
+
+import org.jpos.log.AuditLogEventRegistry;
+import org.jpos.log.AuditLogEventType;
+import org.jpos.log.TestAuditLogEventProvider;
+import org.jpos.log.evt.ProfilerEvt;
+import org.jpos.log.evt.SessionStart;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class KindTest {
+
+    @Test
+    void everyRegisteredKindIsValidAndHasAFamily() {
+        Set<String> kinds = Kind.registered();
+        assertTrue(kinds.size() >= 35, "core registers its emitted kinds");
+        for (String k : kinds) {
+            assertTrue(Kind.isValid(k), k);
+            assertTrue(Kind.isRegistered(k), k);
+            assertNotNull(Kind.family(k), k);
+        }
+    }
+
+    @Test
+    void everyTypeThatImpliesAKindImpliesARegisteredOne() {
+        for (AuditLogEventType t : AuditLogEventRegistry.types()) {
+            if (t.kind() != null)
+                assertTrue(Kind.isRegistered(t.kind()), t.name() + " -> " + t.kind());
+        }
+    }
+
+    @Test
+    void familyNeverReturnsNull() {
+        assertEquals(Kind.Family.NEUTRAL, Kind.family(null));
+        assertEquals(Kind.Family.NEUTRAL, Kind.family(""));
+        assertEquals(Kind.Family.NEUTRAL, Kind.family("   "));
+        assertEquals(Kind.Family.NEUTRAL, Kind.family("no-such-kind"));
+        assertEquals(Kind.Family.NEUTRAL, Kind.family("jcard.pin-change"));
+    }
+
+    @Test
+    void familyIsCaseInsensitiveAndHonoursLegacyAliases() {
+        assertEquals(Kind.Family.WARN, Kind.family("WARN"));
+        assertEquals(Kind.Family.WARN, Kind.family("warning"));
+        assertEquals(Kind.Family.WARN, Kind.family(" Warning "));
+        assertEquals(Kind.Family.FAIL, Kind.family("fatal"));
+        assertEquals(Kind.Family.FAIL, Kind.family("Fatal"));
+        assertEquals(Kind.Family.TRANSPORT, Kind.family(Kind.ISO_SESSION));
+        assertEquals(Kind.Family.SECURITY, Kind.family(Kind.S_M_OPERATION));
+    }
+
+    @Test
+    void kindOfTypeFollowsTheUmbrella() {
+        assertEquals(Kind.ISO_SESSION, Kind.kindOf("listen"));
+        assertEquals(Kind.ISO_SESSION, Kind.kindOf("session-start"));
+        assertEquals(Kind.LIFECYCLE, Kind.kindOf("start"));
+        assertEquals(Kind.LIFECYCLE, Kind.kindOf("license"));
+        assertEquals(Kind.DEPLOY, Kind.kindOf("undeploy"));
+        assertEquals(Kind.ERROR, Kind.kindOf("throwable"));
+        assertEquals(Kind.ISO_SESSION, Kind.kindOf(new SessionStart(1, 10, "x")));
+    }
+
+    @Test
+    void kindOfFallsBackToInfo() {
+        assertEquals(Kind.INFO, Kind.kindOf("profiler"), "secondary payload implies no kind");
+        assertEquals(Kind.INFO, Kind.kindOf(new ProfilerEvt(0L, List.of())));
+        assertEquals(Kind.INFO, Kind.kindOf("no-such-type"));
+        assertEquals(Kind.INFO, Kind.kindOf((String) null));
+        assertEquals(Kind.INFO, Kind.kindOf((org.jpos.log.AuditLogEvent) null));
+    }
+
+    @Test
+    void isValidEnforcesTheFormat() {
+        assertTrue(Kind.isValid("send"));
+        assertTrue(Kind.isValid("session-start"));
+        assertTrue(Kind.isValid("jcard.pin-change"));
+        assertTrue(Kind.isValid("a".repeat(Kind.MAX_LENGTH)));
+        assertFalse(Kind.isValid(null));
+        assertFalse(Kind.isValid(""));
+        assertFalse(Kind.isValid("Send"));
+        assertFalse(Kind.isValid("a b"));
+        assertFalse(Kind.isValid("comm/channel"));
+        assertFalse(Kind.isValid("1abc"));
+        assertFalse(Kind.isValid("-abc"));
+        assertFalse(Kind.isValid("abc."));
+        assertFalse(Kind.isValid("a".repeat(Kind.MAX_LENGTH + 1)));
+    }
+
+    @Test
+    void registeredIsImmutable() {
+        assertThrows(UnsupportedOperationException.class, () -> Kind.registered().add("x"));
+        assertThrows(UnsupportedOperationException.class, () -> Kind.registered().remove(Kind.INFO));
+    }
+
+    @Test
+    void providersRegisterKindsAndImpliedKinds() {
+        assertTrue(Kind.isRegistered(TestAuditLogEventProvider.CUSTOM_KIND));
+        assertEquals(Kind.Family.TELEMETRY, Kind.family(TestAuditLogEventProvider.CUSTOM_KIND));
+        assertEquals(TestAuditLogEventProvider.CUSTOM_KIND, Kind.kindOf("custom-test"));
+        assertEquals(TestAuditLogEventProvider.CUSTOM_KIND,
+          Kind.kindOf(new TestAuditLogEventProvider.CustomEvent("v")));
+        assertEquals("custom-family", Kind.family(TestAuditLogEventProvider.UNTYPED_KIND),
+          "families are extensible");
+    }
+
+    @Test
+    void conflictingRegistrationThrows() {
+        Map<String, String> map = new HashMap<>();
+        Kind.register(map, new Kind.Def("dup", Kind.Family.WARN), "a");
+        Kind.register(map, new Kind.Def("dup", Kind.Family.WARN), "b"); // same family: fine
+        assertThrows(IllegalStateException.class,
+          () -> Kind.register(map, new Kind.Def("dup", Kind.Family.FAIL), "c"));
+    }
+
+    @Test
+    void defRejectsMalformedValues() {
+        assertThrows(IllegalArgumentException.class, () -> new Kind.Def("Bad", Kind.Family.WARN));
+        assertThrows(IllegalArgumentException.class, () -> new Kind.Def("ok", null));
+        assertThrows(IllegalArgumentException.class, () -> new Kind.Def("ok", "Bad Family"));
+        assertThrows(IllegalArgumentException.class, () -> new AuditLogEventType("t", SessionStart.class, "Bad"));
+    }
+
+    @Test
+    void logLevelConstantsAreUnchangedAndReferenceKind() {
+        assertEquals("trace", Log.TRACE);
+        assertEquals("debug", Log.DEBUG);
+        assertEquals("info",  Log.INFO);
+        assertEquals("warn",  Log.WARN);
+        assertEquals("error", Log.ERROR);
+        assertEquals("fatal", Log.FATAL);
+        assertEquals(Kind.FATAL, Log.FATAL);
+        assertTrue(Kind.isRegistered(Log.FATAL));
+    }
+
+    @Test
+    void createEventUsesTheImpliedKindAndDefaultStaysInfo() {
+        Log log = new Log(new Logger(), "test");
+        LogEvent evt = log.createEvent(new SessionStart(1, 10, "x"));
+        assertEquals(Kind.ISO_SESSION, evt.getTag());
+        assertEquals(1, evt.getPayLoad().size());
+        assertEquals(Kind.INFO, log.createEvent(new ProfilerEvt(0L, List.of())).getTag());
+        assertEquals(Kind.INFO, new LogEvent().getTag());
+        assertEquals(Kind.ISO_SESSION, new LogEvent(log, new SessionStart(1, 10, "x")).getTag());
+    }
+}


### PR DESCRIPTION
Implements #759.

## What

- `org.jpos.util.Kind`: family constants, the 35 kinds core emits, `Def`, `family()`, `kindOf()` by type id and by payload, `isValid()`, `isRegistered()`, `registered()`.
- `AuditLogEventType` gains an optional third component, the kind the type implies. Two-argument constructor kept.
- `AuditLogEventProvider` gains `default kinds()` so jPOS-EE modules and applications register kinds through the existing ServiceLoader SPI.
- `AuditLogEventRegistry` built-ins declare their implied kinds (`iso-session`, `lifecycle`, `deploy`, ...) and expose `typeOf(String)` / `typeOf(Class)`.
- `Log.createEvent(AuditLogEvent)` and `LogEvent(LogSource, AuditLogEvent)` set the tag from the payload's registered type. No heuristic in the writers; `new LogEvent()` still means `info`.
- `Log.TRACE/DEBUG/INFO/WARN/ERROR/FATAL` reference `Kind`; values unchanged. `fatal` is a registered kind.
- Javadoc on `LogEvent` constructors and `Log.createLogEvent` describes the tag as a kind.

## Behaviour

No emitter changes and no change to emitted or serialized values. The registry loads lazily on first use, merges core with every provider, and throws on a conflicting family or on a type implying an unregistered kind. Families are extensible; javadoc discourages new ones.

## Tests

`KindTest` (13 tests) covers every acceptance criterion in #759, including provider-registered kinds and families via `TestAuditLogEventProvider`. Full `:jpos:test` and `:jpos:javadoc` pass with no warnings.

## Follow-up

Core conformance sweep (rename the handful of non-conforming tags and switch the eight `AuditLogEvent` emission sites to `createEvent`) is a separate issue since it changes serialized output.
