### PR TITLE
Typed session-start and session-end records

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/ISOServer.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOServer.java
@@ -31,6 +31,7 @@ import java.net.BindException;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
@@ -334,15 +335,20 @@ public class ISOServer extends Observable
             setChanged ();
             notifyObservers ();
             UUID sessionUUID = uuid;
-            String sessionInfo = "";
             String endpoint = null;
+            String host = null;
+            int remotePort = 0;
+            int localPort = 0;
+            Instant start = Instant.now();
             if (channel instanceof BaseChannel baseChannel) {
                 Socket socket = baseChannel.getSocket ();
-                sessionInfo = socket.toString();
+                host = socket.getInetAddress().getHostAddress();
+                remotePort = socket.getPort();
+                localPort = socket.getLocalPort();
                 sessionUUID = getSocketUUID(socket);
                 endpoint = baseChannel.toEndpoint(socket);
                 LogEvent ev = createSessionEvent(sessionUUID, endpoint)
-                  .add(new SessionStart(getActiveConnections(), permitsCount, sessionInfo)
+                  .add(new SessionStart(getActiveConnections(), permitsCount, host, remotePort, localPort)
                 );
                 if (!checkPermission (socket, ev))
                     return;
@@ -387,7 +393,7 @@ public class ISOServer extends Observable
                 fireEvent(new ISOServerClientDisconnectEvent(ISOServer.this, channel));
             }
             Logger.log(createSessionEvent(sessionUUID, endpoint)
-              .add(new SessionEnd(getActiveConnections(), permitsCount, sessionInfo)
+              .add(new SessionEnd(getActiveConnections(), permitsCount, host, remotePort, localPort, Duration.between(start, Instant.now()))
               )
             );
         }

--- a/jpos/src/main/java/org/jpos/log/evt/SessionEnd.java
+++ b/jpos/src/main/java/org/jpos/log/evt/SessionEnd.java
@@ -18,13 +18,29 @@
 
 package org.jpos.log.evt;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.jpos.log.AuditLogEvent;
+
+import java.time.Duration;
 
 /**
  * Audit event recorded when a server session terminates.
  *
+ * <p>Field names mirror {@link Connect} and {@link Disconnect} so viewers can
+ * render channel and server sessions with one template.</p>
+ *
  * @param connections active connection count after this session ended
  * @param permits     remaining session permits
- * @param info        free-form description of the closing session
+ * @param host        remote address, or {@code null} when the channel exposes no socket
+ * @param remotePort  remote port
+ * @param localPort   local port the session was accepted on
+ * @param duration    session length, from accept to close
  */
-public record SessionEnd(int connections, int permits, String info) implements AuditLogEvent { }
+public record SessionEnd(
+  int connections,
+  int permits,
+  @JsonInclude(JsonInclude.Include.NON_NULL) String host,
+  int remotePort,
+  int localPort,
+  Duration duration
+) implements AuditLogEvent { }

--- a/jpos/src/main/java/org/jpos/log/evt/SessionStart.java
+++ b/jpos/src/main/java/org/jpos/log/evt/SessionStart.java
@@ -16,32 +16,27 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.jpos.log.evt;/*
- * jPOS Project [http://jpos.org]
- * Copyright (C) 2000-2010 Alejandro P. Revilla
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+package org.jpos.log.evt;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.jpos.log.AuditLogEvent;
 
 /**
  * Audit event recorded when a server session opens.
  *
+ * <p>Field names mirror {@link Connect} and {@link Disconnect} so viewers can
+ * render channel and server sessions with one template.</p>
+ *
  * @param connections active connection count after this session started
  * @param permits     remaining session permits
- * @param info        free-form description of the opening session
+ * @param host        remote address, or {@code null} when the channel exposes no socket
+ * @param remotePort  remote port
+ * @param localPort   local port the session was accepted on
  */
-public record SessionStart(int connections, int permits, String info) implements AuditLogEvent {
-}
+public record SessionStart(
+  int connections,
+  int permits,
+  @JsonInclude(JsonInclude.Include.NON_NULL) String host,
+  int remotePort,
+  int localPort
+) implements AuditLogEvent { }

--- a/jpos/src/test/java/org/jpos/iso/ISOServerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/ISOServerTest.java
@@ -189,6 +189,21 @@ public class ISOServerTest {
                 assertEquals(org.jpos.util.Kind.ISO_SESSION, sessionEvent.getTag(), "sessionEvent.getTag()");
                 assertTrue(sessionEvent.getTags().containsKey("session"), "sessionEvent.getTags().containsKey(session)");
                 assertTrue(sessionEvent.getTags().containsKey("endpoint"), "sessionEvent.getTags().containsKey(endpoint)");
+                org.jpos.log.evt.SessionStart start = sessionEvent.getPayLoad().stream()
+                  .filter(p -> p instanceof org.jpos.log.evt.SessionStart)
+                  .map(p -> (org.jpos.log.evt.SessionStart) p)
+                  .findFirst().orElseThrow();
+                assertEquals("127.0.0.1", start.host(), "start.host()");
+                assertEquals(port, start.localPort(), "start.localPort()");
+                assertTrue(start.remotePort() > 0, "start.remotePort()");
+                org.jpos.log.evt.SessionEnd end = events.stream()
+                  .flatMap(ev -> ev.getPayLoad().stream())
+                  .filter(p -> p instanceof org.jpos.log.evt.SessionEnd)
+                  .map(p -> (org.jpos.log.evt.SessionEnd) p)
+                  .findFirst().orElseThrow();
+                assertEquals(start.remotePort(), end.remotePort(), "end.remotePort()");
+                assertEquals(port, end.localPort(), "end.localPort()");
+                assertTrue(end.duration() != null && !end.duration().isNegative(), "end.duration()");
             }
         } finally {
             server.shutdown();

--- a/jpos/src/test/java/org/jpos/util/KindTest.java
+++ b/jpos/src/test/java/org/jpos/util/KindTest.java
@@ -85,7 +85,7 @@ public class KindTest {
         assertEquals(Kind.LIFECYCLE, Kind.kindOf("license"));
         assertEquals(Kind.DEPLOY, Kind.kindOf("undeploy"));
         assertEquals(Kind.ERROR, Kind.kindOf("throwable"));
-        assertEquals(Kind.ISO_SESSION, Kind.kindOf(new SessionStart(1, 10, "x")));
+        assertEquals(Kind.ISO_SESSION, Kind.kindOf(new SessionStart(1, 10, "127.0.0.1", 4321, 8000)));
     }
 
     @Test
@@ -163,11 +163,11 @@ public class KindTest {
     @Test
     void createEventUsesTheImpliedKindAndDefaultStaysInfo() {
         Log log = new Log(new Logger(), "test");
-        LogEvent evt = log.createEvent(new SessionStart(1, 10, "x"));
+        LogEvent evt = log.createEvent(new SessionStart(1, 10, "127.0.0.1", 4321, 8000));
         assertEquals(Kind.ISO_SESSION, evt.getTag());
         assertEquals(1, evt.getPayLoad().size());
         assertEquals(Kind.INFO, log.createEvent(new ProfilerEvt(0L, List.of())).getTag());
         assertEquals(Kind.INFO, new LogEvent().getTag());
-        assertEquals(Kind.ISO_SESSION, new LogEvent(log, new SessionStart(1, 10, "x")).getTag());
+        assertEquals(Kind.ISO_SESSION, new LogEvent(log, new SessionStart(1, 10, "127.0.0.1", 4321, 8000)).getTag());
     }
 }


### PR DESCRIPTION
Implements #767. First slice of typed payloads for opaque audit records.

## What

```java
public record SessionStart(int connections, int permits, String host, int remotePort, int localPort)
public record SessionEnd  (int connections, int permits, String host, int remotePort, int localPort, Duration duration)
```

- `info` (which was `Socket.toString()`) is gone. Host, remote port and local port are named fields, with the same names as `Connect` and `Disconnect` so one viewer template renders all four.
- `SessionEnd.duration` is the session length, measured from an `Instant` captured when the session thread starts.
- `host` is `null`-omitted in JSON for channels that expose no socket; the ports default to 0 in that case.
- ISOServer populates both records from the accepted socket. No other construction site exists in jPOS or jPOS-EE, so no deprecated constructor is kept.

## Tests

- `ISOServerTest.testSessionEventsUseStableRealmAndDynamicTags` now asserts host `127.0.0.1`, local port equal to the server port and a positive remote port on `SessionStart`, and matching ports plus a non-negative duration on `SessionEnd`.
- `KindTest` constructor calls updated.
- Full `:jpos:test` and `:jpos:javadoc` pass.

## Release note

The `session-start` and `session-end` payload shape changes: `info` disappears; `host`, `remotePort`, `localPort` appear, and `session-end` gains `duration`. The Control Plane log viewer renders both records and needs to read the new fields, keeping a fallback on `info` for already-indexed events.
