### PR TITLE
Stop composing realms in packagers and ISOServer; field tag for nested packagers

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOBasePackager.java
@@ -100,6 +100,19 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     }
 
     /**
+     * Tags a pack/unpack event with the field number when the component is a
+     * nested message, so nested packagers keep the configured realm.
+     *
+     * @param evt the event, may be {@code null} when logging is off
+     * @param m the component being packed or unpacked
+     * @return {@code evt}, tagged with {@code field} when {@code m} is a nested message
+     */
+    protected static LogEvent withField (LogEvent evt, ISOComponent m) {
+        if (evt != null && m instanceof ISOMsg msg && msg.getFieldNumber() >= 0)
+            evt.withTag ("field", Integer.toString (msg.getFieldNumber()));
+        return evt;
+    }
+    /**
      * pack method that works in conjunction with {@link #unpack(ISOComponent, byte[])}.
      * <p>
      * Handles a tertiary bitmap possibly appearing in Data Element {@code thirdBitmapField}.<br>
@@ -113,7 +126,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     {
         LogEvent evt = null;
         if (logger != null)
-            evt = new LogEvent (this, "pack");
+            evt = withField (new LogEvent (this, "pack"), m);
 
         try {
             if (m.getComposite() != m)
@@ -248,7 +261,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
      */
     @Override
     public int unpack (ISOComponent m, byte[] b) throws ISOException {
-        LogEvent evt = logger != null ? new LogEvent (this, "unpack") : null;
+        LogEvent evt = logger != null ? withField (new LogEvent (this, "unpack"), m) : null;
         int consumed = 0;
 
         try {
@@ -373,7 +386,7 @@ public abstract class ISOBasePackager implements ISOPackager, LogSource {
     public void unpack (ISOComponent m, InputStream in)
         throws IOException, ISOException
     {
-        LogEvent evt = logger != null ? new LogEvent (this, "unpack") : null;
+        LogEvent evt = logger != null ? withField (new LogEvent (this, "unpack"), m) : null;
         try {
             if (m.getComposite() != m)
                 throw new ISOException ("Can't call packager on non Composite");

--- a/jpos/src/main/java/org/jpos/iso/ISOServer.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOServer.java
@@ -88,8 +88,6 @@ public class ISOServer extends Observable
     protected Logger logger;
     /** The realm string for this server. */
     protected String realm;
-    /** The realm string for channel sessions. */
-    protected String realmChannel;
     /** Optional factory for creating server sockets. */
     protected ISOServerSocketFactory socketFactory = null;
 
@@ -615,7 +613,6 @@ public class ISOServer extends Observable
     public void setLogger (Logger logger, String realm) {
         this.logger = logger;
         this.realm  = realm;
-        this.realmChannel = realm + ".channel";
     }
     @Override
     public String getRealm () {

--- a/jpos/src/main/java/org/jpos/iso/packager/Base1SubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/Base1SubFieldPackager.java
@@ -70,7 +70,7 @@ public class Base1SubFieldPackager extends ISOBasePackager
 
     public int unpack (ISOComponent m, byte[] b) throws ISOException 
     {
-        LogEvent evt = new LogEvent (this, "unpack");
+        LogEvent evt = withField (new LogEvent (this, "unpack"), m);
         try 
         {
             if (m.getComposite() != m) 
@@ -122,7 +122,7 @@ public class Base1SubFieldPackager extends ISOBasePackager
      */
     @Override
     public byte[] pack (ISOComponent m) throws ISOException {
-        LogEvent evt = new LogEvent (this, "pack");
+        LogEvent evt = withField (new LogEvent (this, "pack"), m);
         try (ByteArrayOutputStream bout = new ByteArrayOutputStream(100))
         {
             ISOComponent c;

--- a/jpos/src/main/java/org/jpos/iso/packager/CTCSubElementPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/CTCSubElementPackager.java
@@ -63,7 +63,7 @@ public class CTCSubElementPackager extends ISOBaseValidatingPackager {
     }
 
     public int unpack ( ISOComponent m, byte[] b ) throws ISOException {
-        LogEvent evt = new LogEvent ( this, "unpack" );
+        LogEvent evt = withField (new LogEvent (this, "unpack"), m);
         int consumed = 0;
         for ( int i=0; consumed < b.length ; i++ ) {
             ISOComponent c = fld[i].createComponent( i );

--- a/jpos/src/main/java/org/jpos/iso/packager/CTCSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/CTCSubFieldPackager.java
@@ -62,7 +62,7 @@ public class CTCSubFieldPackager extends ISOBaseValidatingPackager {
     }
 
     public int unpack ( ISOComponent m, byte[] b ) throws ISOException {
-        LogEvent evt = new LogEvent ( this, "unpack" );
+        LogEvent evt = withField (new LogEvent (this, "unpack"), m);
         int consumed = 0;
         for ( int i=0; consumed < b.length ; i++ ) {
             ISOComponent c = fld[i].createComponent( i );

--- a/jpos/src/main/java/org/jpos/iso/packager/DatasetPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/DatasetPackager.java
@@ -96,7 +96,7 @@ public class DatasetPackager extends GenericPackager implements ISODatasetPackag
         if (!(m instanceof ISODatasetField)) {
             throw new ISOException("Can't call dataset packager on " + (m != null ? m.getClass().getName() : "null"));
         }
-        LogEvent evt = new LogEvent(this, "pack");
+        LogEvent evt = withField (new LogEvent (this, "pack"), m);
         try (ByteArrayOutputStream out = new ByteArrayOutputStream(128)) {
             ISODatasetField field = (ISODatasetField) m;
             for (Dataset dataset : field.getDatasets()) {
@@ -141,7 +141,7 @@ public class DatasetPackager extends GenericPackager implements ISODatasetPackag
         if (!(m instanceof ISODatasetField)) {
             throw new ISOException("Can't call dataset packager on " + (m != null ? m.getClass().getName() : "null"));
         }
-        LogEvent evt = new LogEvent(this, "unpack");
+        LogEvent evt = withField (new LogEvent (this, "unpack"), m);
         try {
             ISODatasetField field = (ISODatasetField) m;
             int consumed = 0;

--- a/jpos/src/main/java/org/jpos/iso/packager/EuroSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/EuroSubFieldPackager.java
@@ -58,7 +58,7 @@ public class EuroSubFieldPackager extends ISOBasePackager
 
     @Override
     public byte[] pack (ISOComponent c) throws ISOException {
-        LogEvent evt = new LogEvent (this, "pack");
+        LogEvent evt = withField (new LogEvent (this, "pack"), c);
         try (ByteArrayOutputStream bout = new ByteArrayOutputStream(100)) {
             Map tab = c.getChildren();
 
@@ -104,7 +104,7 @@ public class EuroSubFieldPackager extends ISOBasePackager
     @Override
     public int unpack (ISOComponent m, byte[] b) throws ISOException
     {
-        LogEvent evt = logger != null ? new LogEvent (this, "unpack") : null;
+        LogEvent evt = logger != null ? withField (new LogEvent (this, "unpack"), m) : null;
         int consumed = 0;
         ISOComponent c = null;
 
@@ -145,7 +145,7 @@ public class EuroSubFieldPackager extends ISOBasePackager
                 if (fld[i] instanceof ISOMsgFieldPackager) {
                     Object o = ((ISOMsgFieldPackager)fld[i]).getISOMsgPackager();
                     if (o instanceof LogSource) {
-                        ((LogSource)o).setLogger (logger, realm + "-fld-" + i);
+                        ((LogSource)o).setLogger (logger, realm);
                     }
                 }
             }

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericPackager.java
@@ -243,7 +243,7 @@ public class GenericPackager
                 if (fld[i] instanceof ISOMsgFieldPackager) {
                     Object o = ((ISOMsgFieldPackager)fld[i]).getISOMsgPackager();
                     if (o instanceof LogSource) {
-                        ((LogSource)o).setLogger (logger, realm + "-fld-" + i);
+                        ((LogSource)o).setLogger (logger, realm);
                     }
                 }
             }
@@ -544,7 +544,7 @@ public class GenericPackager
 
                 Integer fno = (Integer) fieldStack.pop();
 
-                msgPackager.setLogger (getLogger(), getRealm() + "-fld-" + fno);
+                msgPackager.setLogger (getLogger(), getRealm());
 
                 ISOFieldPackager mfp;
                 if (msgPackager instanceof ISODatasetPackager) {

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericSubFieldPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericSubFieldPackager.java
@@ -67,7 +67,7 @@ public class GenericSubFieldPackager extends GenericPackager implements ISOSubFi
     @Override
     public int unpack (ISOComponent m, byte[] b) throws ISOException 
     {
-        LogEvent evt = new LogEvent (this, "unpack");
+        LogEvent evt = withField (new LogEvent (this, "unpack"), m);
         try 
         {
             if (m.getComposite() != m) 
@@ -126,7 +126,7 @@ public class GenericSubFieldPackager extends GenericPackager implements ISOSubFi
     @Override
     public byte[] pack(ISOComponent m) throws ISOException
     {
-        LogEvent evt = new LogEvent (this, "pack");
+        LogEvent evt = withField (new LogEvent (this, "pack"), m);
         try (ByteArrayOutputStream bout = new ByteArrayOutputStream(100))
         {
             ISOComponent c;

--- a/jpos/src/main/java/org/jpos/iso/packager/GenericTaggedFieldsPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/GenericTaggedFieldsPackager.java
@@ -76,7 +76,7 @@ public class GenericTaggedFieldsPackager extends GenericPackager
 
     @Override
     public int unpack(ISOComponent m, byte[] b) throws ISOException {
-        LogEvent evt = new LogEvent(this, "unpack");
+        LogEvent evt = withField (new LogEvent (this, "unpack"), m);
         try {
             if (m.getComposite() != m)
                 throw new ISOException("Can't call packager on non Composite");
@@ -134,7 +134,7 @@ public class GenericTaggedFieldsPackager extends GenericPackager
      */
     @Override
     public byte[] pack(ISOComponent m) throws ISOException {
-        LogEvent evt = new LogEvent(this, "pack");
+        LogEvent evt = withField (new LogEvent (this, "pack"), m);
         try (ByteArrayOutputStream bout = new ByteArrayOutputStream(100)) {
             ISOComponent c;
             byte[] b;

--- a/jpos/src/main/java/org/jpos/iso/packager/PostPackager.java
+++ b/jpos/src/main/java/org/jpos/iso/packager/PostPackager.java
@@ -259,6 +259,6 @@ public class PostPackager extends ISOBasePackager {
      */
     public void setLogger (Logger logger, String realm) {
         super.setLogger (logger, realm);
-        p127.setLogger (logger, realm + ".PostPrivatePackager");
+        p127.setLogger (logger, realm);
     }
 }

--- a/jpos/src/main/java/org/jpos/q2/QBeanSupport.java
+++ b/jpos/src/main/java/org/jpos/q2/QBeanSupport.java
@@ -296,9 +296,10 @@ public class QBeanSupport
     private void syncLogConfiguration() {
         if (log == null)
             return;
-        log.setRealm(resolveRealm());
+        String realm = resolveRealm();
+        log.setRealm(realm);
         log.removeDefaultTag("component");
-        if (configuredRealm == null && defaultRealm() != null && name != null)
+        if (name != null && !name.equals(realm))
             log.setDefaultTag("component", name);
     }
 

--- a/jpos/src/main/java/org/jpos/tlv/packager/TaggedSequencePackager.java
+++ b/jpos/src/main/java/org/jpos/tlv/packager/TaggedSequencePackager.java
@@ -88,7 +88,7 @@ public class TaggedSequencePackager extends GenericPackager {
 
     @Override
     public int unpack(ISOComponent m, byte[] b) throws ISOException {
-        LogEvent evt = new LogEvent(this, "unpack");
+        LogEvent evt = withField (new LogEvent (this, "unpack"), m);
         try {
             if (m.getComposite() != m)
                 throw new ISOException("Can't call packager on non Composite");
@@ -148,7 +148,7 @@ public class TaggedSequencePackager extends GenericPackager {
      */
     @Override
     public byte[] pack(ISOComponent m) throws ISOException {
-        LogEvent evt = new LogEvent(this, "pack");
+        LogEvent evt = withField (new LogEvent (this, "pack"), m);
         try (ByteArrayOutputStream bout = new ByteArrayOutputStream(100)) {
             ISOComponent c;
             Map fields = m.getChildren();

--- a/jpos/src/main/java/org/jpos/tlv/packager/bertlv/BERTLVPackager.java
+++ b/jpos/src/main/java/org/jpos/tlv/packager/bertlv/BERTLVPackager.java
@@ -120,7 +120,7 @@ public abstract class BERTLVPackager extends GenericPackager {
      */
     public byte[] pack(ISOComponent m, boolean nested, int startIdx, int endIdx)
             throws ISOException {
-        LogEvent evt = new LogEvent(this, "pack");
+        LogEvent evt = withField (new LogEvent (this, "pack"), m);
         try (ByteArrayOutputStream bout = new ByteArrayOutputStream(100)) {
             ISOComponent c;
             Map fields = m.getChildren();
@@ -244,7 +244,7 @@ public abstract class BERTLVPackager extends GenericPackager {
      * @throws ISOException on unpacking error
      */
     public int unpack(ISOComponent m, byte[] b, boolean nested) throws ISOException {
-        LogEvent evt = new LogEvent(this, "unpack");
+        LogEvent evt = withField (new LogEvent (this, "unpack"), m);
         try {
             if (m.getComposite() == null)
                 throw new ISOException("Can't call packager on non Composite");

--- a/jpos/src/test/java/org/jpos/iso/packager/GenericPackagerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/packager/GenericPackagerTest.java
@@ -36,6 +36,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.EmptyStackException;
 
 import org.jpos.core.Configuration;
+import org.jpos.util.LogEvent;
+import org.jpos.util.Logger;
+import java.util.ArrayList;
+import java.util.List;
 import org.jpos.core.ConfigurationException;
 import org.jpos.core.SimpleConfiguration;
 import org.jpos.core.SubConfiguration;
@@ -598,5 +602,51 @@ public class GenericPackagerTest {
             assertNull(genericSubFieldPackager.getLogger(), "(GenericSubFieldPackager) genericSubFieldPackager.getLogger()");
             assertNull(genericSubFieldPackager.getRealm(), "(GenericSubFieldPackager) genericSubFieldPackager.getRealm()");
         }
+    }
+
+    @Test
+    public void testNestedPackagerKeepsParentRealmAndTagsField() throws Exception {
+        String xml = "<!DOCTYPE isopackager PUBLIC \"-//jPOS/jPOS Generic Packager DTD 1.0//EN\" \"http://jpos.org/dtd/generic-packager-1.0.dtd\">"
+            + "<isopackager>"
+            + "<isofield id=\"0\" length=\"4\" name=\"MTI\" class=\"org.jpos.iso.IFA_NUMERIC\"/>"
+            + "<isofield id=\"1\" length=\"16\" name=\"BITMAP\" class=\"org.jpos.iso.IFA_BITMAP\"/>"
+            + "<isofieldpackager id=\"48\" length=\"10\" name=\"Sub\""
+            + " class=\"org.jpos.iso.IFB_LLHBINARY\" inclusive=\"true\""
+            + " emitBitmap=\"false\" firstField=\"1\""
+            + " packager=\"org.jpos.iso.packager.GenericSubFieldPackager\">"
+            + "<isofield id=\"1\" length=\"5\" name=\"Id\" class=\"org.jpos.iso.IFE_CHAR\"/>"
+            + "<isofield id=\"2\" length=\"5\" name=\"Reserved\" class=\"org.jpos.iso.IFB_BINARY\"/>"
+            + "</isofieldpackager>"
+            + "</isopackager>";
+        GenericPackager packager = new GenericPackager(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        List<LogEvent> events = new ArrayList<>();
+        Logger logger = new Logger();
+        logger.addListener(ev -> { events.add(ev); return ev; });
+        packager.setLogger(logger, "test-packager");
+
+        ISOMsg sub = new ISOMsg(48);
+        sub.set(1, "VCIND");
+        sub.set(2, ISOUtil.hex2byte("F1F1F1F1F1"));
+        ISOMsg m = new ISOMsg("0800");
+        m.set(sub);
+        m.setPackager(packager);
+        byte[] packed = m.pack();
+
+        assertEquals(2, events.size(), "inner and outer pack events");
+        LogEvent inner = events.get(0);
+        LogEvent outer = events.get(1);
+        assertEquals("test-packager", inner.getRealm(), "nested packager keeps the parent realm");
+        assertEquals("48", inner.getTags().get("field"));
+        assertEquals("test-packager", outer.getRealm());
+        assertNull(outer.getTags().get("field"));
+
+        events.clear();
+        ISOMsg in = new ISOMsg();
+        in.setPackager(packager);
+        in.unpack(packed);
+        assertEquals(2, events.size(), "inner and outer unpack events");
+        assertEquals("48", events.get(0).getTags().get("field"));
+        assertEquals("test-packager", events.get(0).getRealm());
+        assertNull(events.get(1).getTags().get("field"));
     }
 }

--- a/jpos/src/test/java/org/jpos/q2/QBeanSupportTest.java
+++ b/jpos/src/test/java/org/jpos/q2/QBeanSupportTest.java
@@ -34,12 +34,12 @@ public class QBeanSupportTest {
     }
 
     @Test
-    void explicitRealmWinsOverDefaultRealmAndRemovesDefaultComponentTag() {
+    void explicitRealmWinsOverDefaultRealmAndKeepsComponentTag() {
         TestQBean bean = new TestQBean();
         bean.setName("mux-alpha");
         bean.setRealm("custom/realm");
         assertEquals("custom/realm", bean.getLog().getRealm(), "bean.getLog().getRealm()");
-        assertFalse(bean.getLog().createInfo().getTags().containsKey("component"));
+        assertEquals("mux-alpha", bean.getLog().createInfo().getTags().get("component"));
     }
 
     @Test
@@ -48,6 +48,8 @@ public class QBeanSupportTest {
         bean.setName("legacy-bean");
         bean.setLogger("Q2");
         assertEquals("legacy-bean", bean.getLog().getRealm(), "bean.getLog().getRealm()");
+        assertFalse(bean.getLog().createInfo().getTags().containsKey("component"),
+          "component would duplicate the realm");
     }
 
     static class TestQBean extends QBeanSupport {


### PR DESCRIPTION
Implements #763. Follow-up to #759 / #761.

## What

Realms are configured once and never string-composed; sub-identity goes to tags.

**Composition removed**

| Site | Was | Now |
|---|---|---|
| `GenericPackager.setLogger` and its `msgPackager` path | `realm + "-fld-" + i` | `realm` |
| `EuroSubFieldPackager.setLogger` | `realm + "-fld-" + i` | `realm` |
| `PostPackager.setLogger` | `realm + ".PostPrivatePackager"` | `realm` |
| `ISOServer.realmChannel` | `realm + ".channel"`, assigned and never read | field removed |

**Field number as a tag.** `ISOBasePackager.withField(LogEvent, ISOComponent)` (protected static) tags a `pack` / `unpack` event with `field=<n>` when the component is a nested message. Applied in `ISOBasePackager` and in every packager that builds its own events and can be nested: Base1SubField, EuroSubField, GenericSubField, CTCSubField, CTCSubElement, Dataset, GenericTaggedFields, BERTLV, TaggedSequence.

**QBeanSupport `component` tag.** Emitted whenever the bean has a name that differs from the resolved realm, including with an explicit `realm=` attribute. Previously only when the realm came from `defaultRealm()`. A bean whose realm is its own name (legacy fallback) carries no `component` tag.

## Not changed

Kind registry and API. Realm values for anything that was not composed. QServer / ChannelAdaptor already passed the configured realm through.

## Tests

- `GenericPackagerTest.testNestedPackagerKeepsParentRealmAndTagsField`: nested packager events carry the parent realm and `field=48` on both pack and unpack; the outer events carry no `field` tag.
- `QBeanSupportTest`: explicit `realm=` keeps `component=<name>`; legacy name-as-realm carries none.
- Full `:jpos:test` and `:jpos:javadoc` pass with no warnings.

## Release note

- Events from nested message packagers move from realm `<parent>-fld-N` to realm `<parent>` with tag `field=N`.
- Field 127 events from `PostPackager` lose the `.PostPrivatePackager` realm suffix.
- `ISOServer.realmChannel` (protected, never read) is removed; subclasses referencing it must drop the reference.
- QBeans deployed with an explicit `realm=` now also carry `component=<name>`.
