### PR TITLE
Embedded Q2 no longer System.exits on a startup exception

### DIFF
--- a/jpos/src/main/java/org/jpos/q2/Q2.java
+++ b/jpos/src/main/java/org/jpos/q2/Q2.java
@@ -411,7 +411,8 @@ public class Q2 implements FileFilter, Runnable {
                 log.error (e);
             else
                 e.printStackTrace();
-            System.exit (1);
+            if (exit)
+                System.exit (1);
         } finally {
             stopJFR();
         }


### PR DESCRIPTION
Implements #765.

## What

`Q2.run()` catches any `Exception` escaping the boot sequence, logs it, and called `System.exit(1)` unconditionally. The clean-shutdown path a few lines above only exits when the `exit` flag is set, and that flag is set only by `Q2.main`. The failure path now honours the same flag.

- Q2 started from the command line: unchanged, exits with status 1 on a startup exception.
- Embedded Q2 (tests, jPOS-EE, Control Plane): logs the exception and returns from `run()`; the host JVM survives.

## Why

On #764 CI failed with `Process 'Gradle Test Executor 4' finished with non-zero exit value 1`: a Q2-booting test hit a transient startup exception, the executor JVM died, and Gradle could not report which test tripped. The rerun passed. With this change the same event shows up as a named failing test with the exception in its output.

## Tests

No test added; the change is a guard on an existing flag. Full `:jpos:test` and `:jpos:javadoc` pass.
