### PR TITLE
Sticky wire-exchange trace id derived from message content

### DIFF
--- a/jpos/src/main/java/org/jpos/iso/BaseChannel.java
+++ b/jpos/src/main/java/org/jpos/iso/BaseChannel.java
@@ -743,7 +743,7 @@ public abstract class BaseChannel extends Observable
     {
         ChannelEvent jfr = new ChannelEvent.Send();
         jfr.begin();
-        LogEvent evt = new LogEvent (this, "send").withTraceId(getSocketUUID());
+        LogEvent evt = new LogEvent (this, "send").withTraceId(getSocketUUID()).withTag("session", getSocketUUID().toString());
         try {
             if (!isConnected())
                 throw new IOException ("unconnected ISOChannel");
@@ -751,6 +751,7 @@ public abstract class BaseChannel extends Observable
             ISOPackager p = getDynamicPackager(m);
             m.setPackager (p);
             m = applyOutgoingFilters (m, evt);
+            stampTraceId (evt, m);
             evt.addMessage (m);
             applyTags (evt, m);
             m.setDirection(ISOMsg.OUTGOING); // filter may have dropped this info
@@ -900,7 +901,7 @@ public abstract class BaseChannel extends Observable
 
         byte[] b=null;
         byte[] header=null;
-        LogEvent evt = new LogEvent (this, "receive").withTraceId(getSocketUUID());
+        LogEvent evt = new LogEvent (this, "receive").withTraceId(getSocketUUID()).withTag("session", getSocketUUID().toString());
         boolean logEvent = true;
         ISOMsg m = createMsg ();  // call createMsg instead of createISOMsg for backward compatibility
 
@@ -951,6 +952,7 @@ public abstract class BaseChannel extends Observable
             evt.addMessage (m);
             applyTags (evt, m);
             m = applyIncomingFilters (m, header, b, evt);
+            stampTraceId (evt, m);
             m.setDirection(ISOMsg.INCOMING);
             cnt[RX]++;
             incrementMsgInCounter(m);
@@ -1195,6 +1197,20 @@ public abstract class BaseChannel extends Observable
         throws VetoException
     {
         return applyIncomingFilters (m, null, null, evt);
+    }
+    /**
+     * Stamps a send/receive event with the message's effective trace id, and
+     * with {@code trace-claimed} when the message carries a claim that differs.
+     *
+     * @param evt the channel event
+     * @param m the message
+     */
+    private static void stampTraceId (LogEvent evt, ISOMsg m) {
+        String traceId = m.getTraceId();
+        evt.withTraceId (traceId);
+        String claimed = m.getClaimedTraceId();
+        if (claimed != null && !claimed.equals (traceId))
+            evt.withTag ("trace-claimed", claimed);
     }
     /**
      * Applies all registered incoming filters with the raw message header and image.

--- a/jpos/src/main/java/org/jpos/iso/ISOMsg.java
+++ b/jpos/src/main/java/org/jpos/iso/ISOMsg.java
@@ -23,6 +23,7 @@ import org.jpos.iso.packager.XMLPackager;
 import org.jpos.util.Loggeable;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.lang.ref.WeakReference;
 import java.util.*;
 
@@ -55,6 +56,10 @@ public class ISOMsg extends ISOComponent
     protected byte[] trailer;
     /** Field number of this message when nested inside another ISOMsg. */
     protected int fieldNumber = -1;
+    /** Explicitly asserted trace id; transient, never packed. See {@link #getTraceId()}. */
+    private transient String claimedTraceId;
+    /** Fields, besides the MTI class, that identify one wire exchange. */
+    private static volatile int[] traceIdFields = { 3, 7, 11, 12, 41, 42 };
     /** Constant indicating an incoming message direction. */
     public static final int INCOMING = 1;
     /** Constant indicating an outgoing message direction. */
@@ -1066,6 +1071,83 @@ public class ISOMsg extends ISOComponent
             throw new ISOException ("can't setMTI on inner message");
         set (new ISOField (0, mti));
     }
+    /**
+     * Sets the fields used by {@link #naturalTraceId()} in addition to the
+     * MTI class. System-wide; defaults to 3, 7, 11, 12, 41 and 42: fields a
+     * response echoes unchanged from its request. Fields the server may mint
+     * (37, 32) are deliberately excluded; 7 and 12 keep a terminal that wraps
+     * its STAN from linking to old exchanges.
+     *
+     * @param fields field numbers
+     */
+    public static void setTraceIdFields (int... fields) {
+        traceIdFields = fields.clone();
+    }
+
+    /**
+     * Trace id derived from message content: the first two MTI digits plus
+     * the {@link #setTraceIdFields(int...) trace id fields} present, trimmed.
+     * A request and its response yield the same value, so one wire exchange
+     * shares one id with no carrier on the wire.
+     *
+     * @return a 32-hex id, or {@code null} when none of the key fields is present
+     */
+    public String naturalTraceId () {
+        StringBuilder sb = new StringBuilder();
+        String mti = getString (0);
+        if (mti != null && mti.length() >= 2)
+            sb.append (mti, 0, 2);
+        boolean hasKey = false;
+        for (int f : traceIdFields) {
+            String v = getString (f);
+            if (v != null && !(v = v.trim()).isEmpty()) {
+                sb.append ('.').append (v);
+                hasKey = true;
+            }
+        }
+        return hasKey
+          ? UUID.nameUUIDFromBytes (sb.toString().getBytes (StandardCharsets.UTF_8)).toString().replace ("-", "")
+          : null;
+    }
+
+    /**
+     * Asserts a trace id on this message, for example the id of the request a
+     * response belongs to. The claim is transient: copied by {@link #clone()},
+     * never packed. Channel events report it as {@code trace-claimed} when it
+     * differs from the {@link #naturalTraceId() natural} id.
+     *
+     * @param traceId the claimed id, or {@code null} to clear
+     */
+    public void setTraceId (String traceId) {
+        this.claimedTraceId = traceId;
+    }
+
+    /**
+     * The id asserted through {@link #setTraceId(String)}.
+     *
+     * @return the claimed id, or {@code null}
+     */
+    public String getClaimedTraceId () {
+        return claimedTraceId;
+    }
+
+    /**
+     * Effective trace id of the wire exchange this message belongs to: the
+     * {@link #naturalTraceId() natural} id when computable, else the
+     * {@link #getClaimedTraceId() claimed} id, else a random id minted once
+     * and kept as the claim.
+     *
+     * @return a 32-hex trace id, never {@code null}
+     */
+    public String getTraceId () {
+        String natural = naturalTraceId();
+        if (natural != null)
+            return natural;
+        if (claimedTraceId == null)
+            claimedTraceId = UUID.randomUUID().toString().replace ("-", "");
+        return claimedTraceId;
+    }
+
     /**
      * moves a field (renumber)
      * @param oldFieldNumber old field number

--- a/jpos/src/main/java/org/jpos/iso/IncomingListener.java
+++ b/jpos/src/main/java/org/jpos/iso/IncomingListener.java
@@ -78,6 +78,7 @@ public class IncomingListener extends Log implements ISORequestListener, Configu
         ctx.put (timestamp, new Date(), remote);
         ctx.put (source, src, remote);
         ctx.put (request, m, remote);
+        ctx.put (ContextConstants.TRACE_ID.toString(), m.getTraceId(), remote);
         if (additionalContextEntries != null) {
             additionalContextEntries.entrySet().forEach(
                 e -> ctx.put(e.getKey(), e.getValue(), remote)

--- a/jpos/src/main/java/org/jpos/transaction/ContextConstants.java
+++ b/jpos/src/main/java/org/jpos/transaction/ContextConstants.java
@@ -79,7 +79,9 @@ public enum ContextConstants {
     /** Routing destination chosen for the transaction. */
     DESTINATION,
     /** Panic flag indicating the transaction must abort immediately. */
-    PANIC;
+    PANIC,
+    /** Effective trace id of the wire exchange being processed; see {@link org.jpos.iso.ISOMsg#getTraceId()}. */
+    TRACE_ID;
 
     private final String name;
 

--- a/jpos/src/main/java/org/jpos/transaction/TransactionManager.java
+++ b/jpos/src/main/java/org/jpos/transaction/TransactionManager.java
@@ -309,7 +309,7 @@ public class TransactionManager
             iter = getParticipants (DEFAULT_GROUP).iterator();
             evt = new LogEvent()
               .withSource(log)
-              .withTraceId(getTraceId(id));
+              .withTraceId(getTraceId(id, context));
             evt.addMessage(txn);
             evt.addMessage(context);
             prof = new Profiler();
@@ -1613,6 +1613,14 @@ public class TransactionManager
         return m;
     }
 
+    private String getTraceId (long transactionId, Serializable context) {
+        if (context instanceof Context ctx) {
+            Object t = ctx.get (ContextConstants.TRACE_ID.toString());
+            if (t != null)
+                return t.toString();
+        }
+        return getTraceId (transactionId).toString().replace ("-", "");
+    }
     private UUID getTraceId (long transactionId) {
         return new UUID(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits() ^ transactionId);
     }

--- a/jpos/src/main/java/org/jpos/transaction/participant/SendResponse.java
+++ b/jpos/src/main/java/org/jpos/transaction/participant/SendResponse.java
@@ -91,6 +91,11 @@ public class SendResponse implements AbortParticipant, Configurable {
                     ((SpaceSource)src).init(isp, timeout);
                 if (src.isConnected() && resp != null) {
                     headerStrategy.handleHeader(m, resp);
+                    if (resp.getClaimedTraceId() == null) {
+                        Object traceId = ctx.get (TRACE_ID.toString());
+                        if (traceId != null)
+                            resp.setTraceId (traceId.toString());
+                    }
                     src.send(resp);
                 }
             }

--- a/jpos/src/test/java/org/jpos/iso/ISOMsgTest.java
+++ b/jpos/src/test/java/org/jpos/iso/ISOMsgTest.java
@@ -392,4 +392,55 @@ public class ISOMsgTest {
         assertFalse(msg.isNetworkManagement());
         assertTrue(msg.isFeeCollection());
     }
+    @Test
+    public void testNaturalTraceIdIsSharedByRequestAndResponse() throws Exception {
+        ISOMsg req = new ISOMsg("0200");
+        req.set(7, "0904120000");
+        req.set(11, "000123");
+        req.set(41, "TERM0001 ");
+        req.set(42, "MERCHANT0000001");
+        req.set(4, "000000001000");
+        ISOMsg rsp = new ISOMsg("0210");
+        rsp.set(7, "0904120000");
+        rsp.set(11, "000123");
+        rsp.set(39, "00");
+        rsp.set(41, "TERM0001");
+        rsp.set(42, "MERCHANT0000001");
+        assertNotNull(req.naturalTraceId());
+        assertEquals(32, req.naturalTraceId().length());
+        assertEquals(req.naturalTraceId(), rsp.naturalTraceId(), "response shares the request's natural id");
+        assertEquals(req.getTraceId(), rsp.getTraceId());
+        assertNull(req.getClaimedTraceId(), "no claim when the natural id exists");
+
+        ISOMsg other = (ISOMsg) req.clone();
+        other.set(11, "000124");
+        assertNotEquals(req.naturalTraceId(), other.naturalTraceId(), "different STAN, different id");
+    }
+
+    @Test
+    public void testClaimedTraceIdIsCopiedByCloneAndDoesNotOverrideNatural() throws Exception {
+        ISOMsg m = new ISOMsg("0200");
+        m.set(11, "000123");
+        m.set(41, "TERM0001");
+        m.setTraceId("0123456789abcdef0123456789abcdef");
+        assertEquals("0123456789abcdef0123456789abcdef", m.getClaimedTraceId());
+        assertEquals(m.naturalTraceId(), m.getTraceId(), "natural id wins over the claim");
+        ISOMsg c = (ISOMsg) m.clone();
+        assertEquals("0123456789abcdef0123456789abcdef", c.getClaimedTraceId());
+        m.setTraceId(null);
+        assertNull(m.getClaimedTraceId());
+    }
+
+    @Test
+    public void testMessageWithoutKeyFieldsGetsAStableMintedId() throws Exception {
+        ISOMsg m = new ISOMsg("0800");
+        m.set(70, "301");
+        assertNull(m.naturalTraceId());
+        String first = m.getTraceId();
+        assertNotNull(first);
+        assertEquals(32, first.length());
+        assertEquals(first, m.getTraceId(), "minted once");
+        assertEquals(first, m.getClaimedTraceId(), "kept as the claim");
+        assertEquals(first, ((ISOMsg) m.clone()).getTraceId());
+    }
 }

--- a/jpos/src/test/java/org/jpos/iso/ISOServerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/ISOServerTest.java
@@ -21,6 +21,7 @@ package org.jpos.iso;
 import static org.apache.commons.lang3.JavaVersion.JAVA_14;
 import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -204,6 +205,74 @@ public class ISOServerTest {
                 assertEquals(start.remotePort(), end.remotePort(), "end.remotePort()");
                 assertEquals(port, end.localPort(), "end.localPort()");
                 assertTrue(end.duration() != null && !end.duration().isNegative(), "end.duration()");
+            }
+        } finally {
+            server.shutdown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testChannelEventsCarryTheExchangeTraceIdAndSessionTag() throws Exception {
+        List<org.jpos.util.LogEvent> events = new ArrayList<>();
+        Logger logger = new Logger();
+        logger.setName("test-trace-logger");
+        logger.addListener(ev -> {
+            synchronized (events) {
+                events.add(ev);
+            }
+            return ev;
+        });
+
+        int port;
+        try (java.net.ServerSocket probe = new java.net.ServerSocket(0)) {
+            port = probe.getLocalPort();
+        }
+
+        CSChannel serverChannel = new CSChannel();
+        serverChannel.setPackager(new ISO87BPackager());
+        serverChannel.setLogger(logger, "comm/server");
+        ISOServer server = new ISOServer(port, serverChannel, 5);
+        server.setLogger(logger, "comm/server");
+        SimpleConfiguration cfg = new SimpleConfiguration();
+        cfg.put("backlog", "10");
+        server.setConfiguration(cfg);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.submit(server);
+        CSChannel client = new CSChannel("127.0.0.1", port, new ISO87BPackager());
+        client.setLogger(logger, "comm/client");
+        ISOMsg m = new ISOMsg("0800");
+        m.set(7, "0904120000");
+        m.set(11, "000321");
+        m.set(41, "TERM0001");
+        m.set(42, "MERCHANT0000001");
+        m.set(70, "301");
+        String expected = m.getTraceId();
+        try {
+            ISOUtil.sleep(250L);
+            client.connect();
+            client.send(m);
+            ISOUtil.sleep(250L);
+            client.disconnect();
+
+            long deadline = System.currentTimeMillis() + 5000L;
+            while (System.currentTimeMillis() < deadline) {
+                synchronized (events) {
+                    if (events.stream().anyMatch(ev -> "receive".equals(ev.getTag())))
+                        break;
+                }
+                ISOUtil.sleep(100L);
+            }
+            synchronized (events) {
+                org.jpos.util.LogEvent send = events.stream().filter(ev -> "send".equals(ev.getTag())).findFirst().orElseThrow();
+                org.jpos.util.LogEvent receive = events.stream().filter(ev -> "receive".equals(ev.getTag())).findFirst().orElseThrow();
+                assertEquals(expected, send.getTags().get("trace-id"), "send trace-id");
+                assertEquals(expected, receive.getTags().get("trace-id"), "receive trace-id");
+                assertTrue(send.getTags().containsKey("session"), "send session tag");
+                assertTrue(receive.getTags().containsKey("session"), "receive session tag");
+                assertFalse(send.getTags().containsKey("trace-claimed"), "no claim on send");
+                assertFalse(receive.getTags().containsKey("trace-claimed"), "no claim on receive");
             }
         } finally {
             server.shutdown();

--- a/jpos/src/test/java/org/jpos/iso/IncomingListenerTest.java
+++ b/jpos/src/test/java/org/jpos/iso/IncomingListenerTest.java
@@ -1,0 +1,56 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.iso;
+
+import org.jpos.core.SimpleConfiguration;
+import org.jpos.iso.channel.LoopbackChannel;
+import org.jpos.space.Space;
+import org.jpos.space.SpaceFactory;
+import org.jpos.transaction.Context;
+import org.jpos.transaction.ContextConstants;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class IncomingListenerTest {
+
+    @Test
+    void contextCarriesTheMessageTraceId() throws Exception {
+        IncomingListener listener = new IncomingListener();
+        SimpleConfiguration cfg = new SimpleConfiguration();
+        cfg.put("space", "tspace:default");
+        cfg.put("queue", "incoming-listener-test");
+        listener.setConfiguration(cfg);
+
+        ISOMsg m = new ISOMsg("0200");
+        m.set(7, "0904120000");
+        m.set(11, "000123");
+        m.set(41, "TERM0001");
+        m.set(42, "MERCHANT0000001");
+
+        listener.process(new LoopbackChannel(), m);
+
+        Space<String, Context> sp = SpaceFactory.getSpace("tspace:default");
+        Context ctx = sp.in("incoming-listener-test", 1000L);
+        assertNotNull(ctx, "context queued");
+        assertEquals(m.getTraceId(), ctx.get(ContextConstants.TRACE_ID.toString()));
+        assertEquals(m.naturalTraceId(), ctx.get(ContextConstants.TRACE_ID.toString()));
+    }
+}


### PR DESCRIPTION
Implements #769.

## What

One trace id per wire exchange, derived from message content so request and response share it with no carrier on the wire and regardless of protocol version.

**ISOMsg**

- `naturalTraceId()`: first two MTI digits plus the trace-id fields present (default 3, 7, 11, 12, 41, 42, trimmed; 37 and 32 are excluded because a server often mints them, 7 and 12 keep a wrapped STAN from linking to old exchanges), hashed to a 32-hex UUID. `null` when none of the key fields is present. `setTraceIdFields(int...)` tunes the field list system-wide.
- `setTraceId(String)` / `getClaimedTraceId()`: an explicitly asserted id. Transient, copied by `clone`, never packed.
- `getTraceId()`: the effective id. Natural when computable, else the claim, else a random id minted once and kept as the claim.

**BaseChannel** send and receive events: `trace-id` = the message's effective id; new `session` tag = socket UUID (which used to be the trace id); `trace-claimed` = the claimed id, only when it differs from the effective one.

**IncomingListener** puts `ContextConstants.TRACE_ID` (new) into the Context.

**TransactionManager** uses the Context trace id for the transaction event, falling back to the per-transaction id when absent.

**SendResponse** claims the Context trace id on the response when it has no claim of its own, so a response whose key fields changed still links back through `trace-claimed`.

## Not changed

No wire field. No thread-locals. LogEvent trace-id format stays 32 hex. Session events in ISOServer are unchanged.

## Behaviour notes

- A retransmission (0201) shares the original's id: the MTI class and key fields are the same. That is the same wire exchange for correlation purposes.
- A MUX-originated request from a participant gets its own natural id; linking it to the inbound transaction's id is a follow-up (claim from the Context in `QueryHost`).
- CMF DE-113.22 adopt/echo is a follow-up once a DE-113 subfield packager exists.

## Tests

- `ISOMsgTest`: request/response share the natural id, a different STAN differs, claim copied by `clone` and never overrides the natural id, a message without key fields gets a stable minted id.
- `IncomingListenerTest` (new): the queued Context carries the message's id.
- `ISOServerTest.testChannelEventsCarryTheExchangeTraceIdAndSessionTag` (new): a real client-to-server exchange; the client's send event and the server's receive event carry the same `trace-id`, both carry `session`, neither carries `trace-claimed`.
- Full `:jpos:test` and `:jpos:javadoc` pass.

## Release note

Channel `send` / `receive` events: `trace-id` now identifies the wire exchange rather than the connection; the connection id moved to the `session` tag. Consumers that joined channel events on `trace-id` per connection should use `session`.
