### PR TITLE
Upgrade Jackson, BC provider, JLine, SnakeYAML, Micrometer and JUnit

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ jdom = "2.0.6.1"
 sleepycatje = "18.3.12"
 commonscli = "1.11.0"
 commonslang3 = "3.20.0"
-jline = "4.3.1"
+jline = "4.4.3"
 jna = '5.19.1'
 jansi = '2.4.3'
 beanshell = "2.0b6"
@@ -12,14 +12,15 @@ mapdb = "3.1.0"
 mockito = "5.23.0"
 mockitojupiter = "5.23.0"
 xmlunit = "1.6"
-junit = "6.1.2"
+junit = "6.1.3"
 bouncycastle = "1.85"
+bcprov = "1.85.2"
 hamcrest = "3.0"
 hdrhistogram = "2.2.2"
-yaml = "2.6"
-micrometercore = "1.17.0"
-micrometerprometheus = "1.17.0"
-jackson = '2.22.1'
+yaml = "2.7"
+micrometercore = "1.17.1"
+micrometerprometheus = "1.17.1"
+jackson = '2.22.2'
 jdbm = '1.0'
 
 [libraries]
@@ -37,7 +38,7 @@ mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockitojupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockitojupiter" }
 xmlunit = { module = "xmlunit:xmlunit", version.ref = "xmlunit" }
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
-bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bcprov" }
 bcpg = { module = "org.bouncycastle:bcpg-jdk18on", version.ref = "bouncycastle" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 hdrhistogram = { module = "org.hdrhistogram:HdrHistogram", version.ref = "hdrhistogram" }

--- a/jpos/build.gradle
+++ b/jpos/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     api libs.jansi
     api libs.beanshell
     api libs.bcpg
+    // The provider patch is released separately from bcpg and bcutil.
+    api libs.bcprov
     api libs.commonscli
     api libs.micrometercore
     api libs.micrometerprometheus


### PR DESCRIPTION
## Summary

Upgrade the dependency groups selected in the dependency review:

| Dependency | Previous | Updated |
| --- | --- | --- |
| Jackson (core, databind, JSR310, XML) | 2.22.1 | 2.22.2 |
| Bouncy Castle provider | 1.85 | 1.85.2 |
| JLine | 4.3.1 | 4.4.3 |
| SnakeYAML | 2.6 | 2.7 |
| Micrometer core and Prometheus registry | 1.17.0 | 1.17.1 |
| JUnit Jupiter/Platform | 6.1.2 | 6.1.3 |

Keep bcpg and bcutil at 1.85: 1.85.2 is a provider-only release. Give bcprov its own version and declare it explicitly so both the runtime and published Maven dependency list select the provider patch.

## Validation

- Java 26.0.2-amzn and Gradle 9.7.1 selected from .sdkmanrc.
- Clean local test suite: 4,436 tests reported; zero failures/errors, 69 skipped.
- Local jpos:check and jpos:assemble.
- Generated Maven POM and resolved runtime dependencies checked for bcprov 1.85.2, bcpg/bcutil 1.85, and the upgraded library versions.
- git diff --check.

No manual cross-platform interactive-terminal testing performed. JLine 4.4 changes the ambiguous-key binding timeout from 1,000 to 100 ms; SnakeYAML 2.7 removes Compact Object Notation, which is not used in the jPOS source tree.

## Upstream notes

- https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.22.2
- https://www.bouncycastle.org/download/bouncy-castle-java/
- https://github.com/jline/jline3/releases/tag/4.4.3
- https://codeberg.org/snakeyaml/snakeyaml/src/tag/snakeyaml-2.7/src/changes/changes.xml
- https://github.com/micrometer-metrics/micrometer/releases/tag/v1.17.1
- https://docs.junit.org/6.1.3/release-notes.html
