### PR TITLE
Core log kinds conform to the registered Kind vocabulary

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/BaseChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/BaseChannel.java
@@ -477,7 +477,7 @@ public abstract class BaseChannel extends Observable
     public void connect () throws IOException {
         ChannelEvent jfr = new ChannelEvent.Connect();
         jfr.begin();
-        LogEvent evt = new LogEvent (this, "connect").withTraceId(uuid);
+        LogEvent evt = new LogEvent (this, Kind.ISO_SESSION).withTraceId(uuid);
         boolean logEvent = logConnections;
         try {
             socket = newSocket (hosts, ports, evt);
@@ -1008,7 +1008,7 @@ public abstract class BaseChannel extends Observable
     public void disconnect () throws IOException {
         var jfr = new ChannelEvent.Disconnect();
         jfr.begin();
-        LogEvent evt = new LogEvent (this, "disconnect");
+        LogEvent evt = new LogEvent (this, Kind.ISO_SESSION);
         if (socket != null) {
             String detail = socket.getRemoteSocketAddress().toString();
             jfr.setDetail(detail);

--- a/jpos/src/main/java/org/jpos/iso/ISOServer.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOServer.java
@@ -264,7 +264,7 @@ public class ISOServer extends Observable
             }
         } catch (IOException e) {
             fireEvent(new ISOServerShutdownEvent(this));
-            Logger.log (new LogEvent (this, "shutdown", e));
+            Logger.log (new LogEvent (this, Kind.ERROR, e));
         }
     }
     private void shutdownChannels () {
@@ -278,7 +278,7 @@ public class ISOServer extends Observable
                     c.disconnect ();
                     fireEvent(new ISOServerClientDisconnectEvent(this, c));
                 } catch (IOException e) {
-                    Logger.log (new LogEvent (this, "shutdown", e));
+                    Logger.log (new LogEvent (this, Kind.ERROR, e));
                 }
             }
         }
@@ -362,10 +362,10 @@ public class ISOServer extends Observable
                         }
                     }
                 } catch (ISOFilter.VetoException e) {
-                    Logger.log(createSessionEvent("VetoException", sessionUUID, endpoint).add(e.getMessage()));
+                    Logger.log(createSessionEvent(Kind.SESSION_WARNING, sessionUUID, endpoint).add(e.getMessage()));
                 } catch (ISOException e) {
                     if (ignoreISOExceptions) {
-                        Logger.log(createSessionEvent("ISOException", sessionUUID, endpoint).add(e.getMessage()));
+                        Logger.log(createSessionEvent(Kind.SESSION_WARNING, sessionUUID, endpoint).add(e.getMessage()));
                     } else {
                         throw e;
                     }
@@ -374,18 +374,18 @@ public class ISOServer extends Observable
                  // Logger.log (new LogEvent (this, "session-warning", "<eof/>"));
             } catch (SocketException e) {
                  if (!shutdown)
-                     Logger.log (createSessionEvent("session-warning", sessionUUID, endpoint).add(e));
+                     Logger.log (createSessionEvent(Kind.SESSION_WARNING, sessionUUID, endpoint).add(e));
             } catch (InterruptedIOException e) {
                 // nothing to log
             } catch (Throwable e) {
-                Logger.log (createSessionEvent("session-error", sessionUUID, endpoint).add(e));
+                Logger.log (createSessionEvent(Kind.SESSION_ERROR, sessionUUID, endpoint).add(e));
             }
 
             try {
                 channel.disconnect();
                 fireEvent(new ISOServerClientDisconnectEvent(ISOServer.this, channel));
             } catch (IOException ex) {
-                Logger.log (createSessionEvent("session-error", sessionUUID, endpoint).add(ex));
+                Logger.log (createSessionEvent(Kind.SESSION_ERROR, sessionUUID, endpoint).add(ex));
                 fireEvent(new ISOServerClientDisconnectEvent(ISOServer.this, channel));
             }
             Logger.log(createSessionEvent(sessionUUID, endpoint)
@@ -406,7 +406,7 @@ public class ISOServer extends Observable
         }
 
         private LogEvent createSessionEvent(UUID sessionUUID, String endpoint) {
-            LogEvent evt = new LogEvent().withSource(this).withTraceId(sessionUUID);
+            LogEvent evt = new LogEvent(Kind.ISO_SESSION).withSource(this).withTraceId(sessionUUID);
             evt.withTag("session", sessionUUID.toString());
             if (endpoint != null)
                 evt.withTag("endpoint", endpoint);
@@ -866,7 +866,7 @@ public class ISOServer extends Observable
     }
 
     private void log (AuditLogEvent log) {
-        Logger.log(new LogEvent()
+        Logger.log(new LogEvent(Kind.kindOf(log))
           .withSource(this)
           .withTraceId(uuid)
           .add(log)

--- a/jpos/src/main/java/org/jpos/iso/channel/BASE24TCPChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/BASE24TCPChannel.java
@@ -19,6 +19,7 @@
 package org.jpos.iso.channel;
 
 import org.jpos.iso.*;
+import org.jpos.util.Kind;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
 
@@ -97,7 +98,7 @@ public class BASE24TCPChannel extends BaseChannel {
     protected int getMessageLength() throws IOException, ISOException {
         int l = 0;
         byte[] b = new byte[2];
-        Logger.log (new LogEvent (this, "get-message-length"));
+        Logger.log (new LogEvent (this, Kind.DEBUG, "get-message-length"));
         while (l == 0) {
             serverIn.readFully(b,0,2);
             l = ((int)b[0] &0xFF) << 8 | (int)b[1] &0xFF;
@@ -106,14 +107,14 @@ public class BASE24TCPChannel extends BaseChannel {
                 serverOut.flush();
             }
         }
-        Logger.log (new LogEvent (this, "got-message-length", Integer.toString(l)));
+        Logger.log (new LogEvent (this, Kind.DEBUG, "got-message-length " + l));
         return l - 1;   // trailler length
     }
     protected void getMessageTrailler() throws IOException {
-        Logger.log (new LogEvent (this, "get-message-trailler"));
+        Logger.log (new LogEvent (this, Kind.DEBUG, "get-message-trailler"));
         byte[] b = new byte[1];
         serverIn.readFully(b,0,1);
-        Logger.log (new LogEvent (this, "got-message-trailler", ISOUtil.hexString(b)));
+        Logger.log (new LogEvent (this, Kind.DEBUG, "got-message-trailler " + ISOUtil.hexString(b)));
     }
 }
 

--- a/jpos/src/main/java/org/jpos/iso/channel/BCDChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/BCDChannel.java
@@ -19,6 +19,7 @@
 package org.jpos.iso.channel;
 
 import org.jpos.iso.*;
+import org.jpos.util.Kind;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
 
@@ -89,7 +90,7 @@ public class BCDChannel extends BaseChannel {
             );
         } 
         catch (ISOException e) {
-            Logger.log (new LogEvent (this, "send-message-length", e));
+            Logger.log (new LogEvent (this, Kind.DEBUG, e));
         }
     }
     protected int getMessageLength() throws IOException, ISOException {

--- a/jpos/src/main/java/org/jpos/iso/channel/ChannelPool.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/ChannelPool.java
@@ -25,6 +25,7 @@ import org.jpos.iso.ISOChannel;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOMsg;
 import org.jpos.iso.ISOPackager;
+import org.jpos.util.Kind;
 import org.jpos.util.LogEvent;
 import org.jpos.util.LogSource;
 import org.jpos.util.Logger;
@@ -66,7 +67,7 @@ public class ChannelPool implements ISOChannel, LogSource, Configurable, Cloneab
         lock.lock();
         try {
             current = null;
-            LogEvent evt = new LogEvent (this, "connect");
+            LogEvent evt = new LogEvent (this, Kind.ISO_SESSION);
             evt.addMessage ("pool-size=" + Integer.toString (pool.size()));
             for (int i=0; i<pool.size(); i++) {
                 try {
@@ -96,7 +97,7 @@ public class ChannelPool implements ISOChannel, LogSource, Configurable, Cloneab
         lock.lock();
         try {
             current = null;
-            LogEvent evt = new LogEvent (this, "disconnect");
+            LogEvent evt = new LogEvent (this, Kind.ISO_SESSION);
             for (Object aPool : pool) {
                 try {
                     ISOChannel c = (ISOChannel) aPool;

--- a/jpos/src/main/java/org/jpos/iso/channel/FSDChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/FSDChannel.java
@@ -24,6 +24,7 @@ import org.jpos.iso.FSDISOMsg;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOMsg;
 import org.jpos.util.FSDMsg;
+import org.jpos.util.Kind;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
 
@@ -67,7 +68,7 @@ public class FSDChannel extends NACChannel {
     @Override
     protected int getMessageLength() throws IOException, ISOException {
         int len = super.getMessageLength();
-        LogEvent evt = new LogEvent (this, "fsd-channel-debug");
+        LogEvent evt = new LogEvent (this, Kind.DEBUG);
         evt.addMessage ("received message length: " + len);
         Logger.log (evt);
         return len;

--- a/jpos/src/main/java/org/jpos/iso/channel/HEXChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/HEXChannel.java
@@ -19,6 +19,7 @@
 package org.jpos.iso.channel;
 
 import org.jpos.iso.*;
+import org.jpos.util.Kind;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
 
@@ -86,7 +87,7 @@ public class HEXChannel extends BaseChannel {
             );
         } 
         catch (ISOException e) {
-            Logger.log (new LogEvent (this, "send-message-length", e));
+            Logger.log (new LogEvent (this, Kind.DEBUG, e));
         }
     }
     protected int getMessageLength() throws IOException, ISOException {

--- a/jpos/src/main/java/org/jpos/iso/channel/LoopbackChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/LoopbackChannel.java
@@ -89,7 +89,7 @@ public class LoopbackChannel extends FilteredBase implements LogSource {
         throws IOException,ISOException {
         if (!isConnected())
             throw new ISOException ("unconnected ISOChannel");
-        LogEvent evt = new LogEvent (this, "loopback-send", m);
+        LogEvent evt = new LogEvent (this, Kind.SEND, m);
         m = applyOutgoingFilters (m, evt);
         queue.enqueue (m);
         cnt[TX]++;
@@ -101,7 +101,7 @@ public class LoopbackChannel extends FilteredBase implements LogSource {
     throws IOException,ISOException {
     if (!isConnected())
         throw new ISOException ("unconnected ISOChannel");
-    LogEvent evt = new LogEvent (this, "loopback-send", b);
+    LogEvent evt = new LogEvent (this, Kind.SEND, b);
     queue.enqueue (b);
     cnt[TX]++;
     notifyObservers();
@@ -114,7 +114,7 @@ public class LoopbackChannel extends FilteredBase implements LogSource {
             throw new ISOException ("unconnected ISOChannel");
         try {
             ISOMsg m = (ISOMsg) ((ISOMsg) queue.dequeue()).clone();
-            LogEvent evt = new LogEvent (this, "loopback-receive", m);
+            LogEvent evt = new LogEvent (this, Kind.RECEIVE, m);
             m = applyIncomingFilters (m, evt);
             cnt[RX]++;
             notifyObservers();

--- a/jpos/src/main/java/org/jpos/iso/channel/NCCChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/channel/NCCChannel.java
@@ -19,6 +19,7 @@
 package org.jpos.iso.channel;
 
 import org.jpos.iso.*;
+import org.jpos.util.Kind;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
 import org.jpos.core.Configuration;
@@ -93,7 +94,7 @@ public class NCCChannel extends BaseChannel {
             );
         } 
         catch (ISOException e) {
-            Logger.log (new LogEvent (this, "send-message-length", e));
+            Logger.log (new LogEvent (this, Kind.DEBUG, e));
         }
     }
     protected int getMessageLength() throws IOException, ISOException {

--- a/jpos/src/main/java/org/jpos/q2/Q2.java
+++ b/jpos/src/main/java/org/jpos/q2/Q2.java
@@ -54,6 +54,7 @@ import org.jpos.metrics.MeterInfo;
 import org.jpos.metrics.PrometheusService;
 import org.jpos.q2.install.ModuleUtils;
 import org.jpos.security.SystemSeed;
+import org.jpos.util.Kind;
 import org.jpos.util.Log;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
@@ -719,7 +720,7 @@ public class Q2 implements FileFilter, Runnable {
 
     private void undeploy (File f) {
         QEntry qentry = dirMap.get (f);
-        LogEvent evt = getDeployLog().createInfo().withTraceId(getInstanceId());
+        LogEvent evt = getDeployLog().createLogEvent(Kind.DEPLOY).withTraceId(getInstanceId());
         try {
             if (evt != null)
                 evt.addMessage (new UnDeploy(f.getCanonicalPath()));
@@ -754,7 +755,7 @@ public class Q2 implements FileFilter, Runnable {
     }
 
     private boolean deploy (File f) {
-        LogEvent evt = getDeployLog().createInfo().withTraceId(getInstanceId());
+        LogEvent evt = getDeployLog().createLogEvent(Kind.DEPLOY).withTraceId(getInstanceId());
         boolean enabled;
         try {
             QEntry qentry = dirMap.get (f);
@@ -1580,7 +1581,7 @@ public class Q2 implements FileFilter, Runnable {
     private boolean waitForChanges (WatchService service) throws InterruptedException {
         WatchKey key = service.poll (SCAN_INTERVAL, TimeUnit.MILLISECONDS);
         if (key != null) {
-            LogEvent evt = getDeployLog().createInfo().withTraceId(getInstanceId());
+            LogEvent evt = getDeployLog().createLogEvent(Kind.DEPLOY).withTraceId(getInstanceId());
             for (WatchEvent<?> ev : key.pollEvents()) {
                 if (ev.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
                     evt.addMessage(new DeployActivity(DeployActivity.Action.CREATE, String.format ("%s/%s", deployDir.getName(), ev.context())));
@@ -1743,7 +1744,7 @@ public class Q2 implements FileFilter, Runnable {
     }
 
     private void audit (AuditLogEvent sal) {
-        Logger.log(getLog().createInfo(sal).withTraceId(getInstanceId()));
+        Logger.log(getLog().createEvent(sal).withTraceId(getInstanceId()));
     }
 
     private Start auditStart() {

--- a/jpos/src/main/java/org/jpos/security/SimpleKeyFile.java
+++ b/jpos/src/main/java/org/jpos/security/SimpleKeyFile.java
@@ -23,6 +23,7 @@ import org.jpos.core.Configurable;
 import org.jpos.core.Configuration;
 import org.jpos.core.ConfigurationException;
 import org.jpos.iso.ISOUtil;
+import org.jpos.util.Kind;
 import org.jpos.util.LogEvent;
 import org.jpos.util.LogSource;
 import org.jpos.util.Logger;
@@ -138,7 +139,7 @@ public class SimpleKeyFile
                 evt.addMessage(secureKey);
         } catch (Exception e) {
             if (evt == null) // this is an exception, we want to log it, even if we don't have an assigned logger
-                evt = new LogEvent(this, "get-key-error", alias);
+                evt = new LogEvent(this, Kind.ERROR, alias);
             evt.addMessage(e);
             throw  e instanceof SecureKeyStoreException ? (SecureKeyStoreException) e : new SecureKeyStoreException(e);
         } finally {

--- a/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
+++ b/jpos/src/main/java/org/jpos/security/jceadapter/JCESecurityModule.java
@@ -26,6 +26,7 @@ import org.jpos.iso.ISODate;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOUtil;
 import org.jpos.security.*;
+import org.jpos.util.Kind;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
 import org.jpos.util.SimpleMsg;
@@ -1886,7 +1887,7 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
      */
     @Override
     protected byte[] generateCBC_MACImpl (byte[] data, SecureDESKey kd) throws SMException {
-        LogEvent evt = new LogEvent(this, "jce-provider-cbc-mac");
+        LogEvent evt = new LogEvent(this, Kind.JCE_PROVIDER);
         try {
           return generateMACImpl(data,kd,cfg.get("cbc-mac","ISO9797ALG3MACWITHISO7816-4PADDING"),evt);
         } catch (Exception e) {
@@ -1906,7 +1907,7 @@ public class JCESecurityModule extends BaseSMAdapter<SecureDESKey> {
      */
     @Override
     protected byte[] generateEDE_MACImpl (byte[] data, SecureDESKey kd) throws SMException {
-        LogEvent evt = new LogEvent(this, "jce-provider-ede-mac");
+        LogEvent evt = new LogEvent(this, Kind.JCE_PROVIDER);
         try {
           return generateMACImpl(data,kd,cfg.get("ede-mac","DESEDEMAC"),evt);
         } catch (Exception e) {

--- a/jpos/src/main/java/org/jpos/util/DirPoll.java
+++ b/jpos/src/main/java/org/jpos/util/DirPoll.java
@@ -406,7 +406,7 @@ public class DirPoll extends SimpleLogSource
                 }
             } catch (InterruptedException e) {
             } catch (Throwable e) {
-                Logger.log (new LogEvent (this, "dirpoll", e));
+                Logger.log (new LogEvent (this, Log.ERROR, e));
                 try {
                     synchronized (shutdownMonitor) {
                         if (!shutdown && pollInterval > 0L) {

--- a/jpos/src/main/java/org/jpos/util/Kind.java
+++ b/jpos/src/main/java/org/jpos/util/Kind.java
@@ -292,7 +292,11 @@ public final class Kind {
         return kind != null && load().containsKey(kind);
     }
 
-    /** @return immutable snapshot of every registered kind */
+    /**
+     * Every registered kind.
+     *
+     * @return immutable snapshot of every registered kind
+     */
     public static Set<String> registered() {
         return load().keySet();
     }

--- a/jpos/src/main/java/org/jpos/util/RealmLogFilter.java
+++ b/jpos/src/main/java/org/jpos/util/RealmLogFilter.java
@@ -95,7 +95,7 @@ public class RealmLogFilter implements LogListener, XmlConfigurable, Configurabl
         } else {
             realmsMissed.add(realm);
             if (dumpInterval > 0 && System.currentTimeMillis() - lastDump > dumpInterval) {
-                LogEvent evt = new LogEvent("ignored-realms");
+                LogEvent evt = new LogEvent(Kind.CONFIG);
                 evt.addMessage(realmsMissed);
                 realmsMissed = new HashSet<>();
                 lastDump = System.currentTimeMillis();

--- a/jpos/src/main/java/org/jpos/util/SimpleLogSource.java
+++ b/jpos/src/main/java/org/jpos/util/SimpleLogSource.java
@@ -97,7 +97,7 @@ public class SimpleLogSource implements LogSource {
      * @param detail the warning text
      */
     public void warning (String detail) {
-        Logger.log (new LogEvent (this, "warning", detail));
+        Logger.log (new LogEvent (this, Log.WARN, detail));
     }
     /**
      * Logs a warning message with an attached object.
@@ -105,7 +105,7 @@ public class SimpleLogSource implements LogSource {
      * @param obj the object to attach
      */
     public void warning (String detail, Object obj) {
-        LogEvent evt = new LogEvent (this, "warning", detail);
+        LogEvent evt = new LogEvent (this, Log.WARN, detail);
         evt.addMessage (obj);
         Logger.log (evt);
     }

--- a/jpos/src/main/java/org/jpos/util/SystemMonitor.java
+++ b/jpos/src/main/java/org/jpos/util/SystemMonitor.java
@@ -97,7 +97,7 @@ public class SystemMonitor implements Runnable, LogSource, Loggeable
 
     public void run() {
         while (!shutdown) {
-            Logger.log (new LogEvent (this, "SystemMonitor", this));
+            Logger.log (new LogEvent (this, Kind.STATUS, this));
             try {
                 long expected = System.currentTimeMillis() + sleepTime;
                 Thread.sleep (sleepTime);

--- a/jpos/src/test/java/org/jpos/iso/BaseChannelTest.java
+++ b/jpos/src/test/java/org/jpos/iso/BaseChannelTest.java
@@ -71,6 +71,7 @@ import org.jpos.iso.packager.ISO93BPackager;
 import org.jpos.iso.packager.ISOBaseValidatingPackager;
 import org.jpos.iso.packager.PostPackager;
 import org.jpos.iso.packager.XMLPackager;
+import org.jpos.util.Kind;
 import org.jpos.util.LogEvent;
 import org.jpos.util.Logger;
 import org.jpos.util.NameRegistrar;
@@ -308,7 +309,7 @@ public class BaseChannelTest {
             try (Socket peer = accepted.get()) {
                 assertEquals("comm/channel", rawChannel.getRealm(), "rawChannel.getRealm()");
                 LogEvent connect = events.stream()
-                  .filter(ev -> "connect".equals(ev.getTag()))
+                  .filter(ev -> Kind.ISO_SESSION.equals(ev.getTag()))
                   .findFirst()
                   .orElseThrow();
                 assertEquals("comm/channel", connect.getRealm(), "connect.getRealm()");
@@ -340,7 +341,7 @@ public class BaseChannelTest {
             rawChannel.setLogConnections(false);
             rawChannel.connect();
             try (Socket peer = accepted.get()) {
-                assertFalse(events.stream().anyMatch(ev -> "connect".equals(ev.getTag())), "connect log event");
+                assertFalse(events.stream().anyMatch(ev -> Kind.ISO_SESSION.equals(ev.getTag())), "connect log event");
                 rawChannel.disconnect();
             } finally {
                 executor.shutdownNow();

--- a/jpos/src/test/java/org/jpos/iso/ISOServerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/ISOServerTest.java
@@ -186,6 +186,7 @@ public class ISOServerTest {
                   .findFirst()
                   .orElseThrow();
                 assertEquals("comm/server", sessionEvent.getRealm(), "sessionEvent.getRealm()");
+                assertEquals(org.jpos.util.Kind.ISO_SESSION, sessionEvent.getTag(), "sessionEvent.getTag()");
                 assertTrue(sessionEvent.getTags().containsKey("session"), "sessionEvent.getTags().containsKey(session)");
                 assertTrue(sessionEvent.getTags().containsKey("endpoint"), "sessionEvent.getTags().containsKey(endpoint)");
             }


### PR DESCRIPTION
Implements #761. Follow-up to #759 / #760.

## What

Core's own log emissions now conform to the registered `Kind` vocabulary.

**Literal tag renames** (all to kinds already registered):

| Site | Was | Now |
|---|---|---|
| `SystemMonitor` | `SystemMonitor` | `status` |
| `SimpleLogSource.warn(...)` | `warning` | `warn` |
| `ISOServer` session loop | `VetoException`, `ISOException` | `session-warning` |
| `ISOServer` shutdown exception | `shutdown` | `error` |
| `BASE24TCPChannel` length / trailer dumps | `get-message-length`, `got-message-length`, `get-message-trailler`, `got-message-trailler` | `debug` |
| `BCDChannel`, `HEXChannel`, `NCCChannel` | `send-message-length` | `debug` |
| `FSDChannel` | `fsd-channel-debug` | `debug` |
| `LoopbackChannel` | `loopback-send`, `loopback-receive` | `send`, `receive` |
| `JCESecurityModule` | `jce-provider-cbc-mac`, `jce-provider-ede-mac` | `jce-provider` |
| `SimpleKeyFile` | `get-key-error` | `error` |
| `DirPoll` | `dirpoll` | `error` |
| `RealmLogFilter` | `ignored-realms` | `config` |

**Type-implied kinds** at the audit-event emission sites (envelope tag now comes from the payload's registered type):

| Site | Was | Now |
|---|---|---|
| `ISOServer` session start / end | `info` | `iso-session` |
| `ISOServer.log(Listen)` | `info` | `iso-session` |
| `ISOServer.log(ThrowableAuditLogEvent)` | `info` | `error` |
| `BaseChannel`, `ChannelPool` connect / disconnect | `connect`, `disconnect` | `iso-session` |
| `Q2` deploy / undeploy / deploy-activity | `info` | `deploy` |
| `Q2.audit()` start / stop / shutdown / license | `info` | `lifecycle` |

The four BASE24TCP markers keep their former tag name as the debug payload, so the events stay distinguishable.

## Not changed

Registry and API. `new LogEvent()` still means `info`. Realms. `s-m-operation`. JSONL format (only `kind` values for the events above).

## Release note

- XML element names change for every renamed tag. The audit sites go from `<info>` to `<iso-session>`, `<lifecycle>` and `<deploy>`; channel connect and disconnect go from `<connect>` / `<disconnect>` to `<iso-session>` (the payload `t` still says which).
- `FilterLogListener` treats unregistered tags as `info`, so filtering of the new kinds is unchanged. Throwable audit events now carry `error` and pass a `warn` threshold.
- `SysLogListener` forwards only the tags listed in its `tags` property. Deployments that list `info` must add `iso-session`, `lifecycle` and `deploy` to keep receiving those events.
