### PR TITLE
build: upgrade Gradle to 9.7.1

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,2 +1,2 @@
 java=26.0.2-amzn
-gradle=9.7.0
+gradle=9.7.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Summary

- upgrade the SDKMAN Gradle version from 9.7.0 to 9.7.1
- update the Gradle wrapper distribution URL and SHA-256 checksum

## Verification

- `./gradlew clean build --warning-mode=all --console=plain`
- build successful with Amazon Corretto 26.0.2
- no Gradle deprecation or compatibility warnings; test execution retains existing JDK class-sharing and JKS migration warnings
