### PR TITLE
QueryHost claims the Context trace id on the outbound request

### DIFF
--- a/jpos/src/main/java/org/jpos/transaction/participant/QueryHost.java
+++ b/jpos/src/main/java/org/jpos/transaction/participant/QueryHost.java
@@ -78,6 +78,11 @@ public class QueryHost implements TransactionParticipant, Configurable {
         ISOMsg m = ctx.get (requestName);
         if (m == null)
             return result.fail(CMF.INVALID_REQUEST, Caller.info(), "'%s' is null", requestName).FAIL();
+        if (m.getClaimedTraceId() == null) {
+            Object traceId = ctx.get (ContextConstants.TRACE_ID.toString());
+            if (traceId != null)
+                m.setTraceId (traceId.toString()); // links the outbound leg to this transaction
+        }
 
         Chronometer chronometer = new Chronometer();
         if (isConnected(mux)) {

--- a/jpos/src/test/java/org/jpos/transaction/participant/QueryHostTest.java
+++ b/jpos/src/test/java/org/jpos/transaction/participant/QueryHostTest.java
@@ -115,6 +115,48 @@ public class QueryHostTest implements TransactionConstants, MUX {
         assertEquals(8877, queryHost.resolveTimeout(ctx));
     }
 
+    @Test
+    public void testClaimsContextTraceIdOnOutboundRequest() throws Exception {
+        Context ctx = new Context();
+        cfg.put("continuations", "no");
+        queryHost.setConfiguration(cfg);
+        ISOMsg request = createDummyRequest();
+        ctx.put(ContextConstants.REQUEST.toString(), request);
+        ctx.put(ContextConstants.DESTINATION.toString(), "TEST");
+        ctx.put(ContextConstants.TRACE_ID.toString(), "0123456789abcdef0123456789abcdef");
+        assertNull(request.getClaimedTraceId());
+        queryHost.prepare(1L, ctx);
+        assertEquals("0123456789abcdef0123456789abcdef", request.getClaimedTraceId(), "claim set from the Context");
+        ISOMsg response = ctx.get(ContextConstants.RESPONSE.toString(), 1000);
+        assertEquals("0123456789abcdef0123456789abcdef", response.getClaimedTraceId(), "clone carries the claim");
+    }
+
+    @Test
+    public void testExistingClaimIsLeftAlone() throws Exception {
+        Context ctx = new Context();
+        cfg.put("continuations", "no");
+        queryHost.setConfiguration(cfg);
+        ISOMsg request = createDummyRequest();
+        request.setTraceId("ffffffffffffffffffffffffffffffff");
+        ctx.put(ContextConstants.REQUEST.toString(), request);
+        ctx.put(ContextConstants.DESTINATION.toString(), "TEST");
+        ctx.put(ContextConstants.TRACE_ID.toString(), "0123456789abcdef0123456789abcdef");
+        queryHost.prepare(1L, ctx);
+        assertEquals("ffffffffffffffffffffffffffffffff", request.getClaimedTraceId());
+    }
+
+    @Test
+    public void testNoTraceIdInContextLeavesRequestUntouched() throws Exception {
+        Context ctx = new Context();
+        cfg.put("continuations", "no");
+        queryHost.setConfiguration(cfg);
+        ISOMsg request = createDummyRequest();
+        ctx.put(ContextConstants.REQUEST.toString(), request);
+        ctx.put(ContextConstants.DESTINATION.toString(), "TEST");
+        queryHost.prepare(1L, ctx);
+        assertNull(request.getClaimedTraceId());
+    }
+
     @Override
     public ISOMsg request(ISOMsg m, long timeout) throws ISOException {
         ISOMsg r = (ISOMsg) m.clone();


### PR DESCRIPTION
Implements #773. Follow-up to #769.

## What

Before handing the request to the MUX, QueryHost sets the Context's `TRACE_ID` as the message's claim when the message has no claim of its own, the same pattern `SendResponse` uses for the response. An existing claim is left alone; a Context without a trace id leaves the message untouched.

## Why

When QueryHost forwards the inbound request unchanged, the outbound leg already shares the inbound trace id through the content-derived natural id. When an edge component builds a new outbound message (different STAN, TID, MID or format), that message has its own natural id and the leg was a separate trace. With the claim, BaseChannel stamps the outbound send event with the leg's id as `trace-id` and the inbound id as `trace-claimed`, which links the two.

The host's response receive event still carries only the leg's id, since the claim cannot reach it before the receive event is emitted. The TM event contains the response and the leg's send event carries `trace-claimed`, so the join is two hops. Stamping the response itself needs an id on the wire (CMF 113.22 filter, separate).

Custom participants that build their own outbound message should apply the same lines.

## Tests

Three cases added to `QueryHostTest`: claim set from the Context (and carried by the cloned response), existing claim left alone, no trace id in the Context. Full `:jpos:test` and `:jpos:javadoc` pass.
